### PR TITLE
PB-925 Clean-up of stale ReplicaSets

### DIFF
--- a/.github/workflows/dockerhub-master.yml
+++ b/.github/workflows/dockerhub-master.yml
@@ -40,3 +40,6 @@ jobs:
 
       - name: Check deployment status
         run: kubectl rollout -n development status deployment/coordinator-deployment
+
+      - name: Clean-up stale ReplicaSets
+        run: kubectl delete replicasets $(kubectl get replicasets | awk 'NR!=1 && ($2==0) {print $1}')


### PR DESCRIPTION
After auto-deploys, we eventually run into stale replicasets, like so:

```
$ kubectl get replicasets -n development
NAME                                DESIRED   CURRENT   READY   AGE
coordinator-deployment-589486dbbd   1         1         1       15h
coordinator-deployment-6574ffcfc5   0         0         0       22h      <================ (DESIRED == 0)
coordinator-deployment-84dfcf597    0         0         0       18h      <================ (DESIRED == 0)
grafana-development-94cfff677       1         1         1       5d17h
```

The proposed addition to the CI takes care of that:

```
$ kubectl delete replicasets $(kubectl get replicasets | awk 'NR!=1 && ($2==0) {print $1}') --dry-run=client
replicaset.apps "coordinator-deployment-6574ffcfc5" deleted (dry run)
replicaset.apps "coordinator-deployment-84dfcf597" deleted (dry run)
```