### PR TITLE
automatically send the phase event before the phase starts

### DIFF
--- a/rust/src/services/tests/fetchers.rs
+++ b/rust/src/services/tests/fetchers.rs
@@ -42,13 +42,12 @@ async fn test_mask_length_svc() {
     let resp = task.call(MaskLengthRequest).await;
     assert_eq!(resp, Ok(None));
 
-    let round_id = subscriber.params_listener().get_latest().round_id;
-    publisher.broadcast_mask_length(round_id.clone(), MaskLengthUpdate::New(42));
+    publisher.broadcast_mask_length(MaskLengthUpdate::New(42));
     assert_ready!(task.poll_ready()).unwrap();
     let resp = task.call(MaskLengthRequest).await;
     assert_eq!(resp, Ok(Some(42)));
 
-    publisher.broadcast_mask_length(round_id, MaskLengthUpdate::Invalidate);
+    publisher.broadcast_mask_length(MaskLengthUpdate::Invalidate);
     assert_ready!(task.poll_ready()).unwrap();
     let resp = task.call(MaskLengthRequest).await;
     assert_eq!(resp, Ok(None));
@@ -64,14 +63,13 @@ async fn test_model_svc() {
     let resp = task.call(ModelRequest).await;
     assert_eq!(resp, Ok(None));
 
-    let round_id = subscriber.params_listener().get_latest().round_id;
     let model = Arc::new(Model::from(vec![]));
-    publisher.broadcast_model(round_id.clone(), ModelUpdate::New(model.clone()));
+    publisher.broadcast_model(ModelUpdate::New(model.clone()));
     assert_ready!(task.poll_ready()).unwrap();
     let resp = task.call(ModelRequest).await;
     assert_eq!(resp, Ok(Some(model)));
 
-    publisher.broadcast_model(round_id, ModelUpdate::Invalidate);
+    publisher.broadcast_model(ModelUpdate::Invalidate);
     assert_ready!(task.poll_ready()).unwrap();
     let resp = task.call(ModelRequest).await;
     assert_eq!(resp, Ok(None));
@@ -110,13 +108,12 @@ async fn test_scalar_svc() {
     let resp = task.call(ScalarRequest).await;
     assert_eq!(resp, Ok(None));
 
-    let round_id = subscriber.params_listener().get_latest().round_id;
-    publisher.broadcast_scalar(round_id.clone(), ScalarUpdate::New(42.42));
+    publisher.broadcast_scalar(ScalarUpdate::New(42.42));
     assert_ready!(task.poll_ready()).unwrap();
     let resp = task.call(ScalarRequest).await;
     assert_eq!(resp, Ok(Some(42.42)));
 
-    publisher.broadcast_scalar(round_id, ScalarUpdate::Invalidate);
+    publisher.broadcast_scalar(ScalarUpdate::Invalidate);
     assert_ready!(task.poll_ready()).unwrap();
     let resp = task.call(ScalarRequest).await;
     assert_eq!(resp, Ok(None));
@@ -152,14 +149,13 @@ async fn test_seed_dict_svc() {
     let resp = task.call(SeedDictRequest).await;
     assert_eq!(resp, Ok(None));
 
-    let round_id = subscriber.params_listener().get_latest().round_id;
     let seed_dict = Arc::new(dummy_seed_dict());
-    publisher.broadcast_seed_dict(round_id.clone(), DictionaryUpdate::New(seed_dict.clone()));
+    publisher.broadcast_seed_dict(DictionaryUpdate::New(seed_dict.clone()));
     assert_ready!(task.poll_ready()).unwrap();
     let resp = task.call(SeedDictRequest).await;
     assert_eq!(resp, Ok(Some(seed_dict)));
 
-    publisher.broadcast_seed_dict(round_id, DictionaryUpdate::Invalidate);
+    publisher.broadcast_seed_dict(DictionaryUpdate::Invalidate);
     assert_ready!(task.poll_ready()).unwrap();
     let resp = task.call(SeedDictRequest).await;
     assert_eq!(resp, Ok(None));
@@ -188,14 +184,13 @@ async fn test_sum_dict_svc() {
     let resp = task.call(SumDictRequest).await;
     assert_eq!(resp, Ok(None));
 
-    let round_id = subscriber.params_listener().get_latest().round_id;
     let sum_dict = Arc::new(dummy_sum_dict());
-    publisher.broadcast_sum_dict(round_id.clone(), DictionaryUpdate::New(sum_dict.clone()));
+    publisher.broadcast_sum_dict(DictionaryUpdate::New(sum_dict.clone()));
     assert_ready!(task.poll_ready()).unwrap();
     let resp = task.call(SumDictRequest).await;
     assert_eq!(resp, Ok(Some(sum_dict)));
 
-    publisher.broadcast_sum_dict(round_id, DictionaryUpdate::Invalidate);
+    publisher.broadcast_sum_dict(DictionaryUpdate::Invalidate);
     assert_ready!(task.poll_ready()).unwrap();
     let resp = task.call(SumDictRequest).await;
     assert_eq!(resp, Ok(None));

--- a/rust/src/services/tests/messages/message_parser.rs
+++ b/rust/src/services/tests/messages/message_parser.rs
@@ -68,7 +68,7 @@ async fn test_valid_request() {
 
     // Simulate the state machine broadcasting the sum phase
     // (otherwise the request will be rejected)
-    publisher.broadcast_phase(round_params.seed.clone(), PhaseName::Sum);
+    publisher.broadcast_phase(PhaseName::Sum);
 
     // Call the service
     let resp = task.call(req).await.unwrap().unwrap();

--- a/rust/src/services/tests/messages/pre_processor.rs
+++ b/rust/src/services/tests/messages/pre_processor.rs
@@ -33,9 +33,8 @@ async fn test_sum_ok() {
     // make sure everyone is eligible
     round_params.sum = 1.0;
 
-    let round_id = round_params.seed.clone();
     publisher.broadcast_params(round_params.clone());
-    publisher.broadcast_phase(round_id, PhaseName::Sum);
+    publisher.broadcast_phase(PhaseName::Sum);
 
     let (message, _, _) = utils::new_sum_message(&round_params);
     let req = make_req(message.clone());
@@ -54,9 +53,8 @@ async fn test_sum_not_eligible() {
     // make sure no-one is eligible
     round_params.sum = 0.0;
 
-    let round_id = round_params.seed.clone();
     publisher.broadcast_params(round_params.clone());
-    publisher.broadcast_phase(round_id, PhaseName::Sum);
+    publisher.broadcast_phase(PhaseName::Sum);
 
     let (message, _, _) = utils::new_sum_message(&round_params);
     let req = make_req(message.clone());
@@ -86,7 +84,7 @@ async fn test_phase_change_between_poll_ready_and_call() {
     let (message, _, _) = utils::new_sum_message(&round_params);
     let req = make_req(message.clone());
 
-    publisher.broadcast_phase(round_params.seed.clone(), PhaseName::Sum);
+    publisher.broadcast_phase(PhaseName::Sum);
 
     let err = task.call(req).await.unwrap().unwrap_err();
     match err {

--- a/rust/src/services/tests/utils.rs
+++ b/rust/src/services/tests/utils.rs
@@ -21,7 +21,8 @@ pub fn new_event_channels() -> (EventPublisher, EventSubscriber) {
         seed: RoundSeed::generate(),
     };
     let phase = PhaseName::Idle;
-    EventPublisher::init(keys, params, phase)
+    let round_id = 0;
+    EventPublisher::init(round_id, keys, params, phase)
 }
 
 /// Simulate a participant generating keys and crafting a valid sum

--- a/rust/src/state_machine/coordinator.rs
+++ b/rust/src/state_machine/coordinator.rs
@@ -136,3 +136,34 @@ impl ByteObject for RoundSeed {
 /// A dictionary created during the sum2 phase of the protocol. It counts the model masks
 /// represented by their hashes.
 pub type MaskDict = HashMap<MaskObject, usize>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state_machine::tests::utils;
+
+    #[test]
+    fn update_round_id() {
+        let (mut coordinator_state, event_subscriber) = CoordinatorState::new(
+            utils::pet_settings(),
+            utils::mask_settings(),
+            utils::model_settings(),
+        );
+        let phases = event_subscriber.phase_listener();
+        // When starting the round ID should be 0
+        let id = phases.get_latest().round_id;
+        assert_eq!(id, 0);
+
+        coordinator_state.set_round_id(1);
+        assert_eq!(coordinator_state.round_id, 1);
+
+        // Old events should still have the same round ID
+        let id = phases.get_latest().round_id;
+        assert_eq!(id, 0);
+
+        // But new events should have the new round ID
+        coordinator_state.events.broadcast_phase(PhaseName::Sum);
+        let id = phases.get_latest().round_id;
+        assert_eq!(id, 1);
+    }
+}

--- a/rust/src/state_machine/coordinator.rs
+++ b/rust/src/state_machine/coordinator.rs
@@ -32,6 +32,8 @@ pub struct RoundParameters {
 pub struct CoordinatorState {
     /// The credentials of the coordinator.
     pub keys: EncryptKeyPair,
+    /// Internal ID used to identify a round
+    pub round_id: u64,
     /// The round parameters.
     pub round_params: RoundParameters,
     /// The minimum of required sum/sum2 messages.
@@ -70,13 +72,15 @@ impl CoordinatorState {
             seed: RoundSeed::zeroed(),
         };
         let phase = PhaseName::Idle;
+        let round_id = 0;
 
         let (publisher, subscriber) =
-            EventPublisher::init(keys.clone(), round_params.clone(), phase);
+            EventPublisher::init(round_id, keys.clone(), round_params.clone(), phase);
 
         let coordinator_state = Self {
             keys,
             round_params,
+            round_id,
             events: publisher,
             min_sum_count: pet_settings.min_sum_count,
             min_update_count: pet_settings.min_update_count,
@@ -89,6 +93,17 @@ impl CoordinatorState {
             model_size: model_settings.size,
         };
         (coordinator_state, subscriber)
+    }
+
+    /// Set the round ID to the given value
+    pub fn set_round_id(&mut self, id: u64) {
+        self.round_id = id;
+        self.events.set_round_id(id);
+    }
+
+    /// Return the current round ID
+    pub fn round_id(&self) -> u64 {
+        self.round_id
     }
 }
 

--- a/rust/src/state_machine/phases/error.rs
+++ b/rust/src/state_machine/phases/error.rs
@@ -45,10 +45,9 @@ where
         error!("state transition failed! error: {:?}", self.inner);
 
         info!("broadcasting error phase event");
-        self.coordinator_state.events.broadcast_phase(
-            self.coordinator_state.round_params.seed.clone(),
-            PhaseName::Error,
-        );
+        self.coordinator_state
+            .events
+            .broadcast_phase(PhaseName::Error);
 
         Ok(())
     }

--- a/rust/src/state_machine/phases/idle.rs
+++ b/rust/src/state_machine/phases/idle.rs
@@ -34,8 +34,6 @@ where
     ///
     /// See the [module level documentation](../index.html) for more details.
     async fn run(&mut self) -> Result<(), StateError> {
-        info!("starting idle phase");
-
         info!("updating the keys");
         self.gen_round_keypair();
 
@@ -48,40 +46,19 @@ where
         let events = &mut self.coordinator_state.events;
 
         info!("broadcasting new keys");
-        events.broadcast_keys(
-            self.coordinator_state.round_params.seed.clone(),
-            self.coordinator_state.keys.clone(),
-        );
-
-        info!("broadcasting idle phase event");
-        events.broadcast_phase(
-            self.coordinator_state.round_params.seed.clone(),
-            PhaseName::Idle,
-        );
+        events.broadcast_keys(self.coordinator_state.keys.clone());
 
         info!("broadcasting invalidation of sum dictionary from previous round");
-        events.broadcast_sum_dict(
-            self.coordinator_state.round_params.seed.clone(),
-            DictionaryUpdate::Invalidate,
-        );
+        events.broadcast_sum_dict(DictionaryUpdate::Invalidate);
 
         info!("broadcasting invalidation of seed dictionary from previous round");
-        events.broadcast_seed_dict(
-            self.coordinator_state.round_params.seed.clone(),
-            DictionaryUpdate::Invalidate,
-        );
+        events.broadcast_seed_dict(DictionaryUpdate::Invalidate);
 
         info!("broadcasting invalidation of scalar from previous round");
-        events.broadcast_scalar(
-            self.coordinator_state.round_params.seed.clone(),
-            ScalarUpdate::Invalidate,
-        );
+        events.broadcast_scalar(ScalarUpdate::Invalidate);
 
         info!("broadcasting invalidation of mask length from previous round");
-        events.broadcast_mask_length(
-            self.coordinator_state.round_params.seed.clone(),
-            MaskLengthUpdate::Invalidate,
-        );
+        events.broadcast_mask_length(MaskLengthUpdate::Invalidate);
 
         info!("broadcasting new round parameters");
         events.broadcast_params(self.coordinator_state.round_params.clone());
@@ -98,7 +75,12 @@ where
 
 impl<R> PhaseState<R, Idle> {
     /// Creates a new idle state.
-    pub fn new(coordinator_state: CoordinatorState, request_rx: RequestReceiver<R>) -> Self {
+    pub fn new(mut coordinator_state: CoordinatorState, request_rx: RequestReceiver<R>) -> Self {
+        // Since some events are emitted very early, the round id must
+        // be correct when the idle phase starts. Therefore, we update
+        // it here, when instantiating the idle PhaseState.
+        coordinator_state.set_round_id(coordinator_state.round_id());
+        debug!("new round ID = {}", coordinator_state.round_id());
         Self {
             inner: Idle,
             coordinator_state,
@@ -141,12 +123,13 @@ mod test {
 
     #[tokio::test]
     pub async fn idle_to_sum() {
-        let (state_machine, _request_tx, events) = StateMachineBuilder::new().build();
+        let (state_machine, _request_tx, events) =
+            StateMachineBuilder::new().with_round_id(2).build();
         assert!(state_machine.is_idle());
 
         let initial_round_params = events.params_listener().get_latest().event;
-        let initial_seed = initial_round_params.seed.clone();
         let initial_keys = events.keys_listener().get_latest().event;
+        let initial_seed = initial_round_params.seed.clone();
 
         let state_machine = state_machine.next().await.unwrap();
         assert!(state_machine.is_sum());
@@ -160,70 +143,51 @@ mod test {
         assert!(sum_state.sum_dict().is_empty());
 
         let new_round_params = coordinator_state.round_params.clone();
-        let new_seed = new_round_params.seed.clone();
         let new_keys = coordinator_state.keys.clone();
 
-        // Make sure that the round seed, coordinator keys, and other
-        // parameters have been updated, since a new round is starting
-        assert_ne!(initial_seed, new_seed);
-        assert_ne!(initial_round_params, new_round_params);
+        // Make sure the seed and keys have updated
+        assert_ne!(initial_seed, new_round_params.seed.clone());
         assert_ne!(initial_keys, new_keys);
+
+        fn expected_event<T>(event: T) -> Event<T> {
+            Event { round_id: 2, event }
+        }
 
         // Check all the events that should be emitted during the idle
         // phase
         assert_eq!(
             events.phase_listener().get_latest(),
-            Event {
-                round_id: new_seed.clone(),
-                event: PhaseName::Idle,
-            }
+            expected_event(PhaseName::Idle)
         );
+
         assert_eq!(
             events.keys_listener().get_latest(),
-            Event {
-                round_id: new_seed.clone(),
-                event: new_keys,
-            }
+            expected_event(new_keys),
         );
 
         assert_eq!(
             events.params_listener().get_latest(),
-            Event {
-                round_id: new_seed.clone(),
-                event: new_round_params,
-            }
+            expected_event(new_round_params)
         );
 
         assert_eq!(
             events.sum_dict_listener().get_latest(),
-            Event {
-                round_id: new_seed.clone(),
-                event: DictionaryUpdate::Invalidate,
-            }
+            expected_event(DictionaryUpdate::Invalidate)
         );
 
         assert_eq!(
             events.seed_dict_listener().get_latest(),
-            Event {
-                round_id: new_seed.clone(),
-                event: DictionaryUpdate::Invalidate,
-            }
+            expected_event(DictionaryUpdate::Invalidate)
         );
 
         assert_eq!(
             events.scalar_listener().get_latest(),
-            Event {
-                round_id: new_seed.clone(),
-                event: ScalarUpdate::Invalidate,
-            }
+            expected_event(ScalarUpdate::Invalidate)
         );
 
         assert_eq!(
             events.mask_length_listener().get_latest(),
-            Event {
-                round_id: new_seed.clone(),
-                event: MaskLengthUpdate::Invalidate,
-            }
+            expected_event(MaskLengthUpdate::Invalidate)
         );
     }
 }

--- a/rust/src/state_machine/phases/shutdown.rs
+++ b/rust/src/state_machine/phases/shutdown.rs
@@ -21,14 +21,6 @@ where
     ///
     /// See the [module level documentation](../index.html) for more details.
     async fn run(&mut self) -> Result<(), StateError> {
-        warn!("shutdown state machine");
-
-        info!("broadcasting shutdown phase event");
-        self.coordinator_state.events.broadcast_phase(
-            self.coordinator_state.round_params.seed.clone(),
-            PhaseName::Shutdown,
-        );
-
         // clear the request channel
         self.request_rx.close();
         while self.request_rx.recv().await.is_some() {}

--- a/rust/src/state_machine/phases/sum.rs
+++ b/rust/src/state_machine/phases/sum.rs
@@ -70,14 +70,6 @@ where
     ///
     /// See the [module level documentation](../index.html) for more details.
     async fn run(&mut self) -> Result<(), StateError> {
-        info!("starting sum phase");
-
-        info!("broadcasting sum phase event");
-        self.coordinator_state.events.broadcast_phase(
-            self.coordinator_state.round_params.seed.clone(),
-            PhaseName::Sum,
-        );
-
         let min_time = self.coordinator_state.min_sum_time;
         debug!("in sum phase for a minimum of {} seconds", min_time);
         self.process_during(Duration::from_secs(min_time)).await?;
@@ -164,10 +156,9 @@ impl<R> PhaseState<R, Sum> {
     /// Freezes the sum dictionary.
     fn freeze_sum_dict(&mut self) {
         info!("broadcasting sum dictionary");
-        self.coordinator_state.events.broadcast_sum_dict(
-            self.coordinator_state.round_params.seed.clone(),
-            DictionaryUpdate::New(Arc::new(self.inner.sum_dict.clone())),
-        );
+        self.coordinator_state
+            .events
+            .broadcast_sum_dict(DictionaryUpdate::New(Arc::new(self.inner.sum_dict.clone())));
 
         info!("initializing seed dictionary");
         self.inner.seed_dict = Some(
@@ -258,7 +249,7 @@ mod test {
         assert_eq!(
             events.phase_listener().get_latest(),
             Event {
-                round_id: seed.clone(),
+                round_id: 0,
                 event: PhaseName::Sum,
             }
         );

--- a/rust/src/state_machine/phases/sum2.rs
+++ b/rust/src/state_machine/phases/sum2.rs
@@ -65,13 +65,6 @@ where
     ///
     /// See the [module level documentation](../index.html) for more details.
     async fn run(&mut self) -> Result<(), StateError> {
-        info!("starting sum2 phase");
-        info!("broadcasting sum2 phase event");
-        self.coordinator_state.events.broadcast_phase(
-            self.coordinator_state.round_params.seed.clone(),
-            PhaseName::Sum2,
-        );
-
         let min_time = self.coordinator_state.min_sum_time;
         debug!("in sum2 phase for a minimum of {} seconds", min_time);
         self.process_during(Duration::from_secs(min_time)).await?;
@@ -292,7 +285,7 @@ mod test {
         assert_eq!(
             events.phase_listener().get_latest(),
             Event {
-                round_id: seed.clone(),
+                round_id: 0,
                 event: PhaseName::Sum2,
             }
         );

--- a/rust/src/state_machine/phases/unmask.rs
+++ b/rust/src/state_machine/phases/unmask.rs
@@ -41,21 +41,12 @@ where
 
     /// Run the unmasking phase
     async fn run(&mut self) -> Result<(), StateError> {
-        info!("starting unmasking phase");
-
-        info!("broadcasting unmasking phase event");
-        self.coordinator_state.events.broadcast_phase(
-            self.coordinator_state.round_params.seed.clone(),
-            PhaseName::Unmask,
-        );
-
         let global_model = self.end_round()?;
 
         info!("broadcasting the new global model");
-        self.coordinator_state.events.broadcast_model(
-            self.coordinator_state.round_params.seed.clone(),
-            ModelUpdate::New(Arc::new(global_model)),
-        );
+        self.coordinator_state
+            .events
+            .broadcast_model(ModelUpdate::New(Arc::new(global_model)));
 
         Ok(())
     }

--- a/rust/src/state_machine/phases/update.rs
+++ b/rust/src/state_machine/phases/update.rs
@@ -59,22 +59,13 @@ where
     ///
     /// See the [module level documentation](../index.html) for more details.
     async fn run(&mut self) -> Result<(), StateError> {
-        info!("starting update phase");
-
-        info!("broadcasting update phase event");
-        self.coordinator_state.events.broadcast_phase(
-            self.coordinator_state.round_params.seed.clone(),
-            PhaseName::Update,
-        );
-
         let scalar = 1_f64
             / (self.coordinator_state.expected_participants as f64
                 * self.coordinator_state.round_params.update);
         info!("broadcasting scalar: {}", scalar);
-        self.coordinator_state.events.broadcast_scalar(
-            self.coordinator_state.round_params.seed.clone(),
-            ScalarUpdate::New(scalar),
-        );
+        self.coordinator_state
+            .events
+            .broadcast_scalar(ScalarUpdate::New(scalar));
 
         let min_time = self.coordinator_state.min_update_time;
         debug!("in update phase for a minimum of {} seconds", min_time);
@@ -104,16 +95,14 @@ where
         } = self;
 
         info!("broadcasting mask length");
-        coordinator_state.events.broadcast_mask_length(
-            coordinator_state.round_params.seed.clone(),
-            MaskLengthUpdate::New(aggregation.len()),
-        );
+        coordinator_state
+            .events
+            .broadcast_mask_length(MaskLengthUpdate::New(aggregation.len()));
 
         info!("broadcasting the global seed dictionary");
-        coordinator_state.events.broadcast_seed_dict(
-            coordinator_state.round_params.seed.clone(),
-            DictionaryUpdate::New(Arc::new(seed_dict)),
-        );
+        coordinator_state
+            .events
+            .broadcast_seed_dict(DictionaryUpdate::New(Arc::new(seed_dict)));
 
         Some(
             PhaseState::<R, Sum2>::new(coordinator_state, request_rx, frozen_sum_dict, aggregation)
@@ -382,14 +371,14 @@ mod test {
         assert_eq!(
             events.phase_listener().get_latest(),
             Event {
-                round_id: seed.clone(),
+                round_id: 0,
                 event: PhaseName::Update,
             }
         );
         assert_eq!(
             events.mask_length_listener().get_latest(),
             Event {
-                round_id: seed.clone(),
+                round_id: 0,
                 event: MaskLengthUpdate::New(model.len()),
             }
         );
@@ -412,7 +401,7 @@ mod test {
         assert_eq!(
             events.seed_dict_listener().get_latest(),
             Event {
-                round_id: seed.clone(),
+                round_id: 0,
                 event: DictionaryUpdate::New(Arc::new(global_seed_dict)),
             }
         );

--- a/rust/src/state_machine/tests/builder.rs
+++ b/rust/src/state_machine/tests/builder.rs
@@ -5,7 +5,7 @@ use crate::{
     state_machine::{
         coordinator::{CoordinatorState, RoundSeed},
         events::EventSubscriber,
-        phases::{self, Handler, PhaseState},
+        phases::{self, Handler, Phase, PhaseState},
         requests::{Request, RequestReceiver, RequestSender},
         tests::utils,
         StateMachine,
@@ -44,7 +44,7 @@ impl StateMachineBuilder<phases::Idle> {
 
 impl<P> StateMachineBuilder<P>
 where
-    PhaseState<Request, P>: Handler<Request>,
+    PhaseState<Request, P>: Handler<Request> + Phase<Request>,
     StateMachine<Request>: From<PhaseState<Request, P>>,
 {
     pub fn build(
@@ -55,12 +55,29 @@ where
         EventSubscriber,
     ) {
         let Self {
-            coordinator_state,
+            mut coordinator_state,
             event_subscriber,
             phase_state,
         } = self;
 
         let (request_rx, request_tx) = RequestReceiver::<Request>::new();
+
+        // Make sure the events that the listeners have are up to date
+        let events = &mut coordinator_state.events;
+        events.broadcast_keys(coordinator_state.keys.clone());
+        events.broadcast_params(coordinator_state.round_params.clone());
+        events.broadcast_phase(<PhaseState<Request, P> as Phase<Request>>::NAME);
+        // Also re-emit the other events in case the round ID changed
+        let scalar = event_subscriber.scalar_listener().get_latest().event;
+        events.broadcast_scalar(scalar);
+        let model = event_subscriber.model_listener().get_latest().event;
+        events.broadcast_model(model);
+        let mask_length = event_subscriber.mask_length_listener().get_latest().event;
+        events.broadcast_mask_length(mask_length);
+        let sum_dict = event_subscriber.sum_dict_listener().get_latest().event;
+        events.broadcast_sum_dict(sum_dict);
+        let seed_dict = event_subscriber.seed_dict_listener().get_latest().event;
+        events.broadcast_seed_dict(seed_dict);
 
         let state = PhaseState {
             inner: phase_state,
@@ -69,33 +86,29 @@ where
         };
 
         let state_machine = StateMachine::from(state);
-        (state_machine, request_tx, event_subscriber)
-    }
 
-    fn broadcast_round_params(&mut self) {
-        let params = self.coordinator_state.round_params.clone();
-        self.coordinator_state.events.broadcast_params(params);
+        (state_machine, request_tx, event_subscriber)
     }
 
     #[allow(dead_code)]
     pub fn with_keys(mut self, keys: EncryptKeyPair) -> Self {
         self.coordinator_state.round_params.pk = keys.public.clone();
         self.coordinator_state.keys = keys.clone();
-        let round_id = self.coordinator_state.round_params.seed.clone();
-        self.coordinator_state.events.broadcast_keys(round_id, keys);
-        self.broadcast_round_params();
+        self
+    }
+
+    pub fn with_round_id(mut self, id: u64) -> Self {
+        self.coordinator_state.set_round_id(id);
         self
     }
 
     pub fn with_sum_ratio(mut self, sum_ratio: f64) -> Self {
         self.coordinator_state.round_params.sum = sum_ratio;
-        self.broadcast_round_params();
         self
     }
 
     pub fn with_update_ratio(mut self, update_ratio: f64) -> Self {
         self.coordinator_state.round_params.update = update_ratio;
-        self.broadcast_round_params();
         self
     }
 
@@ -106,7 +119,6 @@ where
 
     pub fn with_seed(mut self, seed: RoundSeed) -> Self {
         self.coordinator_state.round_params.seed = seed;
-        self.broadcast_round_params();
         self
     }
 

--- a/rust/src/state_machine/tests/builder.rs
+++ b/rust/src/state_machine/tests/builder.rs
@@ -1,7 +1,6 @@
 use crate::{
     crypto::encrypt::EncryptKeyPair,
     mask::config::MaskConfig,
-    settings::{ModelSettings, PetSettings},
     state_machine::{
         coordinator::{CoordinatorState, RoundSeed},
         events::EventSubscriber,
@@ -21,18 +20,11 @@ pub struct StateMachineBuilder<P> {
 
 impl StateMachineBuilder<phases::Idle> {
     pub fn new() -> Self {
-        let pet_settings = PetSettings {
-            sum: 0.4,
-            update: 0.5,
-            min_sum_count: 1,
-            min_update_count: 3,
-            expected_participants: 10,
-            ..Default::default()
-        };
-        let mask_settings = utils::mask_settings();
-        let model_settings = ModelSettings { size: 1 };
-        let (coordinator_state, event_subscriber) =
-            CoordinatorState::new(pet_settings, mask_settings, model_settings);
+        let (coordinator_state, event_subscriber) = CoordinatorState::new(
+            utils::pet_settings(),
+            utils::mask_settings(),
+            utils::model_settings(),
+        );
         let phase_state = phases::Idle;
         StateMachineBuilder {
             coordinator_state,

--- a/rust/src/state_machine/tests/utils.rs
+++ b/rust/src/state_machine/tests/utils.rs
@@ -2,7 +2,7 @@ use crate::{
     client::{Participant, Task},
     crypto::ByteObject,
     mask::config::{BoundType, DataType, GroupType, ModelType},
-    settings::MaskSettings,
+    settings::{MaskSettings, ModelSettings, PetSettings},
     state_machine::coordinator::RoundSeed,
 };
 
@@ -44,4 +44,19 @@ pub fn mask_settings() -> MaskSettings {
         bound_type: BoundType::B0,
         model_type: ModelType::M3,
     }
+}
+
+pub fn pet_settings() -> PetSettings {
+    PetSettings {
+        sum: 0.4,
+        update: 0.5,
+        min_sum_count: 1,
+        min_update_count: 3,
+        expected_participants: 10,
+        ..Default::default()
+    }
+}
+
+pub fn model_settings() -> ModelSettings {
+    ModelSettings { size: 1 }
 }


### PR DESCRIPTION
this started as a small improvement: instead of repeating the same
snippet for each phase, we wanted to do it once in
`PhaseState<R,S>::run_phase()`:

```rust
pub async fn run_phase(mut self) -> Option<StateMachine<R>> {
    let phase = <Self as Phase<R>>::NAME;
    self.coordinator_state.events.broadcast_phase(phase); // <-- add this
    self.run().await.unwrap();
    self.purge_outdated_requests().unwrap();
    self.next()
}
```

It turns out that this doesn't work for the idle phase, because the
round ID is updated in the `run()` implementation, _after_ the phase
event is broadcasted. Therefore, the event that is emitted has the
wrong round id.

There are multiple solutions:

  1. re-emit an event in the idle phase. That may work but that means
     there's a small interval of time during which the listeners still
     have an inconsistent Phase event.

  2. add some logic before broadcasting the phase, such that if this
     is the idle phase, update the round seed before anything
     else. But this logic really belong to the phase itself, so that
     feels very hacky

  3. generate the round seed in `PhaseState<R, Idle>::new`. But
     generating a round seed here is again a bit hacky. This should
     happen when the phase _runs_, in the `Handle::run` impl.

Therefore we went for a 4th solution, and introduced a round id that
is only used internally and has nothing to do with the round
parameters. Updating it in `PhaseState<R, Idle>::new` is fine, since
it has nothing to do with the _phase_ logic itself. The round
parameters are still fully taken care of in `Handle::run`.

Interestingly, this has opened the door to some simplifications in the
`EventPublisher` logic, and we were able to make its API simpler by
removing the round id from the methods arguments altogether.