### PR TITLE
metrics settings

### DIFF
--- a/configs/config.toml
+++ b/configs/config.toml
@@ -23,3 +23,7 @@ model_type = "M3"
 
 [model]
 size = 4
+
+[metrics]
+store_url = "http://influxdb:8086"
+store_name = "metrics"

--- a/configs/config.toml
+++ b/configs/config.toml
@@ -24,6 +24,6 @@ model_type = "M3"
 [model]
 size = 4
 
-[metrics]
-store_url = "http://influxdb:8086"
-store_name = "metrics"
+[metrics.influxdb]
+url = "http://influxdb:8086"
+db = "metrics"

--- a/configs/docker-dev.toml
+++ b/configs/docker-dev.toml
@@ -23,3 +23,7 @@ model_type = "M3"
 
 [model]
 size = 4
+
+[metrics]
+store_url = "http://influxdb:8086"
+store_name = "metrics"

--- a/configs/docker-dev.toml
+++ b/configs/docker-dev.toml
@@ -24,6 +24,6 @@ model_type = "M3"
 [model]
 size = 4
 
-[metrics]
-store_url = "http://influxdb:8086"
-store_name = "metrics"
+[metrics.influxdb]
+url = "http://influxdb:8086"
+db = "metrics"

--- a/configs/docker-release.toml
+++ b/configs/docker-release.toml
@@ -23,3 +23,7 @@ model_type = "M3"
 
 [model]
 size = 4
+
+[metrics]
+store_url = "http://influxdb:8086"
+store_name = "metrics"

--- a/configs/docker-release.toml
+++ b/configs/docker-release.toml
@@ -24,6 +24,6 @@ model_type = "M3"
 [model]
 size = 4
 
-[metrics]
-store_url = "http://influxdb:8086"
-store_name = "metrics"
+[metrics.influxdb]
+url = "http://influxdb:8086"
+db = "metrics"

--- a/k8s/coordinator/development/config.toml
+++ b/k8s/coordinator/development/config.toml
@@ -23,3 +23,7 @@ model_type = "M3"
 
 [model]
 size = 4
+
+[metrics]
+store_url = "http://influxdb:8086"
+store_name = "metrics"

--- a/k8s/coordinator/development/config.toml
+++ b/k8s/coordinator/development/config.toml
@@ -24,6 +24,6 @@ model_type = "M3"
 [model]
 size = 4
 
-[metrics]
-store_url = "http://influxdb:8086"
-store_name = "metrics"
+[metrics.influxdb]
+url = "http://influxdb:8086"
+db = "metrics"

--- a/rust/src/bin/main.rs
+++ b/rust/src/bin/main.rs
@@ -25,6 +25,7 @@ async fn main() {
         api: api_settings,
         log: log_settings,
         model: model_settings,
+        metrics: _metrics_settings,
     } = Settings::new(opt.config_path).unwrap_or_else(|err| {
         eprintln!("{}", err);
         process::exit(1);

--- a/rust/src/settings.rs
+++ b/rust/src/settings.rs
@@ -34,6 +34,7 @@ pub struct Settings {
     pub mask: MaskSettings,
     pub log: LoggingSettings,
     pub model: ModelSettings,
+    #[validate]
     pub metrics: MetricsSettings,
 }
 
@@ -437,16 +438,18 @@ pub struct ModelSettings {
     pub size: usize,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Validate)]
 /// Metrics settings.
 pub struct MetricsSettings {
+    #[validate]
     /// Settings for the InfluxDB backend.
     pub influxdb: InfluxSettings,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Validate)]
 /// InfluxDB settings.
 pub struct InfluxSettings {
+    #[validate(url)]
     /// The URL where InfluxDB is running.
     ///
     /// # Examples

--- a/rust/src/settings.rs
+++ b/rust/src/settings.rs
@@ -452,7 +452,7 @@ pub struct MetricsSettings {
     ///
     /// **Environment variable**
     /// ```text
-    /// XAYNET_API__STORE_URL=http://localhost:8086
+    /// XAYNET_METRICS__STORE_URL=http://localhost:8086
     /// ```
     pub store_url: String,
 
@@ -468,7 +468,7 @@ pub struct MetricsSettings {
     ///
     /// **Environment variable**
     /// ```text
-    /// XAYNET_API__STORE_NAME=test
+    /// XAYNET_METRICS__STORE_NAME=test
     /// ```
     pub store_name: String,
 }

--- a/rust/src/settings.rs
+++ b/rust/src/settings.rs
@@ -440,37 +440,44 @@ pub struct ModelSettings {
 #[derive(Debug, Deserialize)]
 /// Metrics settings.
 pub struct MetricsSettings {
-    /// The URL address of the metrics store.
-    ///
-    /// # Examples
-    ///
-    /// **TOML**
-    /// ```text
-    /// [metrics]
-    /// store_url = "http://localhost:8086"
-    /// ```
-    ///
-    /// **Environment variable**
-    /// ```text
-    /// XAYNET_METRICS__STORE_URL=http://localhost:8086
-    /// ```
-    pub store_url: String,
+    /// Settings for the InfluxDB backend.
+    pub influxdb: InfluxSettings,
+}
 
-    /// The name of the metrics store.
+#[derive(Debug, Deserialize)]
+/// InfluxDB settings.
+pub struct InfluxSettings {
+    /// The URL where InfluxDB is running.
     ///
     /// # Examples
     ///
     /// **TOML**
     /// ```text
-    /// [metrics]
-    /// store_name = "test"
+    /// [metrics.influxdb]
+    /// url = "http://localhost:8086"
     /// ```
     ///
     /// **Environment variable**
     /// ```text
-    /// XAYNET_METRICS__STORE_NAME=test
+    /// XAYNET_METRICS__INFLUXDB__URL=http://localhost:8086
     /// ```
-    pub store_name: String,
+    pub url: String,
+
+    /// The InfluxDB database name.
+    ///
+    /// # Examples
+    ///
+    /// **TOML**
+    /// ```text
+    /// [metrics.influxdb]
+    /// db = "test"
+    /// ```
+    ///
+    /// **Environment variable**
+    /// ```text
+    /// XAYNET_METRICS__INFLUXDB__DB=test
+    /// ```
+    pub db: String,
 }
 
 #[derive(Debug, Deserialize)]

--- a/rust/src/settings.rs
+++ b/rust/src/settings.rs
@@ -34,6 +34,7 @@ pub struct Settings {
     pub mask: MaskSettings,
     pub log: LoggingSettings,
     pub model: ModelSettings,
+    pub metrics: MetricsSettings,
 }
 
 impl Settings {
@@ -434,6 +435,42 @@ pub struct ModelSettings {
     /// XAYNET_MODEL__SIZE=100
     /// ```
     pub size: usize,
+}
+
+#[derive(Debug, Deserialize)]
+/// Metrics settings.
+pub struct MetricsSettings {
+    /// The URL address of the metrics store.
+    ///
+    /// # Examples
+    ///
+    /// **TOML**
+    /// ```text
+    /// [metrics]
+    /// store_url = "http://localhost:8086"
+    /// ```
+    ///
+    /// **Environment variable**
+    /// ```text
+    /// XAYNET_API__STORE_URL=http://localhost:8086
+    /// ```
+    pub store_url: String,
+
+    /// The name of the metrics store.
+    ///
+    /// # Examples
+    ///
+    /// **TOML**
+    /// ```text
+    /// [metrics]
+    /// store_name = "test"
+    /// ```
+    ///
+    /// **Environment variable**
+    /// ```text
+    /// XAYNET_API__STORE_NAME=test
+    /// ```
+    pub store_name: String,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
Adds a settings struct for `[metrics.influxdb]` settings

```rust
pub struct InfluxSettings {
    /// The URL where InfluxDB is running.
    ///
    /// # Examples
    ///
    /// **TOML**
    /// ```text
    /// [metrics.influxdb]
    /// url = "http://localhost:8086"
    /// ```
    ///
    /// **Environment variable**
    /// ```text
    /// XAYNET_METRICS__INFLUXDB__URL=http://localhost:8086
    /// ```
    pub url: String,

    /// The InfluxDB database name.
    ///
    /// # Examples
    ///
    /// **TOML**
    /// ```text
    /// [metrics.influxdb]
    /// db = "test"
    /// ```
    ///
    /// **Environment variable**
    /// ```text
    /// XAYNET_METRICS__INFLUXDB__DB=test
    /// ```
    pub db: String,
}

```