### PR TITLE
add metrics service

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -37,6 +37,8 @@ tracing-subscriber = "0.2.7"
 uuid = { version = "0.8.1", features = ["v4"]}
 rayon = "1.3.0"
 async-trait = "0.1.35"
+influxdb = { version = "0.1.0", features = ["derive"] }
+chrono = "0.4.13"
 
 # optional dependencies
 influxdb = { version = "0.1.0", features = ["derive"], optional = true }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -37,8 +37,6 @@ tracing-subscriber = "0.2.7"
 uuid = { version = "0.8.1", features = ["v4"]}
 rayon = "1.3.0"
 async-trait = "0.1.35"
-influxdb = { version = "0.1.0", features = ["derive"] }
-chrono = "0.4.13"
 
 # optional dependencies
 influxdb = { version = "0.1.0", features = ["derive"], optional = true }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -90,6 +90,7 @@ pub mod crypto;
 pub mod examples;
 pub mod mask;
 pub mod message;
+pub mod metrics;
 pub mod rest;
 pub mod sdk;
 pub mod services;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -90,7 +90,6 @@ pub mod crypto;
 pub mod examples;
 pub mod mask;
 pub mod message;
-pub mod metrics;
 pub mod rest;
 pub mod sdk;
 pub mod services;
@@ -98,6 +97,9 @@ pub mod settings;
 pub mod state_machine;
 pub mod utils;
 pub(crate) mod vendor;
+
+#[cfg(feature = "metrics")]
+pub mod metrics;
 
 use std::collections::HashMap;
 

--- a/rust/src/metrics/mod.rs
+++ b/rust/src/metrics/mod.rs
@@ -216,15 +216,24 @@ pub struct MetricsService {
 }
 
 impl MetricsService {
-    pub fn new(host: &str, db_name: &str) -> (MetricsService, MetricsSender) {
+    pub fn new(url: &str, database: &str) -> (MetricsService, MetricsSender) {
+        let client = Client::new(url, database);
+        Self::new_metrics_service(client)
+    }
+
+    pub fn new_with_auth(
+        url: &str,
+        database: &str,
+        username: &str,
+        password: &str,
+    ) -> (MetricsService, MetricsSender) {
+        let client_auth = Client::new(url, database).with_auth(username, password);
+        Self::new_metrics_service(client_auth)
+    }
+
+    fn new_metrics_service(client: Client) -> (MetricsService, MetricsSender) {
         let (sender, receiver) = unbounded_channel();
-        (
-            MetricsService {
-                client: Client::new(host, db_name),
-                receiver,
-            },
-            MetricsSender(sender),
-        )
+        (MetricsService { client, receiver }, MetricsSender(sender))
     }
 }
 

--- a/rust/src/metrics/mod.rs
+++ b/rust/src/metrics/mod.rs
@@ -1,0 +1,229 @@
+use influxdb::{Client, WriteQuery};
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+
+mod models;
+
+pub mod round_parameters {
+    use super::models::{Measurement, Sum, Update};
+    use influxdb::{InfluxDbWriteable, Timestamp, WriteQuery};
+    pub mod sum {
+        use super::*;
+
+        pub fn update(sum: f64) -> WriteQuery {
+            Sum {
+                time: Timestamp::Now.into(),
+                sum,
+            }
+            .into_query(Measurement::StateMachine.to_string())
+        }
+    }
+
+    pub mod update {
+        use super::*;
+
+        pub fn update(update: f64) -> WriteQuery {
+            Update {
+                time: Timestamp::Now.into(),
+                update,
+            }
+            .into_query(Measurement::StateMachine.to_string())
+        }
+    }
+}
+
+pub mod phase {
+    use super::models::{Event, Measurement, Phase};
+    use crate::state_machine::phases::{PhaseName, StateError};
+    use influxdb::{InfluxDbWriteable, Timestamp, WriteQuery};
+    pub mod error {
+        use super::*;
+
+        pub fn emit(error: &StateError) -> WriteQuery {
+            Event {
+                time: Timestamp::Now.into(),
+                title: error.to_string(),
+                text: None,
+                tags: None,
+            }
+            .into_query(Measurement::Event.to_string())
+        }
+    }
+
+    pub fn update(phase: PhaseName) -> WriteQuery {
+        Phase {
+            time: Timestamp::Now.into(),
+            phase: phase as u8,
+        }
+        .into_query(Measurement::StateMachine.to_string())
+    }
+}
+
+pub mod masks {
+    use super::models::{MasksTotalNumber, Measurement};
+    use influxdb::{InfluxDbWriteable, Timestamp, WriteQuery};
+    pub mod total_number {
+        use super::*;
+
+        pub fn update(total_number: usize) -> WriteQuery {
+            MasksTotalNumber {
+                time: Timestamp::Now.into(),
+                masks_total_number: total_number as u64,
+            }
+            .into_query(Measurement::StateMachine.to_string())
+        }
+    }
+}
+
+pub mod round {
+    use super::models::{Measurement, RoundSuccessful, RoundTotalNumber};
+    use influxdb::{InfluxDbWriteable, Timestamp, WriteQuery};
+    pub mod total_number {
+        use super::*;
+
+        pub fn update(total_number: u64) -> WriteQuery {
+            RoundTotalNumber {
+                time: Timestamp::Now.into(),
+                round_total_number: total_number,
+            }
+            .into_query(Measurement::StateMachine.to_string())
+        }
+    }
+
+    pub mod successful {
+        use super::*;
+
+        pub fn increment() -> WriteQuery {
+            RoundSuccessful {
+                time: Timestamp::Now.into(),
+                round_successful: 1,
+            }
+            .into_query(Measurement::StateMachine.to_string())
+        }
+    }
+}
+
+pub mod message {
+    use super::models::{
+        Measurement,
+        MessageDiscarded,
+        MessageRejected,
+        MessageSum,
+        MessageSum2,
+        MessageUpdate,
+    };
+    use crate::state_machine::phases::PhaseName;
+    use influxdb::{InfluxDbWriteable, Timestamp, WriteQuery};
+    pub mod sum {
+        use super::*;
+
+        pub fn increment(round_id: u64, phase: PhaseName) -> WriteQuery {
+            MessageSum {
+                time: Timestamp::Now.into(),
+                sum: 1,
+                round_id,
+                phase: phase as u8,
+            }
+            .into_query(Measurement::StateMachine.to_string())
+        }
+    }
+
+    pub mod update {
+        use super::*;
+
+        pub fn increment(round_id: u64, phase: PhaseName) -> WriteQuery {
+            MessageUpdate {
+                time: Timestamp::Now.into(),
+                update: 1,
+                round_id,
+                phase: phase as u8,
+            }
+            .into_query(Measurement::StateMachine.to_string())
+        }
+    }
+
+    pub mod sum2 {
+        use super::*;
+
+        pub fn increment(round_id: u64, phase: PhaseName) -> WriteQuery {
+            MessageSum2 {
+                time: Timestamp::Now.into(),
+                sum2: 1,
+                round_id,
+                phase: phase as u8,
+            }
+            .into_query(Measurement::StateMachine.to_string())
+        }
+    }
+
+    pub mod discarded {
+        use super::*;
+
+        pub fn increment(round_id: u64, phase: PhaseName) -> WriteQuery {
+            MessageDiscarded {
+                time: Timestamp::Now.into(),
+                discarded: 1,
+                round_id,
+                phase: phase as u8,
+            }
+            .into_query(Measurement::StateMachine.to_string())
+        }
+    }
+
+    pub mod rejected {
+        use super::*;
+
+        pub fn increment(round_id: u64, phase: PhaseName) -> WriteQuery {
+            MessageRejected {
+                time: Timestamp::Now.into(),
+                rejected: 1,
+                round_id,
+                phase: phase as u8,
+            }
+            .into_query(Measurement::StateMachine.to_string())
+        }
+    }
+}
+
+pub async fn run_metric_service(mut metics_service: MetricsService) {
+    loop {
+        match metics_service.receiver.recv().await {
+            Some(write_query) => {
+                let _ = metics_service
+                    .client
+                    .query(&write_query)
+                    .await
+                    .map_err(|e| error!("{}", e));
+            }
+            None => {
+                warn!("All senders have been dropped!");
+                return;
+            }
+        }
+    }
+}
+
+pub struct MetricsSender(UnboundedSender<WriteQuery>);
+
+impl MetricsSender {
+    pub fn send(&self, query: WriteQuery) {
+        let _ = self.0.send(query).map_err(|e| error!("{}", e));
+    }
+}
+
+pub struct MetricsService {
+    client: Client,
+    receiver: UnboundedReceiver<WriteQuery>,
+}
+
+impl MetricsService {
+    pub fn new(host: &str, db_name: &str) -> (MetricsService, MetricsSender) {
+        let (sender, receiver) = unbounded_channel();
+        (
+            MetricsService {
+                client: Client::new(host, db_name),
+                receiver,
+            },
+            MetricsSender(sender),
+        )
+    }
+}

--- a/rust/src/metrics/models.rs
+++ b/rust/src/metrics/models.rs
@@ -22,15 +22,15 @@ impl ToString for Measurement {
 }
 
 #[derive(InfluxDbWriteable)]
-pub struct Sum {
+pub struct RoundParamSum {
     pub time: DateTime<Utc>,
-    pub sum: f64,
+    pub round_param_sum: f64,
 }
 
 #[derive(InfluxDbWriteable)]
-pub struct Update {
+pub struct RoundParamUpdate {
     pub time: DateTime<Utc>,
-    pub update: f64,
+    pub round_param_update: f64,
 }
 
 #[derive(InfluxDbWriteable)]
@@ -60,7 +60,7 @@ pub struct RoundSuccessful {
 #[derive(InfluxDbWriteable)]
 pub struct MessageSum {
     pub time: DateTime<Utc>,
-    pub sum: u8,
+    pub message_sum: u8,
     #[tag]
     pub round_id: u64,
     #[tag]
@@ -70,7 +70,7 @@ pub struct MessageSum {
 #[derive(InfluxDbWriteable)]
 pub struct MessageUpdate {
     pub time: DateTime<Utc>,
-    pub update: u8,
+    pub message_update: u8,
     #[tag]
     pub round_id: u64,
     #[tag]
@@ -80,7 +80,7 @@ pub struct MessageUpdate {
 #[derive(InfluxDbWriteable)]
 pub struct MessageSum2 {
     pub time: DateTime<Utc>,
-    pub sum2: u8,
+    pub message_sum2: u8,
     #[tag]
     pub round_id: u64,
     #[tag]
@@ -90,7 +90,7 @@ pub struct MessageSum2 {
 #[derive(InfluxDbWriteable)]
 pub struct MessageDiscarded {
     pub time: DateTime<Utc>,
-    pub discarded: u8,
+    pub message_discarded: u8,
     #[tag]
     pub round_id: u64,
     #[tag]
@@ -100,7 +100,7 @@ pub struct MessageDiscarded {
 #[derive(InfluxDbWriteable)]
 pub struct MessageRejected {
     pub time: DateTime<Utc>,
-    pub rejected: u8,
+    pub message_rejected: u8,
     #[tag]
     pub round_id: u64,
     #[tag]

--- a/rust/src/metrics/models.rs
+++ b/rust/src/metrics/models.rs
@@ -1,0 +1,116 @@
+use chrono::{DateTime, Utc};
+use influxdb::InfluxDbWriteable;
+
+pub enum Measurement {
+    StateMachine,
+    Event,
+}
+
+impl From<&Measurement> for &'static str {
+    fn from(measurement: &Measurement) -> &'static str {
+        match measurement {
+            Measurement::StateMachine => "state_machine",
+            Measurement::Event => "event",
+        }
+    }
+}
+
+impl ToString for Measurement {
+    fn to_string(&self) -> String {
+        Into::<&str>::into(self).into()
+    }
+}
+
+#[derive(InfluxDbWriteable)]
+pub struct Sum {
+    pub time: DateTime<Utc>,
+    pub sum: f64,
+}
+
+#[derive(InfluxDbWriteable)]
+pub struct Update {
+    pub time: DateTime<Utc>,
+    pub update: f64,
+}
+
+#[derive(InfluxDbWriteable)]
+pub struct Phase {
+    pub time: DateTime<Utc>,
+    pub phase: u8,
+}
+
+#[derive(InfluxDbWriteable)]
+pub struct MasksTotalNumber {
+    pub time: DateTime<Utc>,
+    pub masks_total_number: u64,
+}
+
+#[derive(InfluxDbWriteable)]
+pub struct RoundTotalNumber {
+    pub time: DateTime<Utc>,
+    pub round_total_number: u64,
+}
+
+#[derive(InfluxDbWriteable)]
+pub struct RoundSuccessful {
+    pub time: DateTime<Utc>,
+    pub round_successful: u8,
+}
+
+#[derive(InfluxDbWriteable)]
+pub struct MessageSum {
+    pub time: DateTime<Utc>,
+    pub sum: u8,
+    #[tag]
+    pub round_id: u64,
+    #[tag]
+    pub phase: u8,
+}
+
+#[derive(InfluxDbWriteable)]
+pub struct MessageUpdate {
+    pub time: DateTime<Utc>,
+    pub update: u8,
+    #[tag]
+    pub round_id: u64,
+    #[tag]
+    pub phase: u8,
+}
+
+#[derive(InfluxDbWriteable)]
+pub struct MessageSum2 {
+    pub time: DateTime<Utc>,
+    pub sum2: u8,
+    #[tag]
+    pub round_id: u64,
+    #[tag]
+    pub phase: u8,
+}
+
+#[derive(InfluxDbWriteable)]
+pub struct MessageDiscarded {
+    pub time: DateTime<Utc>,
+    pub discarded: u8,
+    #[tag]
+    pub round_id: u64,
+    #[tag]
+    pub phase: u8,
+}
+
+#[derive(InfluxDbWriteable)]
+pub struct MessageRejected {
+    pub time: DateTime<Utc>,
+    pub rejected: u8,
+    #[tag]
+    pub round_id: u64,
+    #[tag]
+    pub phase: u8,
+}
+
+#[derive(InfluxDbWriteable)]
+pub struct Event {
+    pub time: DateTime<Utc>,
+    pub title: String,
+    pub text: Option<String>,
+    pub tags: Option<String>,
+}


### PR DESCRIPTION
First part of the `Implement data collection to InfluxDB` task.
This PR focus on the definition of the influx data models and the implementation of the metrics service + sender. The integration of the metrics service into the state machine is addressed in a separate PR.  

**metrics/mod.rs**

The `mod.rs` file contains the `MetricsService`, the `MetricsSender` and the functions to generate metrics. 
The `MetricsSender` communicates with the `MetricsService` via an unbounded channel. The unbounded channel 
accepts the type `WriteQuery`. The `WriteQuery` is a struct of the `influxdb` crate. 

My actual plan was to build a wrapper around that struct like:

```rust

enum Metric {
	RoundTotalNumber(RoundTotalNumber);
	Phase(Phase);
}

receiver: UnboundedReceiver<Metric>,
```

However, the `#[derive(InfluxDbWriteable)]` cannot be applied on enums. I would have had to implement the method `into_query` on each variant. So I decided against it. 

I tried to find a solution to encode some properties/information of the metrics into the code. I first started with a couple of structs but that didn't work that well. In the end I used the module system.
Of course, I could have implemented it more generic and save some lines of code. However, I think the abstraction makes it easier to use and less error-prone. 

Structure:

```rust
    use crate::metrics;
    metrics::round_parameters::sum::update(0.3);
    metrics::round_parameters::update::update(0.3);
    metrics::phase::update(PhaseName);
    metrics::phase::error::emit(StateError);
    metrics::masks::total_number::update(1);
    metrics::round::total_number::update(1);
    metrics::round::successful::increment();
    metrics::message::sum::increment(11, PhaseName);
    metrics::message::update::increment(21, PhaseName);
    metrics::message::sum2::increment(31, PhaseName);
    metrics::message::discarded::increment(41, PhaseName);
    metrics::message::rejected::increment(41, PhaseName);
```

The `models.rs` file only contains the influx data models. Through `InfluxDbWriteable` the structs are automatically implement the `into_query` methods.
