### PR TITLE
Use circleCI workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,7 @@ jobs:
   tests_benchmark:
     docker:
       - image: circleci/python:3.7
+    resource_class: large
     steps:
       - checkout
 


### PR DESCRIPTION
- Separate different test sessions into different jobs
- Use xlarge instance only for the slow tests.

There is currently some duplication in the circle CI config. Need to figure out how to reuse the common parts between jobs.