### PR TITLE
First version async/sync/mobile client

### DIFF
--- a/configs/docker-dev.toml
+++ b/configs/docker-dev.toml
@@ -1,5 +1,5 @@
 [log]
-filter = "xain_fl=trace,http=warn,info"
+filter = "info"
 
 [api]
 bind_address = "0.0.0.0:8081"

--- a/configs/docker-dev.toml
+++ b/configs/docker-dev.toml
@@ -1,5 +1,5 @@
 [log]
-filter = "xain_fl=debug,http=warn,info"
+filter = "xain_fl=trace,http=warn,info"
 
 [api]
 bind_address = "0.0.0.0:8081"
@@ -7,9 +7,9 @@ bind_address = "0.0.0.0:8081"
 [pet]
 min_sum = 1
 min_update = 3
-sum = 0.01
-update = 0.1
-expected_participants = 10
+sum = 0.3
+update = 0.7
+expected_participants = 20
 
 [mask]
 group_type = "Prime"

--- a/configs/docker-dev.toml
+++ b/configs/docker-dev.toml
@@ -1,5 +1,5 @@
 [log]
-filter = "info"
+filter = "xain_fl=debug,http=warn"
 
 [api]
 bind_address = "0.0.0.0:8081"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -687,6 +687,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac965ea399ec3a25ac7d13b8affd4b8f39325cca00858ddf5eb29b79e6b14b08"
+dependencies = [
+ "bytes 0.5.5",
+ "futures-util",
+ "hyper",
+ "log 0.4.8",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "webpki",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1589,6 +1605,7 @@ dependencies = [
  "http 0.2.1",
  "http-body",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "js-sys",
  "lazy_static",
@@ -1598,15 +1615,33 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
  "serde 1.0.114",
  "serde_urlencoded",
  "tokio",
+ "tokio-rustls",
  "tokio-tls",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "952cd6b98c85bbc30efa1ba5783b8abf12fec8b3287ffa52605b9432313e34e4"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -1628,6 +1663,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustls"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0d4a31f5d68413404705d6982529b0e11a9aacd4839d1d6222ee3b8cb4015e1"
+dependencies = [
+ "base64 0.11.0",
+ "log 0.4.8",
+ "ring",
+ "sct",
+ "webpki",
 ]
 
 [[package]]
@@ -1669,6 +1717,16 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "security-framework"
@@ -1852,6 +1910,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2027,6 +2091,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15cb62a0d2770787abc96e99c1cd98fcf17f94959f3af63ca85bdfb203f051b4"
+dependencies = [
+ "futures-core",
+ "rustls",
+ "tokio",
+ "webpki",
 ]
 
 [[package]]
@@ -2450,6 +2526,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "url"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2653,6 +2735,25 @@ checksum = "7b72fe77fd39e4bd3eaa4412fd299a0be6b3dfe9d2597e2f1c20beb968f41d17"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab146130f5f790d45f82aeeb09e55a256573373ec64409fc19a6fb82fb1032ae"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -24,7 +24,6 @@ thiserror = "1.0.19"
 anyhow = "1.0.31"
 bitflags = "1.2.1"
 warp = "0.2.3"
-reqwest = "0.10.6"
 config = "0.10.1"
 validator = "0.10"
 validator_derive = "0.10"
@@ -40,9 +39,14 @@ uuid = { version = "0.8.1", features = ["v4"]}
 rayon = "1.3.0"
 async-trait = "0.1.35"
 
+[dependencies.reqwest]
+version = "0.10.6"
+default-features = false
+
 [[bin]]
 name = "coordinator"
 path = "src/bin/main.rs"
 
 [features]
-default = []
+default = ["reqwest/default-tls"]
+rustls = ["reqwest/rustls-tls"]

--- a/rust/src/bin/test-drive-net.rs
+++ b/rust/src/bin/test-drive-net.rs
@@ -56,7 +56,7 @@ async fn main() -> Result<(), ClientError> {
         clients.push(client);
     }
 
-    for _ in 0..10 {
+    for _ in 0..opt.nb_client {
         for client in clients.iter_mut() {
             let model =
                 Model::from_primitives(vec![rng.gen_range(0, 10); len].into_iter()).unwrap();

--- a/rust/src/bin/test-mobile.rs
+++ b/rust/src/bin/test-mobile.rs
@@ -1,0 +1,55 @@
+#[macro_use]
+extern crate tracing;
+
+use std::io::{stdin, stdout, Read, Write};
+use structopt::StructOpt;
+use tracing_subscriber::*;
+use xain_fl::{
+    client::mobile_client::MobileClient,
+    mask::{FromPrimitives, Model},
+};
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = "Test Drive")]
+struct Opt {
+    #[structopt(
+        default_value = "http://127.0.0.1:8081",
+        short,
+        help = "The URL of the coordinator"
+    )]
+    url: String,
+    #[structopt(default_value = "4", short, help = "The length of the model")]
+    len: u32,
+    #[structopt(
+        default_value = "1",
+        short,
+        help = "The time period at which to poll for service data, in seconds"
+    )]
+    period: u64,
+    #[structopt(default_value = "10", short, help = "The number of clients")]
+    nb_client: u32,
+}
+
+fn pause() {
+    let mut stdout = stdout();
+    stdout.write(b"Press Enter to continue...").unwrap();
+    stdout.flush().unwrap();
+    stdin().read(&mut [0]).unwrap();
+}
+
+fn main() -> Result<(), ()> {
+    let _fmt_subscriber = FmtSubscriber::builder()
+        .with_env_filter(EnvFilter::from_default_env())
+        .with_ansi(true)
+        .init();
+
+    let mut client = MobileClient::new("http://localhost:8081");
+
+    let model = Model::from_primitives(vec![1; 4].into_iter()).unwrap();
+
+    loop {
+        client.set_local_model(model.clone());
+        client.next();
+        pause();
+    }
+}

--- a/rust/src/client/client.rs
+++ b/rust/src/client/client.rs
@@ -248,7 +248,7 @@ impl Client {
 
     /// Work flow for unselected participants.
     async fn unselected() -> Result<(), ClientError> {
-        debug!("not selected");
+        info!("not selected");
         Ok(())
     }
 }

--- a/rust/src/client/client.rs
+++ b/rust/src/client/client.rs
@@ -1,0 +1,268 @@
+use crate::{
+    client::{ClientError, Participant, Proxy, Task},
+    crypto::ByteObject,
+    mask::model::Model,
+    state_machine::coordinator::RoundParameters,
+    CoordinatorPublicKey,
+    InitError,
+    PetError,
+};
+use futures::{
+    future::{Fuse, FutureExt},
+    pin_mut,
+    select,
+};
+use std::{default::Default, sync::Arc, time::Duration};
+use tokio::{
+    sync::{broadcast, mpsc, watch},
+    time,
+};
+pub struct RoundParamFetcher {
+    /// Coordinator public key
+    coordinator_pk: CoordinatorPublicKey,
+    round_param_tx: mpsc::UnboundedSender<RoundParameters>,
+
+    global_model: Option<Model>,
+    global_model_tx: watch::Sender<Option<Model>>,
+
+    proxy: Arc<Proxy>,
+}
+
+impl RoundParamFetcher {
+    pub fn new(
+        proxy: Arc<Proxy>,
+        global_model_tx: watch::Sender<Option<Model>>,
+    ) -> (mpsc::UnboundedReceiver<RoundParameters>, Self) {
+        let (round_param_tx, round_param_rx) = mpsc::unbounded_channel();
+        (
+            round_param_rx,
+            Self {
+                coordinator_pk: CoordinatorPublicKey::zeroed(),
+                round_param_tx,
+                global_model: None,
+                global_model_tx,
+                proxy,
+            },
+        )
+    }
+
+    pub async fn check_new_round_param(&mut self) {
+        let mut interval = time::interval(Duration::from_secs(5));
+
+        loop {
+            if let Ok(round_params) = self.proxy.get_round_params().await {
+                if round_params.pk != self.coordinator_pk {
+                    debug!("new round parameters");
+                    self.coordinator_pk = round_params.pk;
+                    self.round_param_tx.send(round_params);
+                    // we can also fetch the global model in a separate task
+                    // but it is more efficient to do it after the coordinator released new
+                    // round parameters(because we know that the coordinator started a new round)
+                    self.fetch_global_model().await;
+                }
+            } else {
+                error!("Error receiving round parameters")
+            }
+
+            interval.tick().await;
+        }
+    }
+
+    async fn fetch_global_model(&mut self) {
+        let model = self.proxy.get_model().await.unwrap();
+        //update our global model where necessary
+        match (model, &self.global_model) {
+            (Some(new_model), None) => self.set_global_model(new_model),
+            (Some(new_model), Some(old_model)) if &new_model != old_model => {
+                self.set_global_model(new_model)
+            }
+            (None, _) => trace!("global model not ready yet"),
+            _ => trace!("global model still fresh"),
+        }
+    }
+
+    fn set_global_model(&mut self, model: Model) {
+        debug!("updating global model");
+        self.global_model = Some(model);
+        self.global_model_tx.broadcast(self.global_model.clone());
+    }
+}
+pub struct Client;
+
+impl Client {
+    pub async fn start(
+        proxy: Arc<Proxy>,
+        local_model_rx: watch::Receiver<Option<Model>>,
+        global_model_tx: watch::Sender<Option<Model>>,
+        mut shutdown_rx: broadcast::Receiver<()>,
+    ) {
+        let (mut fetcher_rx, mut fetcher) = RoundParamFetcher::new(proxy.clone(), global_model_tx);
+
+        let join_handle_fetcher = tokio::spawn(async move {
+            tokio::select! {
+                _ = fetcher.check_new_round_param() => {}
+                _ = shutdown_rx.recv() => {info!("shutdown fetcher")}
+            }
+        });
+
+        let join_handle_task = tokio::spawn(async move {
+            // idea from https://rust-lang.github.io/async-book/06_multiple_futures/03_select.html#concurrent-tasks-in-a-select-loop-with-fuse-and-futuresunordered
+            let participant_task = Fuse::terminated();
+            pin_mut!(participant_task);
+
+            loop {
+                select! {
+                    new_round_param = fetcher_rx.recv().fuse() => {
+                        // New round parameters have arrived-- start a new `participant_task`,
+                        // dropping the old one.
+                        match new_round_param {
+                            Some(round_params) =>  participant_task.set(Self::run_participant_task(round_params, proxy.clone(), local_model_rx.clone()).fuse()),
+                            // fetcher is dropped -> signal to shut down
+                            None => {info!("shutdown task"); break;}
+                        }
+                    },
+                    // Run the `participant_task`
+                    _ = participant_task => {},
+                    // something went wrong
+                    complete => break,
+                }
+            }
+        });
+
+        tokio::join!(join_handle_fetcher, join_handle_task);
+    }
+
+    async fn run_participant_task(
+        round_params: RoundParameters,
+        proxy: Arc<Proxy>,
+        local_model_rx: watch::Receiver<Option<Model>>,
+    ) -> Result<(), ClientError> {
+        let mut participant = Participant::new().map_err(ClientError::ParticipantInitErr)?;
+
+        participant.compute_signatures(round_params.seed.as_slice());
+        let (sum_frac, upd_frac) = (round_params.sum, round_params.update);
+
+        // update the flag only after everything else is done such that the client can learn
+        // via the API that a new round has started once all parameters are available
+        let task = participant.check_task(sum_frac, upd_frac);
+
+        let coordinator_pk = round_params.pk;
+        return match task {
+            Task::Sum => Self::summer(proxy, coordinator_pk, participant).await,
+            Task::Update => Self::update(proxy, coordinator_pk, participant, local_model_rx).await,
+            Task::None => Self::unselected().await,
+        };
+    }
+
+    /// Work flow for sum participants.
+    async fn summer(
+        proxy: std::sync::Arc<Proxy>,
+        coordinator_pk: CoordinatorPublicKey,
+        mut participant: Participant,
+    ) -> Result<(), ClientError> {
+        info!("selected to sum");
+        let mut interval = time::interval(Duration::from_secs(5));
+
+        let sum1_msg = participant.compose_sum_message(&coordinator_pk);
+        proxy.post_message(sum1_msg).await?;
+
+        debug!("polling for model/mask length");
+        let length = loop {
+            if let Some(length) = proxy.get_mask_length().await? {
+                if length > usize::MAX as u64 {
+                    return Err(ClientError::ParticipantErr(PetError::InvalidModel));
+                } else {
+                    break length as usize;
+                }
+            }
+            trace!("model/mask length not ready, retrying.");
+            interval.tick().await;
+        };
+
+        debug!("sum message sent, polling for seed dict.");
+        let seeds = loop {
+            if let Some(seeds) = proxy.get_seeds(participant.pk).await? {
+                break seeds;
+            }
+            trace!("seed dict not ready, retrying.");
+            interval.tick().await;
+        };
+
+        debug!("seed dict received, sending sum2 message.");
+        let sum2_msg = participant
+            .compose_sum2_message(coordinator_pk, &seeds, length)
+            .map_err(|e| {
+                error!("failed to compose sum2 message with seeds: {:?}", &seeds);
+                ClientError::ParticipantErr(e)
+            })?;
+        proxy.post_message(sum2_msg).await?;
+
+        info!("sum participant completed a round");
+        Ok(())
+    }
+
+    /// Work flow for update participants.
+    async fn update(
+        proxy: std::sync::Arc<Proxy>,
+        coordinator_pk: CoordinatorPublicKey,
+        participant: Participant,
+        mut local_model_rx: watch::Receiver<Option<Model>>,
+    ) -> Result<(), ClientError> {
+        info!("selected to update");
+        let mut interval = time::interval(Duration::from_secs(5));
+
+        let local_model = loop {
+            if let Some(local_model) = local_model_rx.recv().await.ok_or(ClientError::GeneralErr)? {
+                break local_model;
+            } else {
+                warn!("local model not ready");
+            }
+        };
+
+        debug!("polling for model scalar");
+        let scalar = loop {
+            if let Some(scalar) = proxy.get_scalar().await? {
+                break scalar;
+            }
+            trace!("model scalar not ready, retrying.");
+            interval.tick().await;
+        };
+
+        debug!("polling for sum dict");
+        let sums = loop {
+            if let Some(sums) = proxy.get_sums().await? {
+                break sums;
+            }
+            trace!("sum dict not ready, retrying.");
+            interval.tick().await;
+        };
+
+        debug!("sum dict received, sending update message.");
+        let upd_msg =
+            participant.compose_update_message(coordinator_pk, &sums, scalar, local_model);
+        proxy.post_message(upd_msg).await?;
+
+        info!("update participant completed a round");
+        Ok(())
+    }
+
+    /// Work flow for unselected participants.
+    async fn unselected() -> Result<(), ClientError> {
+        debug!("not selected");
+        Ok(())
+    }
+}
+
+// async fn retry<R>(
+//     period: u64,
+//     fut: impl Future<Output = Result<Option<R>, ClientError>> + Copy,
+// ) -> Result<R, ClientError> {
+//     let mut interval = time::interval(Duration::from_secs(period));
+//     loop {
+//         if let Some(R) = fut.await? {
+//             break Ok(R);
+//         }
+//         trace!("not ready, retrying.");
+//         interval.tick().await;
+//     }
+// }

--- a/rust/src/client/mobile_client.rs
+++ b/rust/src/client/mobile_client.rs
@@ -1,0 +1,254 @@
+use crate::{
+    client::{participant::Task, ClientError, Participant, Proxy},
+    crypto::ByteObject,
+    mask::model::{FromPrimitives, Model},
+    CoordinatorPublicKey,
+    PetError,
+};
+use derive_more::From;
+use std::sync::{Arc, Mutex};
+
+pub struct MobileClient {
+    local_model: Option<Arc<Mutex<Model>>>,
+    global_model: Option<Arc<Mutex<Model>>>,
+    participant: StateMachine,
+}
+
+impl MobileClient {
+    pub fn new(proxy: Proxy) -> Self {
+        Self {
+            local_model: None,
+            global_model: None,
+            participant: StateMachine::new(proxy),
+        }
+    }
+
+    pub fn set_local_model(&self, local_model: Model) {
+        if let Some(current_local_model) = &self.local_model {
+            let mut new_local_model = current_local_model.lock().unwrap();
+            *new_local_model = local_model;
+        }
+    }
+
+    pub fn get_global_model(&self) -> Option<Model> {
+        if let Some(global_model) = &self.global_model {
+            Some(global_model.lock().unwrap().clone())
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(From)]
+pub enum StateMachine {
+    Idle(State<Idle>),
+    Sum(State<Sum>),
+    Update(State<Update>),
+    Sum2(State<Sum2>),
+}
+
+impl StateMachine {
+    pub fn new(proxy: Proxy) -> Self {
+        StateMachine::from(State::<Idle>::new(proxy))
+    }
+
+    pub async fn next(self) -> Self {
+        match self {
+            StateMachine::Idle(state) => state.next().await,
+            StateMachine::Sum(state) => state.next().await,
+            StateMachine::Update(state) => state.next().await,
+            StateMachine::Sum2(state) => state.next().await,
+        }
+    }
+}
+
+pub struct Idle; // unselected participant
+pub struct Sum;
+pub struct Update;
+pub struct Sum2;
+
+pub struct State<Task> {
+    task: Task,
+    proxy: Proxy,
+    participant: Participant,
+    coordinator_pk: CoordinatorPublicKey,
+}
+
+impl<Task> State<Task> {
+    async fn check_round_freshness(&self) -> Result<(), ClientError> {
+        let round_params = self.proxy.get_round_params().await?;
+        if round_params.pk != self.coordinator_pk {
+            debug!("new round parameters");
+            Err(ClientError::GeneralErr) //old round
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl State<Idle> {
+    fn new(proxy: Proxy) -> Self {
+        Self {
+            task: Idle,
+            participant: Participant::new().unwrap(),
+            coordinator_pk: CoordinatorPublicKey::zeroed(),
+            proxy,
+        }
+    }
+
+    async fn next(mut self) -> StateMachine {
+        match self.step().await {
+            Ok(Task::Sum) => {
+                State::<Sum>::new(self.proxy, self.participant, self.coordinator_pk).into()
+            }
+            Ok(Task::Update) => {
+                State::<Update>::new(self.proxy, self.participant, self.coordinator_pk).into()
+            }
+            Ok(Task::None) => State::<Idle>::new(self.proxy).into(),
+            Err(_) => State::<Idle>::new(self.proxy).into(),
+        }
+    }
+
+    async fn step(&mut self) -> Result<Task, ClientError> {
+        let round_params = self.proxy.get_round_params().await?;
+        self.coordinator_pk = round_params.pk;
+        self.participant = Participant::new().unwrap();
+
+        let model = self.proxy.get_model().await?;
+
+        self.participant
+            .compute_signatures(round_params.seed.as_slice());
+        Ok(self
+            .participant
+            .check_task(round_params.sum, round_params.update))
+    }
+}
+
+impl State<Sum> {
+    fn new(proxy: Proxy, participant: Participant, coordinator_pk: CoordinatorPublicKey) -> Self {
+        Self {
+            task: Sum,
+            participant,
+            coordinator_pk,
+            proxy,
+        }
+    }
+
+    async fn next(mut self) -> StateMachine {
+        info!("selected to sum");
+        match self.step().await {
+            Ok(_) => State::<Sum2>::new(self.proxy, self.participant, self.coordinator_pk).into(),
+            Err(_) => State::<Idle>::new(self.proxy).into(),
+        }
+    }
+
+    async fn step(&mut self) -> Result<(), ClientError> {
+        self.check_round_freshness().await?;
+        let sum1_msg = self.participant.compose_sum_message(&self.coordinator_pk);
+        self.proxy.post_message(sum1_msg).await?;
+        debug!("sum message sent");
+        Ok(())
+    }
+}
+
+impl State<Update> {
+    fn new(proxy: Proxy, participant: Participant, coordinator_pk: CoordinatorPublicKey) -> Self {
+        Self {
+            task: Update,
+            participant,
+            coordinator_pk,
+            proxy,
+        }
+    }
+
+    async fn next(self) -> StateMachine {
+        info!("selected to update");
+        State::<Idle>::new(self.proxy).into()
+    }
+
+    async fn step(&mut self) -> Result<(), ClientError> {
+        self.check_round_freshness().await?;
+
+        // let local_model = loop {
+        //     if let Some(local_model) = local_model_rx.recv().await.ok_or(ClientError::GeneralErr)? {
+        //         break local_model;
+        //     } else {
+        //         warn!("local model not ready");
+        //     }
+        // };
+
+        debug!("polling for model scalar");
+        let scalar = self
+            .proxy
+            .get_scalar()
+            .await?
+            .ok_or(ClientError::GeneralErr)?;
+
+        debug!("polling for sum dict");
+        let sums = self
+            .proxy
+            .get_sums()
+            .await?
+            .ok_or(ClientError::GeneralErr)?;
+
+        debug!("sum dict received, sending update message.");
+        let upd_msg = self.participant.compose_update_message(
+            self.coordinator_pk,
+            &sums,
+            scalar,
+            Model::from_primitives(vec![0; 4].into_iter()).unwrap(),
+        );
+        self.proxy.post_message(upd_msg).await?;
+
+        info!("update participant completed a round");
+        Ok(())
+    }
+}
+
+impl State<Sum2> {
+    fn new(proxy: Proxy, participant: Participant, coordinator_pk: CoordinatorPublicKey) -> Self {
+        Self {
+            task: Sum2,
+            participant,
+            coordinator_pk,
+            proxy,
+        }
+    }
+
+    async fn next(self) -> StateMachine {
+        info!("selected to sum2");
+        State::<Idle>::new(self.proxy).into()
+    }
+
+    async fn step(&mut self) -> Result<(), ClientError> {
+        self.check_round_freshness().await?;
+
+        debug!("polling for model/mask length");
+        let length = self
+            .proxy
+            .get_mask_length()
+            .await?
+            .ok_or(ClientError::GeneralErr)?;
+        if length > usize::MAX as u64 {
+            return Err(ClientError::ParticipantErr(PetError::InvalidModel));
+        };
+
+        let seeds = self
+            .proxy
+            .get_seeds(self.participant.pk)
+            .await?
+            .ok_or(ClientError::GeneralErr)?;
+
+        debug!("seed dict received, sending sum2 message.");
+        let sum2_msg = self
+            .participant
+            .compose_sum2_message(self.coordinator_pk, &seeds, length as usize)
+            .map_err(|e| {
+                error!("failed to compose sum2 message with seeds: {:?}", &seeds);
+                ClientError::ParticipantErr(e)
+            })?;
+        self.proxy.post_message(sum2_msg).await?;
+        info!("sum participant completed a round");
+        Ok(())
+    }
+}

--- a/rust/src/client/mod.rs
+++ b/rust/src/client/mod.rs
@@ -261,7 +261,7 @@ impl SyncClient {
         self.client.get_global_model()
     }
 
-    pub fn set_global_model(&mut self, local_model: Model) {
+    pub fn set_local_model(&mut self, local_model: Model) {
         self.client.set_local_model(local_model);
     }
 

--- a/rust/src/client/mod.rs
+++ b/rust/src/client/mod.rs
@@ -196,7 +196,7 @@ impl LocalModelCache {
 }
 
 // A cache to store the global model.
-// We want to be able to provide latest fetch model even if the Client is not running
+// We want to be able to provide the latest fetch model even if the Client is not running
 pub struct GlobalModelCache {
     current_model: Option<Model>,
     receiver: Option<watch::Receiver<Option<Model>>>,
@@ -267,8 +267,8 @@ impl SyncClient {
 
     pub fn stop(&mut self) {
         if let Some(shutdown) = self.shutdown.take() {
-            // dropping the shutdown handel will trigger the shutdown branch of
-            // the fetcher tokio:select which will trigger the shutdown branch of the task select
+            // dropping the shutdown handle will trigger the shutdown tokio:select branch of
+            // the RoundParamFetcher which will trigger the shutdown the participant task
             drop(shutdown);
             // we wait until the tokio runtime has finished the task
             self.handle.take().unwrap().join();

--- a/rust/src/client/mod.rs
+++ b/rust/src/client/mod.rs
@@ -80,7 +80,7 @@ use tokio::{
     sync::{broadcast, mpsc, watch},
 };
 
-mod mobile_client;
+pub mod mobile_client;
 
 mod client;
 pub use client::{Client, RoundParamFetcher};
@@ -125,6 +125,9 @@ pub enum ClientError {
     #[error("unexpected client error")]
     /// Unexpected client error.
     GeneralErr,
+
+    #[error("mobile client failed: {0}")]
+    MobileClientError(&'static str),
 }
 
 pub struct AsyncClient {

--- a/rust/src/client/mod.rs
+++ b/rust/src/client/mod.rs
@@ -80,6 +80,8 @@ use tokio::{
     sync::{broadcast, mpsc, watch},
 };
 
+mod mobile_client;
+
 mod client;
 pub use client::{Client, RoundParamFetcher};
 

--- a/rust/src/sdk/api_sync.rs
+++ b/rust/src/sdk/api_sync.rs
@@ -144,7 +144,7 @@ pub unsafe extern "C" fn update_model(
     len: c_uint,
 ) -> c_int {
     if client.is_null() || model.is_null() {
-        return -1_i32 as c_uint;
+        return -1_i32 as c_int;
     }
     let client = &mut *client;
 

--- a/rust/src/sdk/api_sync.rs
+++ b/rust/src/sdk/api_sync.rs
@@ -1,6 +1,15 @@
-use std::{ffi::CStr, os::raw::c_char, panic, ptr};
+use std::{
+    ffi::CStr,
+    os::raw::{c_char, c_int, c_uint, c_void},
+    panic,
+    ptr,
+    slice,
+};
 
-use crate::client::SyncClient;
+use crate::{
+    client::SyncClient,
+    mask::model::{FromPrimitives, IntoPrimitives, Model},
+};
 
 pub unsafe extern "C" fn new_client(address: *const c_char) -> *mut SyncClient {
     if address.is_null() {
@@ -40,5 +49,147 @@ pub unsafe extern "C" fn stop_client(client: *mut SyncClient) {
 pub unsafe extern "C" fn drop_client(client: *mut SyncClient) {
     if !client.is_null() {
         Box::from_raw(client);
+    }
+}
+
+// error codes:
+// -1: null pointers
+// 0: success
+// 1: no model available
+// 2: conversion failed
+pub unsafe extern "C" fn get_model(
+    client: *mut SyncClient,
+    dtype: c_uint,
+    model: *mut c_void,
+    len: c_uint,
+) -> c_int {
+    if client.is_null() || model.is_null() {
+        return -1_i32 as c_int;
+    }
+    let client = &mut *client;
+
+    let len = len as usize;
+    if let Some(m) = client.get_global_model() {
+        match dtype as u32 {
+            1 => {
+                // safety checks missing
+                let model = slice::from_raw_parts_mut(model as *mut f32, len);
+                for (i, p) in m.into_primitives().enumerate() {
+                    if i >= len {
+                        return 2_i32 as c_int;
+                    }
+                    if let Ok(p) = p {
+                        model[i] = p;
+                    } else {
+                        return 2_i32 as c_int;
+                    }
+                }
+            }
+            2 => {
+                let model = slice::from_raw_parts_mut(model as *mut f64, len);
+                for (i, p) in m.into_primitives().enumerate() {
+                    if i >= len {
+                        return 2_i32 as c_int;
+                    }
+                    if let Ok(p) = p {
+                        model[i] = p;
+                    } else {
+                        return 2_i32 as c_int;
+                    }
+                }
+            }
+            3 => {
+                let model = slice::from_raw_parts_mut(model as *mut i32, len);
+                for (i, p) in m.into_primitives().enumerate() {
+                    if i >= len {
+                        return 2_i32 as c_int;
+                    }
+                    if let Ok(p) = p {
+                        model[i] = p;
+                    } else {
+                        return 2_i32 as c_int;
+                    }
+                }
+            }
+            4 => {
+                let model = slice::from_raw_parts_mut(model as *mut i64, len);
+                for (i, p) in m.into_primitives().enumerate() {
+                    if i >= len {
+                        return 2_i32 as c_int;
+                    }
+                    if let Ok(p) = p {
+                        model[i] = p;
+                    } else {
+                        return 2_i32 as c_int;
+                    }
+                }
+            }
+            _ => return 2_i32 as c_int,
+        }
+        return 0_i32 as c_int;
+    } else {
+        return 1_i32 as c_int;
+    }
+}
+
+// error codes:
+// -1: null pointers
+// 0: success
+// 1: length mismatch
+// 2: conversion failed
+pub unsafe extern "C" fn update_model(
+    client: *mut SyncClient,
+    dtype: c_uint,
+    model: *const c_void,
+    len: c_uint,
+) -> c_int {
+    if client.is_null() || model.is_null() {
+        return -1_i32 as c_uint;
+    }
+    let client = &mut *client;
+
+    // length checks missing
+    let len = len as usize;
+    match dtype as u32 {
+        1 => {
+            // safety checks missing
+            let model = slice::from_raw_parts(model as *const f32, len);
+            if let Ok(m) = Model::from_primitives(model.iter().copied()) {
+                client.set_local_model(m);
+                return 0_i32 as c_int;
+            } else {
+                return 2_i32 as c_int;
+            }
+        }
+        2 => {
+            let model = slice::from_raw_parts(model as *const f64, len);
+            if let Ok(m) = Model::from_primitives(model.iter().copied()) {
+                client.set_local_model(m);
+                return 0_i32 as c_int;
+            } else {
+                return 2_i32 as c_int;
+            }
+        }
+        3 => {
+            let model = slice::from_raw_parts(model as *const i32, len);
+            if let Ok(m) = Model::from_primitives(model.iter().copied()) {
+                client.set_local_model(m);
+                return 0_i32 as c_int;
+            } else {
+                return 2_i32 as c_int;
+            }
+        }
+        4 => {
+            let model = slice::from_raw_parts(model as *const i64, len);
+            if let Ok(m) = Model::from_primitives(model.iter().copied()) {
+                client.set_local_model(m);
+                return 0_i32 as c_int;
+            } else {
+                return 2_i32 as c_int;
+            }
+        }
+        _ => {
+            return 2_i32 as c_int;
+        }
     }
 }

--- a/rust/src/sdk/api_sync.rs
+++ b/rust/src/sdk/api_sync.rs
@@ -11,6 +11,7 @@ use crate::{
     mask::model::{FromPrimitives, IntoPrimitives, Model},
 };
 
+#[no_mangle]
 pub unsafe extern "C" fn new_client(address: *const c_char) -> *mut SyncClient {
     if address.is_null() {
         return ptr::null_mut() as *mut SyncClient;
@@ -28,6 +29,7 @@ pub unsafe extern "C" fn new_client(address: *const c_char) -> *mut SyncClient {
     Box::into_raw(Box::new(SyncClient::new(address)))
 }
 
+#[no_mangle]
 pub unsafe extern "C" fn start_client(client: *mut SyncClient) {
     if !client.is_null() {
         let client = &mut *client;
@@ -37,6 +39,7 @@ pub unsafe extern "C" fn start_client(client: *mut SyncClient) {
     }
 }
 
+#[no_mangle]
 pub unsafe extern "C" fn stop_client(client: *mut SyncClient) {
     if !client.is_null() {
         let client = &mut *client;
@@ -46,6 +49,7 @@ pub unsafe extern "C" fn stop_client(client: *mut SyncClient) {
     }
 }
 
+#[no_mangle]
 pub unsafe extern "C" fn drop_client(client: *mut SyncClient) {
     if !client.is_null() {
         Box::from_raw(client);
@@ -57,6 +61,7 @@ pub unsafe extern "C" fn drop_client(client: *mut SyncClient) {
 // 0: success
 // 1: no model available
 // 2: conversion failed
+#[no_mangle]
 pub unsafe extern "C" fn get_model(
     client: *mut SyncClient,
     dtype: c_uint,
@@ -137,6 +142,7 @@ pub unsafe extern "C" fn get_model(
 // 0: success
 // 1: length mismatch
 // 2: conversion failed
+#[no_mangle]
 pub unsafe extern "C" fn update_model(
     client: *mut SyncClient,
     dtype: c_uint,

--- a/rust/src/sdk/api_sync.rs
+++ b/rust/src/sdk/api_sync.rs
@@ -1,0 +1,44 @@
+use std::{ffi::CStr, os::raw::c_char, panic, ptr};
+
+use crate::client::SyncClient;
+
+pub unsafe extern "C" fn new_client(address: *const c_char) -> *mut SyncClient {
+    if address.is_null() {
+        return ptr::null_mut() as *mut SyncClient;
+    }
+    let address = if let Ok(address) = unsafe {
+        // safe if the raw pointer `address` comes from a null-terminated C-string
+        CStr::from_ptr(address)
+    }
+    .to_str()
+    {
+        address
+    } else {
+        return ptr::null_mut() as *mut SyncClient;
+    };
+    Box::into_raw(Box::new(SyncClient::new(address)))
+}
+
+pub unsafe extern "C" fn start_client(client: *mut SyncClient) {
+    if !client.is_null() {
+        let client = &mut *client;
+        if let Err(_) = panic::catch_unwind(panic::AssertUnwindSafe(|| client.start())) {
+            error!("client panicked");
+        }
+    }
+}
+
+pub unsafe extern "C" fn stop_client(client: *mut SyncClient) {
+    if !client.is_null() {
+        let client = &mut *client;
+        if let Err(_) = panic::catch_unwind(panic::AssertUnwindSafe(|| client.stop())) {
+            error!("client panicked");
+        }
+    }
+}
+
+pub unsafe extern "C" fn drop_client(client: *mut SyncClient) {
+    if !client.is_null() {
+        Box::from_raw(client);
+    }
+}

--- a/rust/src/sdk/mod.rs
+++ b/rust/src/sdk/mod.rs
@@ -1,3 +1,4 @@
 //! A SDK for XayNet participants.
 
 //pub mod api;
+pub mod api_sync;

--- a/rust/src/sdk/mod.rs
+++ b/rust/src/sdk/mod.rs
@@ -1,3 +1,3 @@
 //! A SDK for XayNet participants.
 
-pub mod api;
+//pub mod api;


### PR DESCRIPTION
A first POC of the async/sync client.
Currently only 4 methods are implemented (start, stop, get_global_model, set_local_model)

You can find an example of the sync (test-drive) and async version (test-drive-net) in the `bin` folder

![async-sync-client](https://user-images.githubusercontent.com/10488408/87143699-cd1fe280-c2a6-11ea-810c-3762190d9399.png)

Feel free to add comments 🙂
