### PR TITLE
Move coordinator state and I/O into the Shared struct

### DIFF
--- a/rust/src/state_machine/phases/mod.rs
+++ b/rust/src/state_machine/phases/mod.rs
@@ -72,7 +72,8 @@ pub struct IO {
     pub(in crate::state_machine) events: EventPublisher,
 }
 
-/// A struct that contains the coordinator state and the I/O interfaces.
+/// A struct that contains the coordinator state and the I/O interfaces that is shared and
+/// accessible by all `PhaseState`s.
 #[derive(Debug)]
 pub struct Shared {
     /// The coordinator state.

--- a/rust/src/state_machine/phases/shutdown.rs
+++ b/rust/src/state_machine/phases/shutdown.rs
@@ -1,7 +1,5 @@
 use crate::state_machine::{
-    coordinator::CoordinatorState,
-    phases::{Phase, PhaseName, PhaseState},
-    requests::RequestReceiver,
+    phases::{Phase, PhaseName, PhaseState, Shared},
     StateError,
     StateMachine,
 };
@@ -19,8 +17,8 @@ impl Phase for PhaseState<Shutdown> {
     /// See the [module level documentation](../index.html) for more details.
     async fn run(&mut self) -> Result<(), StateError> {
         // clear the request channel
-        self.request_rx.close();
-        while self.request_rx.recv().await.is_some() {}
+        self.shared.io.request_rx.close();
+        while self.shared.io.request_rx.recv().await.is_some() {}
         Ok(())
     }
 
@@ -31,12 +29,11 @@ impl Phase for PhaseState<Shutdown> {
 
 impl PhaseState<Shutdown> {
     /// Creates a new shutdown state.
-    pub fn new(coordinator_state: CoordinatorState, request_rx: RequestReceiver) -> Self {
+    pub fn new(shared: Shared) -> Self {
         info!("state transition");
         Self {
             inner: Shutdown,
-            coordinator_state,
-            request_rx,
+            shared,
         }
     }
 }

--- a/rust/src/state_machine/requests.rs
+++ b/rust/src/state_machine/requests.rs
@@ -111,7 +111,7 @@ impl From<MessageOwned> for StateMachineRequest {
 /// A handle to send requests to the [`StateMachine`].
 ///
 /// [`StateMachine`]: crate::state_machine
-#[derive(Clone, From)]
+#[derive(Clone, From, Debug)]
 pub struct RequestSender(mpsc::UnboundedSender<(Request<StateMachineRequest>, ResponseSender)>);
 
 impl RequestSender {
@@ -148,7 +148,7 @@ pub(in crate::state_machine) type ResponseSender = oneshot::Sender<StateMachineR
 /// requests.
 ///
 /// [`StateMachine`]: crate::state_machine
-#[derive(From)]
+#[derive(From, Debug)]
 pub struct RequestReceiver(mpsc::UnboundedReceiver<(Request<StateMachineRequest>, ResponseSender)>);
 
 impl Stream for RequestReceiver {

--- a/rust/src/state_machine/tests/builder.rs
+++ b/rust/src/state_machine/tests/builder.rs
@@ -2,10 +2,10 @@ use crate::{
     crypto::encrypt::EncryptKeyPair,
     mask::config::MaskConfig,
     state_machine::{
-        coordinator::{CoordinatorState, RoundSeed},
+        coordinator::RoundSeed,
         events::EventSubscriber,
-        phases::{self, Handler, Phase, PhaseState},
-        requests::{RequestReceiver, RequestSender},
+        phases::{self, Handler, Phase, PhaseState, Shared},
+        requests::RequestSender,
         tests::utils,
         StateMachine,
     },
@@ -13,21 +13,20 @@ use crate::{
 
 #[derive(Debug)]
 pub struct StateMachineBuilder<P> {
-    coordinator_state: CoordinatorState,
+    shared: Shared,
+    request_tx: RequestSender,
     event_subscriber: EventSubscriber,
     phase_state: P,
 }
 
 impl StateMachineBuilder<phases::Idle> {
     pub fn new() -> Self {
-        let (coordinator_state, event_subscriber) = CoordinatorState::new(
-            utils::pet_settings(),
-            utils::mask_settings(),
-            utils::model_settings(),
-        );
+        let (shared, event_subscriber, request_tx) = utils::init_shared();
+
         let phase_state = phases::Idle;
         StateMachineBuilder {
-            coordinator_state,
+            shared,
+            request_tx,
             event_subscriber,
             phase_state,
         }
@@ -41,17 +40,16 @@ where
 {
     pub fn build(self) -> (StateMachine, RequestSender, EventSubscriber) {
         let Self {
-            mut coordinator_state,
+            mut shared,
+            request_tx,
             event_subscriber,
             phase_state,
         } = self;
 
-        let (request_rx, request_tx) = RequestReceiver::new();
-
         // Make sure the events that the listeners have are up to date
-        let events = &mut coordinator_state.events;
-        events.broadcast_keys(coordinator_state.keys.clone());
-        events.broadcast_params(coordinator_state.round_params.clone());
+        let events = &mut shared.io.events;
+        events.broadcast_keys(shared.state.keys.clone());
+        events.broadcast_params(shared.state.round_params.clone());
         events.broadcast_phase(<PhaseState<P> as Phase>::NAME);
         // Also re-emit the other events in case the round ID changed
         let scalar = event_subscriber.scalar_listener().get_latest().event;
@@ -67,8 +65,7 @@ where
 
         let state = PhaseState {
             inner: phase_state,
-            coordinator_state,
-            request_rx,
+            shared,
         };
 
         let state_machine = StateMachine::from(state);
@@ -78,64 +75,66 @@ where
 
     #[allow(dead_code)]
     pub fn with_keys(mut self, keys: EncryptKeyPair) -> Self {
-        self.coordinator_state.round_params.pk = keys.public.clone();
-        self.coordinator_state.keys = keys.clone();
+        self.shared.state.round_params.pk = keys.public.clone();
+        self.shared.state.keys = keys.clone();
         self
     }
 
     pub fn with_round_id(mut self, id: u64) -> Self {
-        self.coordinator_state.set_round_id(id);
+        self.shared.set_round_id(id);
         self
     }
 
     pub fn with_sum_ratio(mut self, sum_ratio: f64) -> Self {
-        self.coordinator_state.round_params.sum = sum_ratio;
+        self.shared.state.round_params.sum = sum_ratio;
         self
     }
 
     pub fn with_update_ratio(mut self, update_ratio: f64) -> Self {
-        self.coordinator_state.round_params.update = update_ratio;
+        self.shared.state.round_params.update = update_ratio;
         self
     }
 
     pub fn with_expected_participants(mut self, expected_participants: usize) -> Self {
-        self.coordinator_state.expected_participants = expected_participants;
+        self.shared.state.expected_participants = expected_participants;
         self
     }
 
     pub fn with_seed(mut self, seed: RoundSeed) -> Self {
-        self.coordinator_state.round_params.seed = seed;
+        self.shared.state.round_params.seed = seed;
         self
     }
 
     pub fn with_min_sum(mut self, min_sum: usize) -> Self {
-        self.coordinator_state.min_sum_count = min_sum;
+        self.shared.state.min_sum_count = min_sum;
         self
     }
 
     pub fn with_mask_config(mut self, mask_config: MaskConfig) -> Self {
-        self.coordinator_state.mask_config = mask_config;
+        self.shared.state.mask_config = mask_config;
         self
     }
 
     pub fn with_min_update(mut self, min_update: usize) -> Self {
-        self.coordinator_state.min_update_count = min_update;
+        self.shared.state.min_update_count = min_update;
         self
     }
 
     pub fn with_model_size(mut self, model_size: usize) -> Self {
-        self.coordinator_state.model_size = model_size;
+        self.shared.state.model_size = model_size;
         self
     }
 
     pub fn with_phase<S>(self, phase_state: S) -> StateMachineBuilder<S> {
         let Self {
-            coordinator_state,
+            shared,
+            request_tx,
             event_subscriber,
             ..
         } = self;
         StateMachineBuilder {
-            coordinator_state,
+            shared,
+            request_tx,
             event_subscriber,
             phase_state,
         }


### PR DESCRIPTION
The implantation of the suggestion in #488

If everyone likes it I would merge this pr first. It will save me a lot of `#[cfg(feature = "metrics")]` annotations in #488 :)