### PR TITLE
minimum phase time

### DIFF
--- a/configs/config.toml
+++ b/configs/config.toml
@@ -5,10 +5,10 @@ filter = "xain_fl=debug,http=warn,info"
 bind_address = "127.0.0.1:8081"
 
 [pet]
-min_sum = 1
-min_update = 3
-min_sum_t = 5
-min_update_t = 10
+min_sum_count = 1
+min_update_count = 3
+min_sum_time = 5
+min_update_time = 10
 sum = 0.5
 update = 0.9
 expected_participants = 10

--- a/configs/config.toml
+++ b/configs/config.toml
@@ -7,6 +7,8 @@ bind_address = "127.0.0.1:8081"
 [pet]
 min_sum = 1
 min_update = 3
+min_sum_t = 5
+min_update_t = 10
 sum = 0.5
 update = 0.9
 expected_participants = 10

--- a/configs/docker-dev.toml
+++ b/configs/docker-dev.toml
@@ -5,8 +5,8 @@ filter = "xain_fl=debug,http=warn,info"
 bind_address = "0.0.0.0:8081"
 
 [pet]
-min_sum = 1
-min_update = 3
+min_sum_count = 1
+min_update_count = 3
 sum = 0.01
 update = 0.1
 expected_participants = 10

--- a/configs/docker-release.toml
+++ b/configs/docker-release.toml
@@ -5,8 +5,8 @@ filter = "info"
 bind_address = "0.0.0.0:8081"
 
 [pet]
-min_sum = 1
-min_update = 3
+min_sum_count = 1
+min_update_count = 3
 sum = 0.01
 update = 0.1
 expected_participants = 10

--- a/rust/src/settings.rs
+++ b/rust/src/settings.rs
@@ -60,7 +60,8 @@ impl Settings {
 pub struct PetSettings {
     #[validate(range(min = 1))]
     /// The minimal number of participants selected for computing the unmasking sum. The value must
-    /// be greater or equal to `1` (i.e. `min_sum >= 1`), otherwise the PET protocol will be broken.
+    /// be greater or equal to `1` (i.e. `min_sum_count >= 1`), otherwise the PET protocol will be
+    /// broken.
     ///
     /// This parameter should only be used to enforce security constraints. To control the expected
     /// number of sum participants, the `sum` fraction should be adjusted wrt the total number of
@@ -71,19 +72,19 @@ pub struct PetSettings {
     /// **TOML**
     /// ```text
     /// [pet]
-    /// min_sum = 1
+    /// min_sum_count = 1
     /// ```
     ///
     /// **Environment variable**
     /// ```text
-    /// XAYNET_PET__MIN_SUM=1
+    /// XAYNET_PET__MIN_SUM_COUNT=1
     /// ```
-    pub min_sum: usize,
+    pub min_sum_count: usize,
 
     #[validate(range(min = 3))]
     /// The expected fraction of participants selected for submitting an updated local model for
-    /// aggregation. The value must be greater or equal to `3` (i.e. `min_update >= 3`), otherwise
-    /// the PET protocol will be broken.
+    /// aggregation. The value must be greater or equal to `3` (i.e. `min_update_count >= 3`),
+    /// otherwise the PET protocol will be broken.
     ///
     /// This parameter should only be used to enforce security constraints. To control the expected
     /// number of update participants, the `update` fraction should be adjusted wrt the total number
@@ -94,58 +95,58 @@ pub struct PetSettings {
     /// **TOML**
     /// ```text
     /// [pet]
-    /// min_update = 3
+    /// min_update_count = 3
     /// ```
     ///
     /// **Environment variable**
     /// ```text
-    /// XAYNET_PET__MIN_UPDATE=3
+    /// XAYNET_PET__MIN_UPDATE_COUNT=3
     /// ```
-    pub min_update: usize,
+    pub min_update_count: usize,
 
     /// The minimum amount of time reserved for processing messages in the `sum`
     /// and `sum2` phases, in seconds.
     ///
-    /// Defaults to 0 i.e. `sum` and `sum2` phases end *as soon as* [`min_sum`]
-    /// messages have been processed. Set this higher to allow for the
-    /// possibility of more than [`min_sum`] messages to be processed in the
-    /// `sum` and `sum2` phases.
+    /// Defaults to 0 i.e. `sum` and `sum2` phases end *as soon as*
+    /// [`min_sum_count`] messages have been processed. Set this higher to allow
+    /// for the possibility of more than [`min_sum_count`] messages to be
+    /// processed in the `sum` and `sum2` phases.
     ///
     /// # Examples
     ///
     /// **TOML**
     /// ```text
     /// [pet]
-    /// min_sum_t = 5
+    /// min_sum_time = 5
     /// ```
     ///
     /// **Environment variable**
     /// ```text
-    /// XAIN_PET__MIN_SUM_T=5
+    /// XAYNET_PET__MIN_SUM_TIME=5
     /// ```
-    pub min_sum_t: u64,
+    pub min_sum_time: u64,
 
     /// The minimum amount of time reserved for processing messages in the
     /// `update` phase, in seconds.
     ///
-    /// Defaults to 0 i.e. `update` phase ends *as soon as* [`min_update`]
+    /// Defaults to 0 i.e. `update` phase ends *as soon as* [`min_update_count`]
     /// messages have been processed. Set this higher to allow for the
-    /// possibility of more than [`min_update`] messages to be processed in the
-    /// `update` phase.
+    /// possibility of more than [`min_update_count`] messages to be processed
+    /// in the `update` phase.
     ///
     /// # Examples
     ///
     /// **TOML**
     /// ```text
     /// [pet]
-    /// min_update_t = 10
+    /// min_update_time = 10
     /// ```
     ///
     /// **Environment variable**
     /// ```text
-    /// XAIN_PET__MIN_UPDATE_T=10
+    /// XAYNET_PET__MIN_UPDATE_TIME=10
     /// ```
-    pub min_update_t: u64,
+    pub min_update_time: u64,
 
     /// The expected fraction of participants selected for computing the unmasking sum. The value
     /// must be between `0` and `1` (i.e. `0 < sum < 1`).
@@ -209,10 +210,10 @@ pub struct PetSettings {
 impl Default for PetSettings {
     fn default() -> Self {
         Self {
-            min_sum: 1_usize,
-            min_update: 3_usize,
-            min_sum_t: 0_u64,
-            min_update_t: 0_u64,
+            min_sum_count: 1_usize,
+            min_update_count: 3_usize,
+            min_sum_time: 0_u64,
+            min_update_time: 0_u64,
             sum: 0.01_f64,
             update: 0.1_f64,
             expected_participants: 10,

--- a/rust/src/settings.rs
+++ b/rust/src/settings.rs
@@ -103,6 +103,50 @@ pub struct PetSettings {
     /// ```
     pub min_update: usize,
 
+    /// The minimum amount of time reserved for processing messages in the `sum`
+    /// and `sum2` phases, in seconds.
+    ///
+    /// Defaults to 0 i.e. `sum` and `sum2` phases end *as soon as* [`min_sum`]
+    /// messages have been processed. Set this higher to allow for the
+    /// possibility of more than [`min_sum`] messages to be processed in the
+    /// `sum` and `sum2` phases.
+    ///
+    /// # Examples
+    ///
+    /// **TOML**
+    /// ```text
+    /// [pet]
+    /// min_sum_t = 5
+    /// ```
+    ///
+    /// **Environment variable**
+    /// ```text
+    /// XAIN_PET__MIN_SUM_T=5
+    /// ```
+    pub min_sum_t: u64,
+
+    /// The minimum amount of time reserved for processing messages in the
+    /// `update` phase, in seconds.
+    ///
+    /// Defaults to 0 i.e. `update` phase ends *as soon as* [`min_update`]
+    /// messages have been processed. Set this higher to allow for the
+    /// possibility of more than [`min_update`] messages to be processed in the
+    /// `update` phase.
+    ///
+    /// # Examples
+    ///
+    /// **TOML**
+    /// ```text
+    /// [pet]
+    /// min_update_t = 10
+    /// ```
+    ///
+    /// **Environment variable**
+    /// ```text
+    /// XAIN_PET__MIN_UPDATE_T=10
+    /// ```
+    pub min_update_t: u64,
+
     /// The expected fraction of participants selected for computing the unmasking sum. The value
     /// must be between `0` and `1` (i.e. `0 < sum < 1`).
     ///
@@ -167,6 +211,8 @@ impl Default for PetSettings {
         Self {
             min_sum: 1_usize,
             min_update: 3_usize,
+            min_sum_t: 0_u64,
+            min_update_t: 0_u64,
             sum: 0.01_f64,
             update: 0.1_f64,
             expected_participants: 10,

--- a/rust/src/state_machine/coordinator.rs
+++ b/rust/src/state_machine/coordinator.rs
@@ -32,13 +32,13 @@ pub struct CoordinatorState {
     /// The round parameters.
     pub round_params: RoundParameters,
     /// The minimum of required sum/sum2 messages.
-    pub min_sum: usize,
+    pub min_sum_count: usize,
     /// The minimum of required update messages.
-    pub min_update: usize,
+    pub min_update_count: usize,
     /// The minimum time (in seconds) reserved for processing sum/sum2 messages.
-    pub min_sum_t: u64,
+    pub min_sum_time: u64,
     /// The minimum time (in seconds) reserved for processing update messages.
-    pub min_update_t: u64,
+    pub min_update_time: u64,
     /// The number of expected participants.
     pub expected_participants: usize,
     /// The masking configuration.
@@ -65,10 +65,10 @@ impl CoordinatorState {
             keys,
             round_params,
             events: publisher,
-            min_sum: pet_settings.min_sum,
-            min_update: pet_settings.min_update,
-            min_sum_t: pet_settings.min_sum_t,
-            min_update_t: pet_settings.min_update_t,
+            min_sum_count: pet_settings.min_sum_count,
+            min_update_count: pet_settings.min_update_count,
+            min_sum_time: pet_settings.min_sum_time,
+            min_update_time: pet_settings.min_update_time,
             expected_participants: pet_settings.expected_participants,
             mask_config: mask_settings.into(),
         };

--- a/rust/src/state_machine/coordinator.rs
+++ b/rust/src/state_machine/coordinator.rs
@@ -35,6 +35,10 @@ pub struct CoordinatorState {
     pub min_sum: usize,
     /// The minimum of required update messages.
     pub min_update: usize,
+    /// The minimum time (in seconds) reserved for processing sum/sum2 messages.
+    pub min_sum_t: u64,
+    /// The minimum time (in seconds) reserved for processing update messages.
+    pub min_update_t: u64,
     /// The number of expected participants.
     pub expected_participants: usize,
     /// The masking configuration.
@@ -63,6 +67,8 @@ impl CoordinatorState {
             events: publisher,
             min_sum: pet_settings.min_sum,
             min_update: pet_settings.min_update,
+            min_sum_t: pet_settings.min_sum_t,
+            min_update_t: pet_settings.min_update_t,
             expected_participants: pet_settings.expected_participants,
             mask_config: mask_settings.into(),
         };

--- a/rust/src/state_machine/phases/mod.rs
+++ b/rust/src/state_machine/phases/mod.rs
@@ -69,7 +69,10 @@ pub struct PhaseState<R, S> {
     pub(in crate::state_machine) request_rx: RequestReceiver<R>,
 }
 
-impl<R, S> PhaseState<R, S> where Self: Handler<R> {
+impl<R, S> PhaseState<R, S>
+where
+    Self: Handler<R>,
+{
     /// Processes requests for as long as the given duration.
     async fn process_during(&mut self, dur: tokio::time::Duration) {
         tokio::select! {

--- a/rust/src/state_machine/phases/mod.rs
+++ b/rust/src/state_machine/phases/mod.rs
@@ -74,13 +74,15 @@ where
     Self: Handler<R>,
 {
     /// Processes requests for as long as the given duration.
-    async fn process_during(&mut self, dur: tokio::time::Duration) {
+    async fn process_during(&mut self, dur: tokio::time::Duration) -> Result<(), StateError> {
         tokio::select! {
-            _ = self.process() => {
-                panic!("unexpected termination of processing loop");
+            err = self.process() => {
+                error!("processing loop terminated before duration elapsed");
+                err
             }
             _ = tokio::time::delay_for(dur) => {
                 debug!("duration elapsed");
+                Ok(())
             }
         }
     }

--- a/rust/src/state_machine/phases/sum.rs
+++ b/rust/src/state_machine/phases/sum.rs
@@ -13,8 +13,7 @@ use crate::{
     SumDict,
 };
 
-use tokio::sync::oneshot;
-use tokio::time::Duration;
+use tokio::{sync::oneshot, time::Duration};
 
 /// Sum state
 #[derive(Debug)]
@@ -87,20 +86,24 @@ where
     /// Runs the sum phase.
     pub async fn run_phase(&mut self) -> Result<SeedDict, StateError> {
         let min_time = self.coordinator_state.min_sum_time;
+        debug!("in sum phase for a minimum of {} seconds", min_time);
         self.process_during(Duration::from_secs(min_time)).await;
 
         while !self.has_enough_sums() {
-            debug!("{} sum messages handled (min {} required)",
-              self.inner.sum_dict.len(),
-              self.coordinator_state.min_sum_count);
+            debug!(
+                "{} sum messages handled (min {} required)",
+                self.inner.sum_dict.len(),
+                self.coordinator_state.min_sum_count,
+            );
             let req = self.next_request().await?;
             self.handle_request(req);
-        };
+        }
 
-        info!("{} sum messages handled (min {} required)",
-              self.inner.sum_dict.len(),
-              self.coordinator_state.min_sum_count);
-
+        info!(
+            "{} sum messages handled (min {} required)",
+            self.inner.sum_dict.len(),
+            self.coordinator_state.min_sum_count
+        );
         Ok(self.freeze_sum_dict())
     }
 }
@@ -152,7 +155,6 @@ impl<R> PhaseState<R, Sum> {
     fn has_enough_sums(&self) -> bool {
         self.inner.sum_dict.len() >= self.coordinator_state.min_sum_count
     }
-
 }
 
 #[cfg(test)]

--- a/rust/src/state_machine/phases/sum.rs
+++ b/rust/src/state_machine/phases/sum.rs
@@ -87,7 +87,7 @@ where
     pub async fn run_phase(&mut self) -> Result<SeedDict, StateError> {
         let min_time = self.coordinator_state.min_sum_time;
         debug!("in sum phase for a minimum of {} seconds", min_time);
-        self.process_during(Duration::from_secs(min_time)).await;
+        self.process_during(Duration::from_secs(min_time)).await?;
 
         while !self.has_enough_sums() {
             debug!(

--- a/rust/src/state_machine/phases/sum.rs
+++ b/rust/src/state_machine/phases/sum.rs
@@ -86,20 +86,20 @@ where
 {
     /// Runs the sum phase.
     pub async fn run_phase(&mut self) -> Result<SeedDict, StateError> {
-        let min_t = self.coordinator_state.min_sum_t;
-        self.process_during(Duration::from_secs(min_t)).await;
+        let min_time = self.coordinator_state.min_sum_time;
+        self.process_during(Duration::from_secs(min_time)).await;
 
         while !self.has_enough_sums() {
             debug!("{} sum messages handled (min {} required)",
               self.inner.sum_dict.len(),
-              self.coordinator_state.min_sum);
+              self.coordinator_state.min_sum_count);
             let req = self.next_request().await?;
             self.handle_request(req);
         };
 
         info!("{} sum messages handled (min {} required)",
               self.inner.sum_dict.len(),
-              self.coordinator_state.min_sum);
+              self.coordinator_state.min_sum_count);
 
         Ok(self.freeze_sum_dict())
     }
@@ -150,7 +150,7 @@ impl<R> PhaseState<R, Sum> {
     /// Checks whether enough sum participants submitted their ephemeral keys to start the update
     /// phase.
     fn has_enough_sums(&self) -> bool {
-        self.inner.sum_dict.len() >= self.coordinator_state.min_sum
+        self.inner.sum_dict.len() >= self.coordinator_state.min_sum_count
     }
 
 }

--- a/rust/src/state_machine/phases/sum2.rs
+++ b/rust/src/state_machine/phases/sum2.rs
@@ -95,20 +95,20 @@ where
 {
     /// Runs the sum2 phase.
     async fn run_phase(&mut self) -> Result<(), StateError> {
-        let min_t = self.coordinator_state.min_sum_t;
-        self.process_during(Duration::from_secs(min_t)).await;
+        let min_time = self.coordinator_state.min_sum_time;
+        self.process_during(Duration::from_secs(min_time)).await;
 
         while !self.has_enough_sum2s() {
             debug!("{} sum2 messages handled (min {} required)",
                   self.mask_count(),
-                  self.coordinator_state.min_sum);
+                  self.coordinator_state.min_sum_count);
             let req = self.next_request().await?;
             self.handle_request(req);
         }
 
         info!("{} sum2 messages handled (min {} required)",
               self.mask_count(),
-              self.coordinator_state.min_sum);
+              self.coordinator_state.min_sum_count);
         Ok(())
     }
 }
@@ -171,6 +171,6 @@ impl<R> PhaseState<R, Sum2> {
 
     /// Checks whether enough sum participants submitted their masks to start the idle phase.
     fn has_enough_sum2s(&self) -> bool {
-        self.mask_count() >= self.coordinator_state.min_sum
+        self.mask_count() >= self.coordinator_state.min_sum_count
     }
 }

--- a/rust/src/state_machine/phases/sum2.rs
+++ b/rust/src/state_machine/phases/sum2.rs
@@ -96,7 +96,7 @@ where
     async fn run_phase(&mut self) -> Result<(), StateError> {
         let min_time = self.coordinator_state.min_sum_time;
         debug!("in sum2 phase for a minimum of {} seconds", min_time);
-        self.process_during(Duration::from_secs(min_time)).await;
+        self.process_during(Duration::from_secs(min_time)).await?;
 
         while !self.has_enough_sum2s() {
             debug!(

--- a/rust/src/state_machine/phases/sum2.rs
+++ b/rust/src/state_machine/phases/sum2.rs
@@ -12,8 +12,7 @@ use crate::{
     SumParticipantPublicKey,
 };
 
-use tokio::sync::oneshot;
-use tokio::time::Duration;
+use tokio::{sync::oneshot, time::Duration};
 
 /// Sum2 state
 #[derive(Debug)]
@@ -96,19 +95,24 @@ where
     /// Runs the sum2 phase.
     async fn run_phase(&mut self) -> Result<(), StateError> {
         let min_time = self.coordinator_state.min_sum_time;
+        debug!("in sum2 phase for a minimum of {} seconds", min_time);
         self.process_during(Duration::from_secs(min_time)).await;
 
         while !self.has_enough_sum2s() {
-            debug!("{} sum2 messages handled (min {} required)",
-                  self.mask_count(),
-                  self.coordinator_state.min_sum_count);
+            debug!(
+                "{} sum2 messages handled (min {} required)",
+                self.mask_count(),
+                self.coordinator_state.min_sum_count
+            );
             let req = self.next_request().await?;
             self.handle_request(req);
         }
 
-        info!("{} sum2 messages handled (min {} required)",
-              self.mask_count(),
-              self.coordinator_state.min_sum_count);
+        info!(
+            "{} sum2 messages handled (min {} required)",
+            self.mask_count(),
+            self.coordinator_state.min_sum_count
+        );
         Ok(())
     }
 }

--- a/rust/src/state_machine/phases/update.rs
+++ b/rust/src/state_machine/phases/update.rs
@@ -137,7 +137,7 @@ where
 
         let min_time = self.coordinator_state.min_update_time;
         debug!("in update phase for a minimum of {} seconds", min_time);
-        self.process_during(Duration::from_secs(min_time)).await;
+        self.process_during(Duration::from_secs(min_time)).await?;
 
         while !self.has_enough_updates() {
             debug!(

--- a/rust/src/state_machine/phases/update.rs
+++ b/rust/src/state_machine/phases/update.rs
@@ -136,20 +136,20 @@ where
             ScalarUpdate::New(scalar),
         );
 
-        let min_t = self.coordinator_state.min_update_t;
-        self.process_during(Duration::from_secs(min_t)).await;
+        let min_time = self.coordinator_state.min_update_time;
+        self.process_during(Duration::from_secs(min_time)).await;
 
         while !self.has_enough_updates() {
             debug!("{} update messages handled (min {} required)",
                   self.updater_count(),
-                  self.coordinator_state.min_update);
+                  self.coordinator_state.min_update_count);
             let req = self.next_request().await?;
             self.handle_request(req);
         };
 
         info!("{} update messages handled (min {} required)",
               self.updater_count(),
-              self.coordinator_state.min_update);
+              self.coordinator_state.min_update_count);
         Ok(())
     }
 }
@@ -271,7 +271,7 @@ impl<R> PhaseState<R, Update> {
     }
 
     fn has_enough_updates(&self) -> bool {
-        self.updater_count() >= self.coordinator_state.min_update
+        self.updater_count() >= self.coordinator_state.min_update_count
     }
 }
 

--- a/rust/src/state_machine/phases/update.rs
+++ b/rust/src/state_machine/phases/update.rs
@@ -16,8 +16,7 @@ use crate::{
     UpdateParticipantPublicKey,
 };
 
-use tokio::sync::oneshot;
-use tokio::time::Duration;
+use tokio::{sync::oneshot, time::Duration};
 
 /// Update state
 #[derive(Debug)]
@@ -137,19 +136,24 @@ where
         );
 
         let min_time = self.coordinator_state.min_update_time;
+        debug!("in update phase for a minimum of {} seconds", min_time);
         self.process_during(Duration::from_secs(min_time)).await;
 
         while !self.has_enough_updates() {
-            debug!("{} update messages handled (min {} required)",
-                  self.updater_count(),
-                  self.coordinator_state.min_update_count);
+            debug!(
+                "{} update messages handled (min {} required)",
+                self.updater_count(),
+                self.coordinator_state.min_update_count
+            );
             let req = self.next_request().await?;
             self.handle_request(req);
-        };
+        }
 
-        info!("{} update messages handled (min {} required)",
-              self.updater_count(),
-              self.coordinator_state.min_update_count);
+        info!(
+            "{} update messages handled (min {} required)",
+            self.updater_count(),
+            self.coordinator_state.min_update_count
+        );
         Ok(())
     }
 }

--- a/rust/src/state_machine/tests/builder.rs
+++ b/rust/src/state_machine/tests/builder.rs
@@ -24,9 +24,10 @@ impl StateMachineBuilder<phases::Idle> {
         let pet_settings = PetSettings {
             sum: 0.4,
             update: 0.5,
-            min_sum: 1,
-            min_update: 3,
+            min_sum_count: 1,
+            min_update_count: 3,
             expected_participants: 10,
+            ..Default::default()
         };
         let mask_settings = utils::mask_settings();
         let (coordinator_state, event_subscriber) =
@@ -109,7 +110,7 @@ where
     }
 
     pub fn with_min_sum(mut self, min_sum: usize) -> Self {
-        self.coordinator_state.min_sum = min_sum;
+        self.coordinator_state.min_sum_count = min_sum;
         self
     }
 
@@ -119,7 +120,7 @@ where
     }
 
     pub fn with_min_update(mut self, min_update: usize) -> Self {
-        self.coordinator_state.min_update = min_update;
+        self.coordinator_state.min_update_count = min_update;
         self
     }
 


### PR DESCRIPTION
The coordinator state machine currently transitions through the phases `sum` -> `update` -> `sum2` too "eagerly". It is due to the combination of
- a phase transition occurs *as soon as* "enough" messages have been processed e.g. for the `sum` phase, this is `min_sum`.
- the thresholds default (and typically are set) to the theoretical minimum e.g. for `min_sum` this is `1`.

As a result, the `sum` phase always ends with just `1` message processed, even when *many* participants have been selected to sum. The situation is similar with the `update` and `sum2` phases. Ideally, as many as possible should be able to participate, to follow the specification of the PET protocol.

This merge request introduces 2 new settings to the coordinator, to complement the existing `min_sum` and `min_update`:
- `min_sum_time`
- `min_update_time`

documented in `settings.rs` as follows:

```rust
 /// The minimum amount of time reserved for processing messages in the `sum`
 /// and `sum2` phases, in seconds.
 ///
 /// Defaults to 0 i.e. `sum` and `sum2` phases end *as soon as*
 /// [`min_sum_count`] messages have been processed. Set this higher to allow
 /// for the possibility of more than [`min_sum_count`] messages to be
 /// processed in the `sum` and `sum2` phases.
 ///
 /// # Examples
 ///
 /// **TOML**
 /// ```text
 /// [pet]
 /// min_sum_time = 5
 /// ```
 ///
 /// **Environment variable**
 /// ```text
 /// XAYNET_PET__MIN_SUM_TIME=5
 /// ```
 pub min_sum_time: u64,

 /// The minimum amount of time reserved for processing messages in the
 /// `update` phase, in seconds.
 ///
 /// Defaults to 0 i.e. `update` phase ends *as soon as* [`min_update_count`]
 /// messages have been processed. Set this higher to allow for the
 /// possibility of more than [`min_update_count`] messages to be processed
 /// in the `update` phase.
 ///
 /// # Examples
 ///
 /// **TOML**
 /// ```text
 /// [pet]
 /// min_update_time = 10
 /// ```
 ///
 /// **Environment variable**
 /// ```text
 /// XAYNET_PET__MIN_UPDATE_TIME=10
 /// ```
 pub min_update_time: u64,
```