### PR TITLE
refactor the state machine full round test

### DIFF
--- a/rust/src/state_machine/tests/mod.rs
+++ b/rust/src/state_machine/tests/mod.rs
@@ -2,52 +2,99 @@ pub mod builder;
 pub mod impls;
 pub mod utils;
 
-use crate::state_machine::tests::{
-    builder::StateMachineBuilder,
-    utils::{enable_logging, gen_sum2_request, gen_sum_request, gen_update_request},
+use crate::{
+    crypto::{ByteObject, EncryptKeyPair},
+    mask::{FromPrimitives, Model},
+    state_machine::{
+        coordinator::RoundSeed,
+        tests::{
+            builder::StateMachineBuilder,
+            utils::{enable_logging, generate_summer, generate_updater},
+        },
+    },
 };
 
 #[tokio::test]
 async fn full_round() {
     enable_logging();
+    let n_updaters = 3;
+    let n_summers = 2;
+    let seed = RoundSeed::generate();
+    let sum_ratio = 0.5;
+    let update_ratio = 1.0;
+    let coord_keys = EncryptKeyPair::generate();
+    let coord_pk = &coord_keys.public;
 
-    let (mut state_machine, request_tx, _events_subscriber) = StateMachineBuilder::new().build();
+    let (state_machine, mut requests, events) = StateMachineBuilder::new()
+        .with_seed(seed.clone())
+        .with_sum_ratio(sum_ratio)
+        .with_update_ratio(update_ratio)
+        .with_min_sum(n_summers)
+        .with_min_update(n_updaters)
+        .with_expected_participants(n_updaters + n_summers)
+        .build();
+
     assert!(state_machine.is_idle());
 
-    state_machine = state_machine.next().await.unwrap(); // transition from init to sum state
+    // Idle phase
+    let state_machine = state_machine.next().await.unwrap();
     assert!(state_machine.is_sum());
 
-    let (sum_req, sum_pk, response_rx) = gen_sum_request();
-    let _ = request_tx.send(sum_req);
-
-    state_machine = state_machine.next().await.unwrap(); // transition from sum to update state
+    // Sum phase
+    let mut summer_1 = generate_summer(&seed, sum_ratio, update_ratio);
+    let mut summer_2 = generate_summer(&seed, sum_ratio, update_ratio);
+    let msg_1 = summer_1.compose_sum_message(coord_pk);
+    let msg_2 = summer_2.compose_sum_message(coord_pk);
+    let req_1 = async { requests.clone().sum(&msg_1).await.unwrap() };
+    let req_2 = async { requests.clone().sum(&msg_2).await.unwrap() };
+    let transition = async { state_machine.next().await.unwrap() };
+    let ((), (), state_machine) = tokio::join!(req_1, req_2, transition);
     assert!(state_machine.is_update());
-    assert!(response_rx.await.is_ok());
 
+    // Update phase
+    let transition_task = tokio::spawn(async { state_machine.next().await.unwrap() });
+    let sum_dict = events.sum_dict_listener().get_latest().event.unwrap();
+    let scalar = 1.0 / (n_updaters as f64 * update_ratio);
+    let model = Model::from_primitives(vec![0; 4].into_iter()).unwrap();
     for _ in 0..3 {
-        let (req, _) = gen_update_request(sum_pk.clone());
-        let _ = request_tx.send(req);
+        let updater = generate_updater(&seed, sum_ratio, update_ratio);
+        let msg = updater.compose_update_message(*coord_pk, &sum_dict, scalar, model.clone());
+        requests.update(&msg).await.unwrap();
     }
-    state_machine = state_machine.next().await.unwrap(); // transition from update to sum state
+    let state_machine = transition_task.await.unwrap();
     assert!(state_machine.is_sum2());
 
-    let (req, response_rx) = gen_sum2_request(sum_pk.clone());
-    let _ = request_tx.send(req);
-    state_machine = state_machine.next().await.unwrap(); // transition from sum2 to unmasked state
-    assert!(response_rx.await.is_ok());
+    // Sum2 phase
+    let seed_dict = events.seed_dict_listener().get_latest().event.unwrap();
+    let mask_length = events.mask_length_listener().get_latest().event.unwrap();
+    let msg_1 = summer_1
+        .compose_sum2_message(*coord_pk, seed_dict.get(&summer_1.pk).unwrap(), mask_length)
+        .unwrap();
+    let msg_2 = summer_2
+        .compose_sum2_message(*coord_pk, seed_dict.get(&summer_2.pk).unwrap(), mask_length)
+        .unwrap();
+    let req_1 = async { requests.clone().sum2(&msg_1).await.unwrap() };
+    let req_2 = async { requests.clone().sum2(&msg_2).await.unwrap() };
+    let transition = async { state_machine.next().await.unwrap() };
+    let ((), (), state_machine) = tokio::join!(req_1, req_2, transition);
     assert!(state_machine.is_unmask());
 
-    state_machine = state_machine.next().await.unwrap(); // transition from unmasked to idle state
+    // Unmask phase
+    let state_machine = state_machine.next().await.unwrap();
     assert!(state_machine.is_idle());
 
-    drop(request_tx);
-    state_machine = state_machine.next().await.unwrap(); // transition from idle to sum state
+    // Go back to the sum phase
+    let state_machine = state_machine.next().await.unwrap();
     assert!(state_machine.is_sum());
 
-    state_machine = state_machine.next().await.unwrap(); // transition from sum to error state
+    // dropping the resquest sender should make the state machine
+    // error out
+    drop(requests);
+    let state_machine = state_machine.next().await.unwrap();
     assert!(state_machine.is_error());
 
-    state_machine = state_machine.next().await.unwrap(); // transition from error to shutdown state
+    // then the state machine should enter the shutdown state
+    let state_machine = state_machine.next().await.unwrap();
     assert!(state_machine.is_shutdown());
     assert!(state_machine.next().await.is_none())
 }

--- a/rust/src/state_machine/tests/utils.rs
+++ b/rust/src/state_machine/tests/utils.rs
@@ -1,22 +1,11 @@
 use crate::{
     client::{Participant, Task},
-    crypto::{encrypt::EncryptKeyPair, sign::SigningKeyPair, ByteObject},
-    mask::{
-        config::{BoundType, DataType, GroupType, ModelType},
-        object::MaskObject,
-        seed::{EncryptedMaskSeed, MaskSeed},
-    },
+    crypto::ByteObject,
+    mask::config::{BoundType, DataType, GroupType, ModelType},
     settings::MaskSettings,
-    state_machine::{
-        coordinator::RoundSeed,
-        requests::{Request, Sum2Request, SumRequest, UpdateRequest},
-    },
-    LocalSeedDict,
-    PetError,
-    SumParticipantPublicKey,
+    state_machine::coordinator::RoundSeed,
 };
 
-use tokio::sync::oneshot;
 use tracing_subscriber::*;
 
 pub fn enable_logging() {
@@ -24,73 +13,6 @@ pub fn enable_logging() {
         .with_env_filter(EnvFilter::from_default_env())
         .with_ansi(true)
         .init();
-}
-
-pub fn gen_sum_request() -> (
-    Request,
-    SumParticipantPublicKey,
-    oneshot::Receiver<Result<(), PetError>>,
-) {
-    let (response_tx, response_rx) = oneshot::channel::<Result<(), PetError>>();
-    let SigningKeyPair {
-        public: participant_pk,
-        ..
-    } = SigningKeyPair::generate();
-    let EncryptKeyPair {
-        public: ephm_pk, ..
-    } = EncryptKeyPair::generate();
-    let req = Request::Sum((
-        SumRequest {
-            participant_pk,
-            ephm_pk,
-        },
-        response_tx,
-    ));
-    (req, participant_pk, response_rx)
-}
-
-pub fn gen_update_request(
-    sum_pk: SumParticipantPublicKey,
-) -> (Request, oneshot::Receiver<Result<(), PetError>>) {
-    let (response_tx, response_rx) = oneshot::channel::<Result<(), PetError>>();
-    let SigningKeyPair {
-        public: participant_pk,
-        ..
-    } = SigningKeyPair::generate();
-    let mut local_seed_dict = LocalSeedDict::new();
-    local_seed_dict.insert(sum_pk, EncryptedMaskSeed::zeroed());
-    let masked_model = gen_mask();
-    let req = Request::Update((
-        UpdateRequest {
-            participant_pk,
-            local_seed_dict,
-            masked_model,
-        },
-        response_tx,
-    ));
-
-    (req, response_rx)
-}
-
-pub fn gen_mask() -> MaskObject {
-    let seed = MaskSeed::generate();
-    let mask = seed.derive_mask(10, mask_settings().into());
-    mask
-}
-
-pub fn gen_sum2_request(
-    sum_pk: SumParticipantPublicKey,
-) -> (Request, oneshot::Receiver<Result<(), PetError>>) {
-    let (response_tx, response_rx) = oneshot::channel::<Result<(), PetError>>();
-    let mask = gen_mask();
-    let req = Request::Sum2((
-        Sum2Request {
-            participant_pk: sum_pk,
-            mask,
-        },
-        response_tx,
-    ));
-    (req, response_rx)
 }
 
 pub fn generate_summer(seed: &RoundSeed, sum_ratio: f64, update_ratio: f64) -> Participant {


### PR DESCRIPTION
this makes the test more consistent with the unit tests we have for
the phases, and allows us to clean up the utils module of the various
`gen_xxx()` helpers.