### PR TITLE
PB-926 GitHub Actions for Docker Hub (PR, merges to master and tagged releases)

### DIFF
--- a/.github/workflows/dockerhub-master.yml
+++ b/.github/workflows/dockerhub-master.yml
@@ -19,6 +19,6 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           dockerfile: docker/Dockerfile
           cache_froms: buildpack-deps:stable-curl
-          repository: xain/xain-fl
+          repository: xaynetwork/xaynet
           tag_with_ref: true
           push: true

--- a/.github/workflows/dockerhub-master.yml
+++ b/.github/workflows/dockerhub-master.yml
@@ -1,0 +1,24 @@
+name: DockerHub (Master)
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-tag-push-master:
+    name: build-tag-push-master
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      
+      - name: build-tag-push
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          dockerfile: docker/Dockerfile
+          cache_froms: buildpack-deps:stable-curl
+          repository: xain/xain-fl
+          tag_with_ref: true
+          push: true

--- a/.github/workflows/dockerhub-master.yml
+++ b/.github/workflows/dockerhub-master.yml
@@ -21,4 +21,5 @@ jobs:
           cache_froms: buildpack-deps:stable-curl
           repository: xaynetwork/xaynet
           tag_with_ref: true
+          tags: development
           push: true

--- a/.github/workflows/dockerhub-pr.yml
+++ b/.github/workflows/dockerhub-pr.yml
@@ -19,6 +19,6 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           dockerfile: docker/Dockerfile
           cache_froms: buildpack-deps:stable-curl
-          repository: xain/xain-fl
+          repository: xaynetwork/xaynet
           tag_with_ref: true
           push: true

--- a/.github/workflows/dockerhub-pr.yml
+++ b/.github/workflows/dockerhub-pr.yml
@@ -1,0 +1,24 @@
+name: DockerHub (PR)
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build-tag-push-pr:
+    name: build-tag-push-pr
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      
+      - name: build-tag-push
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          dockerfile: docker/Dockerfile
+          cache_froms: buildpack-deps:stable-curl
+          repository: xain/xain-fl
+          tag_with_ref: true
+          push: true

--- a/.github/workflows/dockerhub-pr.yml
+++ b/.github/workflows/dockerhub-pr.yml
@@ -47,6 +47,6 @@ jobs:
           dockerfile: docker/Dockerfile
           cache_froms: buildpack-deps:stable-curl
           repository: xaynetwork/xaynet
-          tag_with_ref: true
+          tags: pr-${{ steps.pr_data.outputs.branch }}
           push: true
 

--- a/.github/workflows/dockerhub-pr.yml
+++ b/.github/workflows/dockerhub-pr.yml
@@ -2,17 +2,44 @@ name: DockerHub (PR)
 
 on:
   pull_request:
-    branches:
-      - master
+    types: [opened]
+  issue_comment:
+    types: [created]
 
 jobs:
-  build-tag-push-pr:
-    name: build-tag-push-pr
+  build-by-request:
+    name: build-by-request
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      
-      - name: build-tag-push
+      - name: PR Comment Trigger
+        uses: Khan/pull-request-comment-trigger@1.0.0
+        id: check
+        with:
+          trigger: '#build'
+          reaction: rocket
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - if: steps.check.outputs.triggered == 'true'
+        name: GitHub API Request
+        uses: octokit/request-action@v2.0.0
+        id: request
+        with:
+          route: ${{ github.event.issue.pull_request.url }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - if: steps.check.outputs.triggered == 'true'
+        name: Get PR metadata
+        id: pr_data
+        run: |
+          echo "::set-output name=branch::${{ fromJson(steps.request.outputs.data).head.ref }}"
+      - if: steps.check.outputs.triggered == 'true'
+        name: Clone branch of the PR
+        uses: actions/checkout@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ steps.pr_data.outputs.branch }}
+      - if: steps.check.outputs.triggered == 'true'
+        name: build-tag-push-pr
         uses: docker/build-push-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -22,3 +49,4 @@ jobs:
           repository: xaynetwork/xaynet
           tag_with_ref: true
           push: true
+

--- a/.github/workflows/dockerhub-release.yml
+++ b/.github/workflows/dockerhub-release.yml
@@ -19,6 +19,6 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           dockerfile: docker/Dockerfile.release
           cache_froms: buildpack-deps:stable-curl
-          repository: xain/xain-fl
+          repository: xaynetwork/xaynet
           tag_with_ref: true
           push: true

--- a/.github/workflows/dockerhub-release.yml
+++ b/.github/workflows/dockerhub-release.yml
@@ -1,0 +1,24 @@
+name: DockerHub (Release)
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  build-tag-push-release:
+    name: build-tag-push-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      
+      - name: build-tag-push
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          dockerfile: docker/Dockerfile.release
+          cache_froms: buildpack-deps:stable-curl
+          repository: xain/xain-fl
+          tag_with_ref: true
+          push: true


### PR DESCRIPTION
Edited the logic for the `Docker Hub (PR)` workflow: only build if trigger word `#build` is found either on the PR's description (when it's first created) or if any comment is posted with such keyword, otherwise don't build an image. Comments that trigger a build automatically get a :rocket: reaction from `github-actions[bot]`.

The workflow for this is a bit cluttered, that's because a comment posted on the PR isn't associated with any branches (not even the branch where the PR is based), `master` is then assumed, so I needed to do that workaround querying GitHub's API to be able to get the PR's branch and checkout that branch to build, tag and publish the image to Docker Hub. 

---

Merges to `master` always trigger a build and the image is pushed under tags `latest` and `development`.

---

Tags on `master` that follow semantic versioning will trigger a **release build** (with optimizations) and will be tagged and published under a tag of same name.