### PR TITLE
Exclude coordinator service in smoke test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -191,7 +191,7 @@ jobs:
 
       - name: Start docker-compose
         working-directory: ./docker
-        run: docker-compose up -d
+        run: docker-compose up -d influxdb minio redis
 
       - name: Run smoke tests
         working-directory: ./rust
@@ -201,4 +201,4 @@ jobs:
 
       - name: Stop docker-compose
         working-directory: ./docker
-        run: docker-compose stop
+        run: docker-compose down


### PR DESCRIPTION
Currently we build the coordinator twice in the smoke test job. The coordinator is build via docker-compose and via cargo test but we only want the latter. We use docker-compose only to run the dependencies.