### PR TITLE
purge pending requests at the end of each phase

### DIFF
--- a/rust/src/services/messages/message_parser.rs
+++ b/rust/src/services/messages/message_parser.rs
@@ -19,7 +19,10 @@ use crate::{
         traits::{FromBytes, ToBytes},
         DecodeError,
     },
-    state_machine::events::{EventListener, EventSubscriber, PhaseEvent},
+    state_machine::{
+        events::{EventListener, EventSubscriber},
+        phases::PhaseName,
+    },
     utils::trace::{Traceable, Traced},
     Signature,
 };
@@ -39,7 +42,7 @@ pub struct MessageParserService {
     /// that cannot be handled in the current phase will be
     /// rejected. The idea is to perform this filtering as early as
     /// possible.
-    phase_events: EventListener<PhaseEvent>,
+    phase_events: EventListener<PhaseName>,
 
     /// Thread-pool the CPU-intensive tasks are offloaded to
     thread_pool: Arc<ThreadPool>,
@@ -147,7 +150,7 @@ struct Handler {
     /// Coordinator keys for the current round
     keys: EncryptKeyPair,
     /// Current phase of the coordinator
-    phase: PhaseEvent,
+    phase: PhaseName,
 }
 
 impl Handler {
@@ -192,9 +195,9 @@ impl Handler {
     /// the current phase
     fn phase_filter(&self, tag: Tag) -> Result<(), MessageParserError> {
         match (tag, self.phase) {
-            (Tag::Sum, PhaseEvent::Sum)
-            | (Tag::Update, PhaseEvent::Update)
-            | (Tag::Sum2, PhaseEvent::Sum2) => Ok(()),
+            (Tag::Sum, PhaseName::Sum)
+            | (Tag::Update, PhaseName::Update)
+            | (Tag::Sum2, PhaseName::Sum2) => Ok(()),
             (tag, phase) => {
                 warn!(
                     "rejecting request: message type is {:?} but phase is {:?}",

--- a/rust/src/services/tests/messages/message_parser.rs
+++ b/rust/src/services/tests/messages/message_parser.rs
@@ -17,7 +17,8 @@ use crate::{
     },
     state_machine::{
         coordinator::RoundParameters,
-        events::{EventPublisher, EventSubscriber, PhaseEvent},
+        events::{EventPublisher, EventSubscriber},
+        phases::PhaseName,
     },
     utils::trace::Traced,
 };
@@ -67,7 +68,7 @@ async fn test_valid_request() {
 
     // Simulate the state machine broadcasting the sum phase
     // (otherwise the request will be rejected)
-    publisher.broadcast_phase(round_params.seed.clone(), PhaseEvent::Sum);
+    publisher.broadcast_phase(round_params.seed.clone(), PhaseName::Sum);
 
     // Call the service
     let resp = task.call(req).await.unwrap().unwrap();

--- a/rust/src/services/tests/messages/pre_processor.rs
+++ b/rust/src/services/tests/messages/pre_processor.rs
@@ -7,7 +7,10 @@ use crate::{
         messages::{PreProcessorError, PreProcessorRequest, PreProcessorService},
         tests::utils,
     },
-    state_machine::events::{EventPublisher, EventSubscriber, PhaseEvent},
+    state_machine::{
+        events::{EventPublisher, EventSubscriber},
+        phases::PhaseName,
+    },
     utils::trace::Traced,
 };
 
@@ -32,7 +35,7 @@ async fn test_sum_ok() {
 
     let round_id = round_params.seed.clone();
     publisher.broadcast_params(round_params.clone());
-    publisher.broadcast_phase(round_id, PhaseEvent::Sum);
+    publisher.broadcast_phase(round_id, PhaseName::Sum);
 
     let (message, _, _) = utils::new_sum_message(&round_params);
     let req = make_req(message.clone());
@@ -53,7 +56,7 @@ async fn test_sum_not_eligible() {
 
     let round_id = round_params.seed.clone();
     publisher.broadcast_params(round_params.clone());
-    publisher.broadcast_phase(round_id, PhaseEvent::Sum);
+    publisher.broadcast_phase(round_id, PhaseName::Sum);
 
     let (message, _, _) = utils::new_sum_message(&round_params);
     let req = make_req(message.clone());
@@ -83,7 +86,7 @@ async fn test_phase_change_between_poll_ready_and_call() {
     let (message, _, _) = utils::new_sum_message(&round_params);
     let req = make_req(message.clone());
 
-    publisher.broadcast_phase(round_params.seed.clone(), PhaseEvent::Sum);
+    publisher.broadcast_phase(round_params.seed.clone(), PhaseName::Sum);
 
     let err = task.call(req).await.unwrap().unwrap_err();
     match err {

--- a/rust/src/services/tests/utils.rs
+++ b/rust/src/services/tests/utils.rs
@@ -3,7 +3,8 @@ use crate::{
     message::{MessageOwned, MessageSeal, SumOwned},
     state_machine::{
         coordinator::{RoundParameters, RoundSeed},
-        events::{EventPublisher, EventSubscriber, PhaseEvent},
+        events::{EventPublisher, EventSubscriber},
+        phases::PhaseName,
     },
     SumParticipantEphemeralPublicKey,
 };
@@ -19,7 +20,7 @@ pub fn new_event_channels() -> (EventPublisher, EventSubscriber) {
         update: 0.0,
         seed: RoundSeed::generate(),
     };
-    let phase = PhaseEvent::Idle;
+    let phase = PhaseName::Idle;
     EventPublisher::init(keys, params, phase)
 }
 

--- a/rust/src/state_machine/coordinator.rs
+++ b/rust/src/state_machine/coordinator.rs
@@ -7,7 +7,10 @@ use crate::{
     crypto::{encrypt::EncryptKeyPair, ByteObject},
     mask::{config::MaskConfig, object::MaskObject},
     settings::{MaskSettings, ModelSettings, PetSettings},
-    state_machine::events::{EventPublisher, EventSubscriber, PhaseEvent},
+    state_machine::{
+        events::{EventPublisher, EventSubscriber},
+        phases::PhaseName,
+    },
     CoordinatorPublicKey,
 };
 
@@ -62,7 +65,7 @@ impl CoordinatorState {
             update: pet_settings.update,
             seed: RoundSeed::zeroed(),
         };
-        let phase = PhaseEvent::Idle;
+        let phase = PhaseName::Idle;
 
         let (publisher, subscriber) =
             EventPublisher::init(keys.clone(), round_params.clone(), phase);

--- a/rust/src/state_machine/phases/error.rs
+++ b/rust/src/state_machine/phases/error.rs
@@ -1,7 +1,6 @@
 use crate::state_machine::{
     coordinator::CoordinatorState,
-    events::PhaseEvent,
-    phases::{Idle, Phase, PhaseState, Shutdown},
+    phases::{Idle, Phase, PhaseName, PhaseState, Shutdown},
     requests::RequestReceiver,
     RoundFailed,
     StateMachine,
@@ -38,9 +37,7 @@ impl<R> Phase<R> for PhaseState<R, StateError>
 where
     R: Send,
 {
-    fn is_error(&self) -> bool {
-        true
-    }
+    const NAME: PhaseName = PhaseName::Error;
 
     async fn run(&mut self) -> Result<(), StateError> {
         error!("state transition failed! error: {:?}", self.inner);
@@ -48,7 +45,7 @@ where
         info!("broadcasting error phase event");
         self.coordinator_state.events.broadcast_phase(
             self.coordinator_state.round_params.seed.clone(),
-            PhaseEvent::Error,
+            PhaseName::Error,
         );
 
         Ok(())

--- a/rust/src/state_machine/phases/mod.rs
+++ b/rust/src/state_machine/phases/mod.rs
@@ -35,13 +35,76 @@ use tokio::sync::oneshot;
 #[async_trait]
 pub trait Phase<R> {
     /// Moves from this state to the next state.
-    async fn next(mut self) -> Option<StateMachine<R>>;
+    fn next(self) -> Option<StateMachine<R>>;
+
+    /// Run this phase to completion
+    async fn run(&mut self) -> Result<(), StateError>;
+
+    /// Return `true` if this is the error phase
+    fn is_error(&self) -> bool {
+        false
+    }
+
+    /// Return `true` if this is the idle phase
+    fn is_idle(&self) -> bool {
+        false
+    }
+
+    /// Return `true` if this is the shutdown phase
+    fn is_shutdown(&self) -> bool {
+        false
+    }
+
+    /// Return `true` if this is the sum phase
+    fn is_sum(&self) -> bool {
+        false
+    }
+
+    /// Return `true` if this is the sum2 phase
+    fn is_sum2(&self) -> bool {
+        false
+    }
+
+    /// Return `true` if this is the update phase
+    fn is_update(&self) -> bool {
+        false
+    }
+
+    /// Return `true` if this is the unmask phase
+    fn is_unmask(&self) -> bool {
+        false
+    }
 }
 
 /// A trait that must be implemented by a state to handle a request.
 pub trait Handler<R> {
     /// Handles a request.
     fn handle_request(&mut self, req: R);
+}
+
+/// When the state machine transitions to a new phase, all the pending
+/// requests are considered outdated, and purged. The [`Purge`] trait
+/// implements this behavior.
+pub trait Purge<R> {
+    /// Process an outdated request.
+    fn handle_outdated_request(&mut self, req: R);
+}
+
+impl<R, S> Purge<Request> for PhaseState<R, S> {
+    fn handle_outdated_request(&mut self, req: Request) {
+        reject_request(req)
+    }
+}
+
+impl<R, S> Purge<Traced<Request>> for PhaseState<R, S>
+where
+    Self: Purge<Request>,
+{
+    fn handle_outdated_request(&mut self, req: Traced<Request>) {
+        let span = req.span().clone();
+        let _enter = span.enter();
+        <Self as Purge<Request>>::handle_outdated_request(self, req.into_inner())
+    }
 }
 
 impl<R, S> Handler<Traced<Request>> for PhaseState<R, S>
@@ -71,7 +134,7 @@ pub struct PhaseState<R, S> {
 
 impl<R, S> PhaseState<R, S>
 where
-    Self: Handler<R>,
+    Self: Handler<R> + Phase<R> + Purge<R>,
 {
     /// Processes requests for as long as the given duration.
     async fn process_during(&mut self, dur: tokio::time::Duration) -> Result<(), StateError> {
@@ -96,6 +159,41 @@ where
     }
 }
 
+impl<R, S> PhaseState<R, S>
+where
+    Self: Phase<R> + Purge<R>,
+{
+    /// Run the current phase to completion, then transition to the
+    /// next phase and return it.
+    pub async fn run_phase(mut self) -> Option<StateMachine<R>> {
+        if let Err(err) = self.run().await {
+            return Some(self.into_error_state(err));
+        }
+
+        if let Err(err) = self.purge_outdated_requests() {
+            // If we're already in the error state or shutdown state,
+            // ignore this error
+            if !self.is_error() && !self.is_shutdown() {
+                return Some(self.into_error_state(err));
+            }
+        }
+
+        self.next()
+    }
+
+    /// Process all the pending requests that are now considered
+    /// outdated. This happens at the end of each phase, before
+    /// transitioning to the next phase.
+    fn purge_outdated_requests(&mut self) -> Result<(), StateError> {
+        loop {
+            match self.try_next_request()? {
+                Some(req) => self.handle_outdated_request(req),
+                None => return Ok(()),
+            }
+        }
+    }
+}
+
 // Functions that are available to all states
 impl<R, S> PhaseState<R, S> {
     /// Receives the next [`Request`].
@@ -110,12 +208,42 @@ impl<R, S> PhaseState<R, S> {
         })
     }
 
-    /// Handles an invalid request by sending [`PetError::InvalidMessage`] to the request sender.
-    fn handle_invalid_message(response_tx: oneshot::Sender<Result<(), PetError>>) {
-        debug!("invalid message");
-        // `send` returns an error if the receiver half has already been dropped. This means that
-        // the receiver is not interested in the response of the request. Therefore the error is
-        // ignored.
-        let _ = response_tx.send(Err(PetError::InvalidMessage));
+    fn try_next_request(&mut self) -> Result<Option<R>, StateError> {
+        match self.request_rx.try_recv() {
+            Ok(req) => Ok(Some(req)),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {
+                debug!("no pending request");
+                Ok(None)
+            }
+            Err(tokio::sync::mpsc::error::TryRecvError::Closed) => {
+                warn!("failed to get next pending request: channel shut down");
+                Err(StateError::ChannelError(
+                    "all message senders have been dropped!",
+                ))
+            }
+        }
     }
+
+    fn into_error_state(self, err: StateError) -> StateMachine<R> {
+        PhaseState::<R, StateError>::new(self.coordinator_state, self.request_rx, err).into()
+    }
+}
+
+/// Respond to the given request with a rejection error.
+pub fn reject_request(req: Request) {
+    match req {
+        Request::Sum((_, response_tx)) => send_rejection(response_tx),
+        Request::Update((_, response_tx)) => send_rejection(response_tx),
+        Request::Sum2((_, response_tx)) => send_rejection(response_tx),
+    }
+}
+
+/// Send a rejection through the given channel
+fn send_rejection(response_tx: oneshot::Sender<Result<(), PetError>>) {
+    debug!("invalid message");
+    // `send` returns an error if the receiver half has already
+    // been dropped. This means that the receiver is not
+    // interested in the response of the request. Therefore the
+    // error is ignored.
+    let _ = response_tx.send(Err(PetError::InvalidMessage));
 }

--- a/rust/src/state_machine/phases/shutdown.rs
+++ b/rust/src/state_machine/phases/shutdown.rs
@@ -1,7 +1,6 @@
 use crate::state_machine::{
     coordinator::CoordinatorState,
-    events::PhaseEvent,
-    phases::{Phase, PhaseState},
+    phases::{Phase, PhaseName, PhaseState},
     requests::RequestReceiver,
     StateError,
     StateMachine,
@@ -16,9 +15,7 @@ impl<R> Phase<R> for PhaseState<R, Shutdown>
 where
     R: Send,
 {
-    fn is_shutdown(&self) -> bool {
-        true
-    }
+    const NAME: PhaseName = PhaseName::Shutdown;
 
     /// Shuts down the [`StateMachine`].
     ///
@@ -29,7 +26,7 @@ where
         info!("broadcasting shutdown phase event");
         self.coordinator_state.events.broadcast_phase(
             self.coordinator_state.round_params.seed.clone(),
-            PhaseEvent::Shutdown,
+            PhaseName::Shutdown,
         );
 
         // clear the request channel

--- a/rust/src/state_machine/phases/sum.rs
+++ b/rust/src/state_machine/phases/sum.rs
@@ -3,8 +3,17 @@ use std::sync::Arc;
 use crate::{
     state_machine::{
         coordinator::CoordinatorState,
-        events::{DictionaryUpdate, PhaseEvent},
-        phases::{reject_request, Handler, Phase, PhaseState, Purge, StateError, Update},
+        events::DictionaryUpdate,
+        phases::{
+            reject_request,
+            Handler,
+            Phase,
+            PhaseName,
+            PhaseState,
+            Purge,
+            StateError,
+            Update,
+        },
         requests::{Request, RequestReceiver, SumRequest, SumResponse},
         StateMachine,
     },
@@ -52,9 +61,7 @@ where
     Self: Handler<R> + Purge<R>,
     R: Send,
 {
-    fn is_sum(&self) -> bool {
-        true
-    }
+    const NAME: PhaseName = PhaseName::Sum;
 
     /// Run the sum phase.
     ///
@@ -65,7 +72,7 @@ where
         info!("broadcasting sum phase event");
         self.coordinator_state.events.broadcast_phase(
             self.coordinator_state.round_params.seed.clone(),
-            PhaseEvent::Sum,
+            PhaseName::Sum,
         );
 
         let min_time = self.coordinator_state.min_sum_time;
@@ -238,7 +245,7 @@ mod test {
             events.phase_listener().get_latest(),
             Event {
                 round_id: seed.clone(),
-                event: PhaseEvent::Sum,
+                event: PhaseName::Sum,
             }
         );
     }

--- a/rust/src/state_machine/phases/sum2.rs
+++ b/rust/src/state_machine/phases/sum2.rs
@@ -2,8 +2,16 @@ use crate::{
     mask::{masking::Aggregation, object::MaskObject},
     state_machine::{
         coordinator::{CoordinatorState, MaskDict},
-        events::PhaseEvent,
-        phases::{reject_request, Handler, Phase, PhaseState, Purge, StateError, Unmask},
+        phases::{
+            reject_request,
+            Handler,
+            Phase,
+            PhaseName,
+            PhaseState,
+            Purge,
+            StateError,
+            Unmask,
+        },
         requests::{Request, RequestReceiver, Sum2Request, Sum2Response},
         StateMachine,
     },
@@ -32,9 +40,11 @@ impl Sum2 {
     pub fn sum_dict(&self) -> &SumDict {
         &self.sum_dict
     }
+
     pub fn aggregation(&self) -> &Aggregation {
         &self.aggregation
     }
+
     pub fn mask_dict(&self) -> &MaskDict {
         &self.mask_dict
     }
@@ -46,9 +56,7 @@ where
     Self: Purge<R> + Handler<R>,
     R: Send,
 {
-    fn is_sum2(&self) -> bool {
-        true
-    }
+    const NAME: PhaseName = PhaseName::Sum2;
 
     /// Run the sum2 phase
     ///
@@ -58,7 +66,7 @@ where
         info!("broadcasting sum2 phase event");
         self.coordinator_state.events.broadcast_phase(
             self.coordinator_state.round_params.seed.clone(),
-            PhaseEvent::Sum2,
+            PhaseName::Sum2,
         );
 
         let min_time = self.coordinator_state.min_sum_time;
@@ -271,7 +279,7 @@ mod test {
             events.phase_listener().get_latest(),
             Event {
                 round_id: seed.clone(),
-                event: PhaseEvent::Sum2,
+                event: PhaseName::Sum2,
             }
         );
     }

--- a/rust/src/state_machine/phases/unmask.rs
+++ b/rust/src/state_machine/phases/unmask.rs
@@ -37,10 +37,12 @@ impl<R> Phase<R> for PhaseState<R, Unmask>
 where
     R: Send,
 {
-    /// Moves from the unmask state to the next state.
-    ///
-    /// See the [module level documentation](../index.html) for more details.
-    async fn next(mut self) -> Option<StateMachine<R>> {
+    fn is_unmask(&self) -> bool {
+        true
+    }
+
+    /// Run the unmasking phase
+    async fn run(&mut self) -> Result<(), StateError> {
         info!("starting unmasking phase");
 
         info!("broadcasting unmasking phase event");
@@ -49,18 +51,23 @@ where
             PhaseEvent::Unmask,
         );
 
-        let next_state = match self.run_phase().await {
-            Ok(_) => {
-                info!("unmasking phased completed successfully, going back to idle phase");
-                PhaseState::<R, Idle>::new(self.coordinator_state, self.request_rx).into()
-            }
-            Err(err) => {
-                error!("unmasking phase failed: {}", err);
-                PhaseState::<R, StateError>::new(self.coordinator_state, self.request_rx, err)
-                    .into()
-            }
-        };
-        Some(next_state)
+        let global_model = self.end_round()?;
+
+        info!("broadcasting the new global model");
+        self.coordinator_state.events.broadcast_model(
+            self.coordinator_state.round_params.seed.clone(),
+            ModelUpdate::New(Arc::new(global_model)),
+        );
+
+        Ok(())
+    }
+
+    /// Moves from the unmask state to the next state.
+    ///
+    /// See the [module level documentation](../index.html) for more details.
+    fn next(self) -> Option<StateMachine<R>> {
+        info!("going back to idle phase");
+        Some(PhaseState::<R, Idle>::new(self.coordinator_state, self.request_rx).into())
     }
 }
 
@@ -81,18 +88,6 @@ impl<R> PhaseState<R, Unmask> {
             coordinator_state,
             request_rx,
         }
-    }
-
-    /// Runs the unmask phase.
-    async fn run_phase(&mut self) -> Result<(), StateError> {
-        let global_model = self.end_round()?;
-        info!("broadcasting the new global model");
-        self.coordinator_state.events.broadcast_model(
-            self.coordinator_state.round_params.seed.clone(),
-            ModelUpdate::New(Arc::new(global_model)),
-        );
-
-        Ok(())
     }
 
     /// Freezes the mask dictionary.

--- a/rust/src/state_machine/phases/unmask.rs
+++ b/rust/src/state_machine/phases/unmask.rs
@@ -4,8 +4,8 @@ use crate::{
     mask::{masking::Aggregation, model::Model, object::MaskObject},
     state_machine::{
         coordinator::{CoordinatorState, MaskDict},
-        events::{ModelUpdate, PhaseEvent},
-        phases::{Idle, Phase, PhaseState, StateError},
+        events::ModelUpdate,
+        phases::{Idle, Phase, PhaseName, PhaseState, StateError},
         requests::RequestReceiver,
         RoundFailed,
         StateMachine,
@@ -37,9 +37,7 @@ impl<R> Phase<R> for PhaseState<R, Unmask>
 where
     R: Send,
 {
-    fn is_unmask(&self) -> bool {
-        true
-    }
+    const NAME: PhaseName = PhaseName::Unmask;
 
     /// Run the unmasking phase
     async fn run(&mut self) -> Result<(), StateError> {
@@ -48,7 +46,7 @@ where
         info!("broadcasting unmasking phase event");
         self.coordinator_state.events.broadcast_phase(
             self.coordinator_state.round_params.seed.clone(),
-            PhaseEvent::Unmask,
+            PhaseName::Unmask,
         );
 
         let global_model = self.end_round()?;

--- a/rust/src/state_machine/phases/update.rs
+++ b/rust/src/state_machine/phases/update.rs
@@ -4,8 +4,8 @@ use crate::{
     mask::{masking::Aggregation, object::MaskObject},
     state_machine::{
         coordinator::CoordinatorState,
-        events::{DictionaryUpdate, MaskLengthUpdate, PhaseEvent, ScalarUpdate},
-        phases::{reject_request, Handler, Phase, PhaseState, Purge, StateError, Sum2},
+        events::{DictionaryUpdate, MaskLengthUpdate, ScalarUpdate},
+        phases::{reject_request, Handler, Phase, PhaseName, PhaseState, Purge, StateError, Sum2},
         requests::{Request, RequestReceiver, UpdateRequest, UpdateResponse},
         StateMachine,
     },
@@ -50,9 +50,7 @@ where
     Self: Handler<R> + Purge<R>,
     R: Send,
 {
-    fn is_update(&self) -> bool {
-        true
-    }
+    const NAME: PhaseName = PhaseName::Update;
 
     /// Moves from the update state to the next state.
     ///
@@ -63,7 +61,7 @@ where
         info!("broadcasting update phase event");
         self.coordinator_state.events.broadcast_phase(
             self.coordinator_state.round_params.seed.clone(),
-            PhaseEvent::Update,
+            PhaseName::Update,
         );
 
         let scalar = 1_f64
@@ -371,7 +369,7 @@ mod test {
             events.phase_listener().get_latest(),
             Event {
                 round_id: seed.clone(),
-                event: PhaseEvent::Update,
+                event: PhaseName::Update,
             }
         );
         assert_eq!(

--- a/rust/src/state_machine/phases/update.rs
+++ b/rust/src/state_machine/phases/update.rs
@@ -5,7 +5,7 @@ use crate::{
     state_machine::{
         coordinator::CoordinatorState,
         events::{DictionaryUpdate, MaskLengthUpdate, PhaseEvent, ScalarUpdate},
-        phases::{Handler, Phase, PhaseState, StateError, Sum2},
+        phases::{reject_request, Handler, Phase, PhaseState, Purge, StateError, Sum2},
         requests::{Request, RequestReceiver, UpdateRequest, UpdateResponse},
         StateMachine,
     },
@@ -47,13 +47,17 @@ impl Update {
 #[async_trait]
 impl<R> Phase<R> for PhaseState<R, Update>
 where
-    Self: Handler<R>,
+    Self: Handler<R> + Purge<R>,
     R: Send,
 {
+    fn is_update(&self) -> bool {
+        true
+    }
+
     /// Moves from the update state to the next state.
     ///
     /// See the [module level documentation](../index.html) for more details.
-    async fn next(mut self) -> Option<StateMachine<R>> {
+    async fn run(&mut self) -> Result<(), StateError> {
         info!("starting update phase");
 
         info!("broadcasting update phase event");
@@ -62,70 +66,6 @@ where
             PhaseEvent::Update,
         );
 
-        let next_state = match self.run_phase().await {
-            Ok(_) => {
-                let PhaseState {
-                    inner:
-                        Update {
-                            frozen_sum_dict,
-                            seed_dict,
-                            aggregation,
-                        },
-                    mut coordinator_state,
-                    request_rx,
-                } = self;
-
-                info!("broadcasting mask length");
-                coordinator_state.events.broadcast_mask_length(
-                    coordinator_state.round_params.seed.clone(),
-                    MaskLengthUpdate::New(aggregation.len()),
-                );
-
-                info!("broadcasting the global seed dictionary");
-                coordinator_state.events.broadcast_seed_dict(
-                    coordinator_state.round_params.seed.clone(),
-                    DictionaryUpdate::New(Arc::new(seed_dict)),
-                );
-
-                PhaseState::<R, Sum2>::new(
-                    coordinator_state,
-                    request_rx,
-                    frozen_sum_dict,
-                    aggregation,
-                )
-                .into()
-            }
-            Err(err) => {
-                PhaseState::<R, StateError>::new(self.coordinator_state, self.request_rx, err)
-                    .into()
-            }
-        };
-        Some(next_state)
-    }
-}
-
-impl<R> Handler<Request> for PhaseState<R, Update> {
-    /// Handles a [`Request::Sum`], [`Request::Update`] or [`Request::Sum2`] request.
-    ///
-    /// If the request is a [`Request::Sum`] or [`Request::Sum2`] request, the request sender
-    /// will receive a [`PetError::InvalidMessage`].
-    fn handle_request(&mut self, req: Request) {
-        match req {
-            Request::Update((update_req, response_tx)) => {
-                self.handle_update(update_req, response_tx)
-            }
-            Request::Sum((_, response_tx)) => Self::handle_invalid_message(response_tx),
-            Request::Sum2((_, response_tx)) => Self::handle_invalid_message(response_tx),
-        }
-    }
-}
-
-impl<R> PhaseState<R, Update>
-where
-    Self: Handler<R>,
-{
-    /// Runs the update phase.
-    async fn run_phase(&mut self) -> Result<(), StateError> {
         let scalar = 1_f64
             / (self.coordinator_state.expected_participants as f64
                 * self.coordinator_state.round_params.update);
@@ -155,6 +95,51 @@ where
             self.coordinator_state.min_update_count
         );
         Ok(())
+    }
+
+    fn next(self) -> Option<StateMachine<R>> {
+        let PhaseState {
+            inner:
+                Update {
+                    frozen_sum_dict,
+                    seed_dict,
+                    aggregation,
+                },
+            mut coordinator_state,
+            request_rx,
+        } = self;
+
+        info!("broadcasting mask length");
+        coordinator_state.events.broadcast_mask_length(
+            coordinator_state.round_params.seed.clone(),
+            MaskLengthUpdate::New(aggregation.len()),
+        );
+
+        info!("broadcasting the global seed dictionary");
+        coordinator_state.events.broadcast_seed_dict(
+            coordinator_state.round_params.seed.clone(),
+            DictionaryUpdate::New(Arc::new(seed_dict)),
+        );
+
+        Some(
+            PhaseState::<R, Sum2>::new(coordinator_state, request_rx, frozen_sum_dict, aggregation)
+                .into(),
+        )
+    }
+}
+
+impl<R> Handler<Request> for PhaseState<R, Update> {
+    /// Handles a [`Request::Sum`], [`Request::Update`] or [`Request::Sum2`] request.
+    ///
+    /// If the request is a [`Request::Sum`] or [`Request::Sum2`] request, the request sender
+    /// will receive a [`PetError::InvalidMessage`].
+    fn handle_request(&mut self, req: Request) {
+        match req {
+            Request::Update((update_req, response_tx)) => {
+                self.handle_update(update_req, response_tx)
+            }
+            _ => reject_request(req),
+        }
     }
 }
 
@@ -190,7 +175,7 @@ impl<R> PhaseState<R, Update> {
             masked_model,
         } = req;
 
-        // See `Self::handle_invalid_message`
+        // See `handle_invalid_message`
         let _ = response_tx.send(self.update_seed_dict_and_aggregate_mask(
             &participant_pk,
             &local_seed_dict,

--- a/rust/src/state_machine/requests.rs
+++ b/rust/src/state_machine/requests.rs
@@ -136,6 +136,14 @@ impl<R> RequestReceiver<R> {
     pub async fn recv(&mut self) -> Option<R> {
         self.0.recv().await
     }
+
+    /// Try to retrieve the next request without blocked
+    /// See [the `tokio` documentation][try_receive] for more information.
+    ///
+    /// [try_receive]: https://docs.rs/tokio/0.2.21/tokio/sync/mpsc/struct.UnboundedReceiver.html#method.try_recv
+    pub fn try_recv(&mut self) -> Result<R, tokio::sync::mpsc::error::TryRecvError> {
+        self.0.try_recv()
+    }
 }
 
 #[cfg(test)]

--- a/rust/src/state_machine/tests/mod.rs
+++ b/rust/src/state_machine/tests/mod.rs
@@ -85,10 +85,6 @@ async fn full_round() {
     let state_machine = state_machine.next().await.unwrap();
     assert!(state_machine.is_idle());
 
-    // Go back to the sum phase
-    let state_machine = state_machine.next().await.unwrap();
-    assert!(state_machine.is_sum());
-
     // dropping the resquest sender should make the state machine
     // error out
     drop(requests);

--- a/rust/src/state_machine/tests/mod.rs
+++ b/rust/src/state_machine/tests/mod.rs
@@ -85,7 +85,7 @@ async fn full_round() {
     let state_machine = state_machine.next().await.unwrap();
     assert!(state_machine.is_idle());
 
-    // dropping the resquest sender should make the state machine
+    // dropping the request sender should make the state machine
     // error out
     drop(requests);
     let state_machine = state_machine.next().await.unwrap();


### PR DESCRIPTION
Instead of adding the same code at the end of each phase, we leveraged
the existing `Phase` trait. The `Phase::next` method is now split in
two parts:

```rust
trait Phase<R> {
    async fn run(&mut self) -> Result<(), StateError>;
    fn next(self) -> Option<StateMachine<R>>;
}
```

The `run` method runs the phase, and the `next` method just consumes
the phase to produce the next one. By separating these two bits of
logic, we can inject code right after the phase ran to completion
and before the transtion is happens:

```rust
impl<R, S> PhaseState<R, S>
    where Self: Phase<R>
{
    pub async fn run_phase(mut self) -> Option<StateMachine<R>> {
           self.run().await.unwrap();
           do_custom_stuff_common_to_all_the_phases();
           self.next()
    }
}
```

In our case, `do_custom_stuff_common_to_all_the_phases()` consists in
purging the request channel. Again, this is implemented for all the
`PhaseState` via the new `Purge` trait, which is very similar to the
`Handler` trait:

```rust
pub trait Purge<R> {
    fn handle_outdated_request(&mut self, req: R);
}
```

Finally, because we needed to be able to know the current phase, we
added a bunch of `is_xxx()` methods to the `Phase` trait, that return
`true` if the state machine is in the specific phase.
