### PR TITLE
Replace `Proxy` by the `ApiClient` trait

### DIFF
--- a/.github/workflows/dockercompose-validation.yml
+++ b/.github/workflows/dockercompose-validation.yml
@@ -7,6 +7,7 @@ on:
     
 jobs:
   check-docker-compose:
+    if: false # skip job (remove after the move to cargo workspaces)
     name: docker-compose validation
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dockerfile-validation.yml
+++ b/.github/workflows/dockerfile-validation.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   lint:
+    if: false # skip job (remove after the move to cargo workspaces)
     name: Dockerfiles linting
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dockerhub-master.yml
+++ b/.github/workflows/dockerhub-master.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build-tag-push-master:
+    if: false # skip job (remove after the move to cargo workspaces)
     name: build-tag-push-master
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dockerhub-pr.yml
+++ b/.github/workflows/dockerhub-pr.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build-by-request:
+    if: false # skip job (remove after the move to cargo workspaces)
     name: build-by-request
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dockerhub-release.yml
+++ b/.github/workflows/dockerhub-release.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build-tag-push-release:
+    if: false # skip job (remove after the move to cargo workspaces)
     name: build-tag-push-release
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/kubernetes-manifests.yml
+++ b/.github/workflows/kubernetes-manifests.yml
@@ -7,6 +7,7 @@ on:
     
 jobs:
   k8s-kustomize-validation:
+    if: false # skip job (remove after the move to cargo workspaces)
     name: Kubernetes manifests validation
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rust-audit-cron.yml
+++ b/.github/workflows/rust-audit-cron.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   audit:
+    if: false # skip job (remove after the move to cargo workspaces)
     name: Rust Audit
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rust-audit-pr.yml
+++ b/.github/workflows/rust-audit-pr.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   audit:
+    if: false # skip job (remove after the move to cargo workspaces)
     name: Rust Audit
     runs-on: ubuntu-latest
     steps:

--- a/rust/examples/test-drive-net.rs
+++ b/rust/examples/test-drive-net.rs
@@ -5,7 +5,11 @@ use structopt::StructOpt;
 use tokio::signal;
 use tracing_subscriber::*;
 use xaynet::{
-    client::{Client, ClientError},
+    client::{
+        api::{HttpApiClient, HttpApiClientError},
+        Client,
+        ClientError,
+    },
     mask::{FromPrimitives, Model},
 };
 
@@ -34,7 +38,7 @@ struct Opt {
 /// learning session, intended for use as a mini integration test.
 /// It assumes that a coordinator is already running.
 #[tokio::main]
-async fn main() -> Result<(), ClientError> {
+async fn main() -> Result<(), ClientError<HttpApiClientError>> {
     let _fmt_subscriber = FmtSubscriber::builder()
         .with_env_filter(EnvFilter::from_default_env())
         .with_ansi(true)
@@ -48,7 +52,7 @@ async fn main() -> Result<(), ClientError> {
 
     let mut clients = Vec::with_capacity(opt.nb_client as usize);
     for id in 0..opt.nb_client {
-        let mut client = Client::new_with_addr(opt.period, id, &opt.url)?;
+        let mut client = Client::new(opt.period, id, HttpApiClient::new(&opt.url))?;
         client.local_model = Some(model.clone());
         let join_hdl = tokio::spawn(async move {
             tokio::select! {

--- a/rust/src/client/api/http.rs
+++ b/rust/src/client/api/http.rs
@@ -1,111 +1,14 @@
-//! Provides functionality to enable clients to communicate with a XayNet
-//! service over HTTP.
-//!
-//! See the [client module] documentation since this is a private module anyways.
-//!
-//! [client module]: ../index.html
-
 use crate::{
+    client::api::ApiClient,
     common::RoundParameters,
     crypto::ByteObject,
     mask::model::Model,
-    services::{FetchError, Fetcher, PetMessageError, PetMessageHandler},
-    state_machine::coordinator::RoundParameters,
     SumDict,
     SumParticipantPublicKey,
     UpdateSeedDict,
 };
 use reqwest::{self, Client, Response, StatusCode};
 use thiserror::Error;
-
-#[async_trait]
-pub trait ApiClient {
-    type Error: ::std::fmt::Debug + ::std::error::Error + 'static;
-
-    /// Retrieve the current round parameters
-    async fn get_round_params(&mut self) -> Result<RoundParameters, Self::Error>;
-
-    /// Retrieve the current sum dictionary, if available
-    async fn get_sums(&mut self) -> Result<Option<SumDict>, Self::Error>;
-
-    /// Retrieve the current seed dictionary for the given sum
-    /// participant, if available.
-    async fn get_seeds(
-        &mut self,
-        pk: SumParticipantPublicKey,
-    ) -> Result<Option<UpdateSeedDict>, Self::Error>;
-
-    /// Retrieve the current model/mask length, if available
-    async fn get_mask_length(&mut self) -> Result<Option<u64>, Self::Error>;
-
-    /// Retrieve the current global model, if available.
-    async fn get_model(&mut self) -> Result<Option<Model>, Self::Error>;
-
-    async fn send_message(&mut self, msg: Vec<u8>) -> Result<(), Self::Error>;
-}
-
-pub struct InMemoryApiClient {
-    fetcher: Box<dyn Fetcher + Send + Sync>,
-    message_handler: Box<dyn PetMessageHandler + Send + Sync>,
-}
-
-impl InMemoryApiClient {
-    #[allow(dead_code)]
-    pub fn new(
-        fetcher: impl Fetcher + 'static + Send + Sync,
-        message_handler: impl PetMessageHandler + 'static + Send + Sync,
-    ) -> Self {
-        Self {
-            fetcher: Box::new(fetcher),
-            message_handler: Box::new(message_handler),
-        }
-    }
-}
-
-#[derive(Debug, Error)]
-pub enum InMemoryClientError {
-    #[error("a PET message could not be processed by the coordinator: {0}")]
-    Message(#[from] PetMessageError),
-
-    #[error("failed to fetch data from the coordinator: {0}")]
-    Fetch(#[from] FetchError),
-}
-
-#[async_trait]
-impl ApiClient for InMemoryApiClient {
-    type Error = InMemoryClientError;
-
-    async fn get_round_params(&mut self) -> Result<RoundParameters, Self::Error> {
-        Ok(self.fetcher.round_params().await?)
-    }
-
-    async fn get_sums(&mut self) -> Result<Option<SumDict>, Self::Error> {
-        Ok(self.fetcher.sum_dict().await?.map(|arc| (*arc).clone()))
-    }
-
-    async fn get_seeds(
-        &mut self,
-        pk: SumParticipantPublicKey,
-    ) -> Result<Option<UpdateSeedDict>, Self::Error> {
-        Ok(self
-            .fetcher
-            .seed_dict()
-            .await?
-            .and_then(|dict| dict.get(&pk).cloned()))
-    }
-
-    async fn get_mask_length(&mut self) -> Result<Option<u64>, Self::Error> {
-        Ok(self.fetcher.mask_length().await?.map(|res| res as u64))
-    }
-
-    async fn get_model(&mut self) -> Result<Option<Model>, Self::Error> {
-        Ok(self.fetcher.model().await?.map(|arc| (*arc).clone()))
-    }
-
-    async fn send_message(&mut self, message: Vec<u8>) -> Result<(), Self::Error> {
-        Ok(self.message_handler.handle_message(message).await?)
-    }
-}
 
 #[derive(Debug)]
 /// Manages client requests over HTTP.

--- a/rust/src/client/api/http.rs
+++ b/rust/src/client/api/http.rs
@@ -11,9 +11,12 @@ use reqwest::{self, Client, Response, StatusCode};
 use thiserror::Error;
 
 #[derive(Debug)]
-/// Manages client requests over HTTP.
+/// A client that communicates with the coordinator's API via
+/// HTTP(S)
 pub struct HttpApiClient {
+    /// HTTP client
     client: Client,
+    /// Coordinator URL
     address: String,
 }
 
@@ -29,6 +32,7 @@ impl HttpApiClient {
     }
 }
 
+/// Error returned by an [`HttpApiClient`]
 #[derive(Debug, Error)]
 pub enum HttpApiClientError {
     #[error("failed to deserialize data: {0}")]

--- a/rust/src/client/api/in_memory.rs
+++ b/rust/src/client/api/in_memory.rs
@@ -10,6 +10,8 @@ use crate::{
 
 use thiserror::Error;
 
+/// A client that communicates with the coordinator's API via
+/// in-memory channels.
 pub struct InMemoryApiClient {
     fetcher: Box<dyn Fetcher + Send + Sync>,
     message_handler: Box<dyn PetMessageHandler + Send + Sync>,
@@ -28,6 +30,7 @@ impl InMemoryApiClient {
     }
 }
 
+/// Error returned by an [`InMemoryApiClient`]
 #[derive(Debug, Error)]
 pub enum InMemoryApiClientError {
     #[error("a PET message could not be processed by the coordinator: {0}")]

--- a/rust/src/client/api/in_memory.rs
+++ b/rust/src/client/api/in_memory.rs
@@ -1,0 +1,74 @@
+use crate::{
+    client::api::ApiClient,
+    mask::model::Model,
+    services::{FetchError, Fetcher, PetMessageError, PetMessageHandler},
+    common::RoundParameters,
+    SumDict,
+    SumParticipantPublicKey,
+    UpdateSeedDict,
+};
+
+use thiserror::Error;
+
+pub struct InMemoryApiClient {
+    fetcher: Box<dyn Fetcher + Send + Sync>,
+    message_handler: Box<dyn PetMessageHandler + Send + Sync>,
+}
+
+impl InMemoryApiClient {
+    #[allow(dead_code)]
+    pub fn new(
+        fetcher: impl Fetcher + 'static + Send + Sync,
+        message_handler: impl PetMessageHandler + 'static + Send + Sync,
+    ) -> Self {
+        Self {
+            fetcher: Box::new(fetcher),
+            message_handler: Box::new(message_handler),
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum InMemoryApiClientError {
+    #[error("a PET message could not be processed by the coordinator: {0}")]
+    Message(#[from] PetMessageError),
+
+    #[error("failed to fetch data from the coordinator: {0}")]
+    Fetch(#[from] FetchError),
+}
+
+#[async_trait]
+impl ApiClient for InMemoryApiClient {
+    type Error = InMemoryApiClientError;
+
+    async fn get_round_params(&mut self) -> Result<RoundParameters, Self::Error> {
+        Ok(self.fetcher.round_params().await?)
+    }
+
+    async fn get_sums(&mut self) -> Result<Option<SumDict>, Self::Error> {
+        Ok(self.fetcher.sum_dict().await?.map(|arc| (*arc).clone()))
+    }
+
+    async fn get_seeds(
+        &mut self,
+        pk: SumParticipantPublicKey,
+    ) -> Result<Option<UpdateSeedDict>, Self::Error> {
+        Ok(self
+            .fetcher
+            .seed_dict()
+            .await?
+            .and_then(|dict| dict.get(&pk).cloned()))
+    }
+
+    async fn get_mask_length(&mut self) -> Result<Option<u64>, Self::Error> {
+        Ok(self.fetcher.mask_length().await?.map(|res| res as u64))
+    }
+
+    async fn get_model(&mut self) -> Result<Option<Model>, Self::Error> {
+        Ok(self.fetcher.model().await?.map(|arc| (*arc).clone()))
+    }
+
+    async fn send_message(&mut self, message: Vec<u8>) -> Result<(), Self::Error> {
+        Ok(self.message_handler.handle_message(message).await?)
+    }
+}

--- a/rust/src/client/api/mod.rs
+++ b/rust/src/client/api/mod.rs
@@ -1,9 +1,4 @@
-//! Provides functionality to enable clients to communicate with a XayNet
-//! service over HTTP.
-//!
-//! See the [client module] documentation since this is a private module anyways.
-//!
-//! [client module]: ../index.html
+//! This module provides clients for the Xaynet coordinator API.
 
 mod http;
 mod in_memory;
@@ -21,6 +16,7 @@ use crate::{
     UpdateSeedDict,
 };
 
+/// An interface that API clients implement
 #[async_trait]
 pub trait ApiClient {
     type Error: ::std::fmt::Debug + ::std::error::Error + 'static;
@@ -44,5 +40,6 @@ pub trait ApiClient {
     /// Retrieve the current global model, if available.
     async fn get_model(&mut self) -> Result<Option<Model>, Self::Error>;
 
+    /// Send an encrypted and signed PET message to the coordinator.
     async fn send_message(&mut self, msg: Vec<u8>) -> Result<(), Self::Error>;
 }

--- a/rust/src/client/api/mod.rs
+++ b/rust/src/client/api/mod.rs
@@ -1,12 +1,12 @@
 //! This module provides clients for the Xaynet coordinator API.
 
 mod http;
-mod in_memory;
+pub use self::http::{HttpApiClient, HttpApiClientError};
 
-pub use self::{
-    http::{HttpApiClient, HttpApiClientError},
-    in_memory::{InMemoryApiClient, InMemoryApiClientError},
-};
+#[cfg(test)]
+mod in_memory;
+#[cfg(test)]
+pub use self::in_memory::{InMemoryApiClient, InMemoryApiClientError};
 
 use crate::{
     mask::model::Model,

--- a/rust/src/client/api/mod.rs
+++ b/rust/src/client/api/mod.rs
@@ -1,0 +1,48 @@
+//! Provides functionality to enable clients to communicate with a XayNet
+//! service over HTTP.
+//!
+//! See the [client module] documentation since this is a private module anyways.
+//!
+//! [client module]: ../index.html
+
+mod http;
+mod in_memory;
+
+pub use self::{
+    http::{HttpApiClient, HttpApiClientError},
+    in_memory::{InMemoryApiClient, InMemoryApiClientError},
+};
+
+use crate::{
+    mask::model::Model,
+    common::RoundParameters,
+    SumDict,
+    SumParticipantPublicKey,
+    UpdateSeedDict,
+};
+
+#[async_trait]
+pub trait ApiClient {
+    type Error: ::std::fmt::Debug + ::std::error::Error + 'static;
+
+    /// Retrieve the current round parameters
+    async fn get_round_params(&mut self) -> Result<RoundParameters, Self::Error>;
+
+    /// Retrieve the current sum dictionary, if available
+    async fn get_sums(&mut self) -> Result<Option<SumDict>, Self::Error>;
+
+    /// Retrieve the current seed dictionary for the given sum
+    /// participant, if available.
+    async fn get_seeds(
+        &mut self,
+        pk: SumParticipantPublicKey,
+    ) -> Result<Option<UpdateSeedDict>, Self::Error>;
+
+    /// Retrieve the current model/mask length, if available
+    async fn get_mask_length(&mut self) -> Result<Option<u64>, Self::Error>;
+
+    /// Retrieve the current global model, if available.
+    async fn get_model(&mut self) -> Result<Option<Model>, Self::Error>;
+
+    async fn send_message(&mut self, msg: Vec<u8>) -> Result<(), Self::Error>;
+}

--- a/rust/src/client/mobile_client/client.rs
+++ b/rust/src/client/mobile_client/client.rs
@@ -1,5 +1,6 @@
 use crate::{
     client::{
+        api::ApiClient,
         mobile_client::participant::{
             Awaiting,
             Participant,
@@ -9,7 +10,6 @@ use crate::{
             Sum2,
             Update,
         },
-        ApiClient,
         ClientError,
     },
     common::RoundParameters,

--- a/rust/src/client/mobile_client/mod.rs
+++ b/rust/src/client/mobile_client/mod.rs
@@ -3,11 +3,11 @@ pub mod participant;
 
 use crate::{
     client::{
+        api::HttpApiClient,
         mobile_client::{
             client::{get_global_model, ClientStateMachine, LocalModel},
             participant::ParticipantSettings,
         },
-        request::HttpApiClient,
     },
     crypto::{SecretSigningKey, SigningKeyPair},
     mask::model::Model,

--- a/rust/src/client/mobile_client/mod.rs
+++ b/rust/src/client/mobile_client/mod.rs
@@ -7,14 +7,14 @@ use crate::{
             client::{get_global_model, ClientStateMachine, LocalModel},
             participant::ParticipantSettings,
         },
-        Proxy,
+        request::HttpApiClient,
     },
     crypto::{SecretSigningKey, SigningKeyPair},
     mask::model::Model,
 };
 
 pub struct MobileClient {
-    proxy: Proxy,
+    api: HttpApiClient,
     local_model: LocalModelCache,
     client_state: ClientStateMachine,
 }
@@ -31,10 +31,10 @@ impl MobileClient {
     }
 
     fn new(url: &str, client_state: ClientStateMachine) -> Self {
-        let proxy = Proxy::new_remote(url);
+        let api = HttpApiClient::new(url);
 
         Self {
-            proxy,
+            api,
             client_state,
             local_model: LocalModelCache(None),
         }
@@ -45,21 +45,21 @@ impl MobileClient {
     }
 
     pub fn get_global_model(&mut self) -> Option<Model> {
-        Self::runtime().block_on(async { get_global_model(&mut self.proxy).await })
+        Self::runtime().block_on(async { get_global_model(&mut self.api).await })
     }
 
     pub fn perform_task(self) -> Self {
         let MobileClient {
-            mut proxy,
+            mut api,
             mut local_model,
             client_state,
         } = self;
 
-        let client_state = Self::runtime()
-            .block_on(async { client_state.next(&mut proxy, &mut local_model).await });
+        let client_state =
+            Self::runtime().block_on(async { client_state.next(&mut api, &mut local_model).await });
 
         Self {
-            proxy,
+            api,
             local_model,
             client_state,
         }

--- a/rust/src/client/mod.rs
+++ b/rust/src/client/mod.rs
@@ -32,34 +32,6 @@
 //! coupled with the workings of the C-API SDK, but this may well change in a
 //! future version to be more independently reusable.
 //!
-//! ## Requests via Proxy
-//! There is a [`Proxy`] which a [`Client`] can use to communicate with the
-//! service. To summarise, the proxy:
-//!
-//! * Wraps either an in-memory service (for local comms) or a _client request_
-//! object (for remote comms over HTTP).
-//! * In the latter case, deals with logging and wrapping of network errors.
-//! * Deals with deserialization
-//!
-//! The client request object is responsible for building the HTTP request and
-//! extracting the response body. As an example:
-//!
-//! ```no_rust
-//! async fn get_sums(&self) -> Result<Option<bytes::Bytes>, reqwest::Error>
-//! ```
-//!
-//! issues a GET request for the sum dictionary. The return type reflects the
-//! presence of networking `Error`s, but also the situation where the dictionary
-//! is simply just not yet available on the service. That is, the type also
-//! reflects the _optionality_ of the data availability.
-//!
-//! [`Proxy`] essentially takes this (deserializing the `Bytes` into a `SumDict`
-//! while handling `Error`s into [`ClientError`]s) to expose the overall method
-//!
-//! ```no_rust
-//! async fn get_sums(&self) -> Result<Option<SumDict>, ClientError>
-//! ```
-//!
 //! [`check_task`]: #method.check_task
 //! [`compose_update_message`]: #method.compose_update_message
 //! [`compose_sum_message`]: #method.compose_sum_message

--- a/rust/src/client/mod.rs
+++ b/rust/src/client/mod.rs
@@ -84,8 +84,7 @@ use crate::{
 #[doc(hidden)]
 pub mod mobile_client;
 
-pub mod request;
-pub use request::ApiClient;
+pub mod api;
 
 mod participant;
 pub use participant::{Participant, Task};
@@ -117,7 +116,7 @@ pub enum ClientError<E: ::std::error::Error + ::std::fmt::Debug + 'static> {
 /// [`Client`] is responsible for communicating with the service, deserialising
 /// its messages and delegating their processing to the underlying
 /// [`Participant`].
-pub struct Client<C: ApiClient> {
+pub struct Client<C: api::ApiClient> {
     /// The underlying [`Participant`]
     pub(crate) participant: Participant,
 
@@ -147,7 +146,7 @@ pub struct Client<C: ApiClient> {
 
 impl<C> Client<C>
 where
-    C: ApiClient,
+    C: api::ApiClient,
 {
     /// Create a new [`Client`] with a given service address.
     ///

--- a/rust/src/client/mod.rs
+++ b/rust/src/client/mod.rs
@@ -67,7 +67,7 @@
 //! [`start()`]: #method.start
 //! [`during_round()`]: #method.during_round
 
-use std::{default::Default, time::Duration};
+use std::time::Duration;
 
 use thiserror::Error;
 use tokio::time;
@@ -76,7 +76,6 @@ use crate::{
     crypto::ByteObject,
     mask::model::Model,
     sdk::api::CachedModel,
-    services::{FetchError, Fetcher, PetMessageError, PetMessageHandler},
     CoordinatorPublicKey,
     InitError,
     PetError,
@@ -85,46 +84,26 @@ use crate::{
 #[doc(hidden)]
 pub mod mobile_client;
 
-mod request;
-pub use request::Proxy;
+pub mod request;
+pub use request::ApiClient;
 
 mod participant;
 pub use participant::{Participant, Task};
 
 #[derive(Debug, Error)]
 /// Client-side errors
-pub enum ClientError {
+pub enum ClientError<E: ::std::error::Error + ::std::fmt::Debug + 'static> {
     #[error("failed to initialise participant: {0}")]
     /// Failed to initialise participant.
     ParticipantInitErr(InitError),
 
-    #[error("Failed to retrieve data: {0}")]
-    /// Failed to retrieve data.
-    Fetch(FetchError),
-
-    #[error("Failed to handle PET message: {0}")]
+    #[error("an API request failed: {0}")]
     /// Failed to handle PET message.
-    PetMessage(PetMessageError),
+    Api(#[from] E),
 
     #[error("error arising from participant")]
     /// Error arising from participant.
     ParticipantErr(PetError),
-
-    #[error("failed to deserialise service data: {0}")]
-    /// Failed to deserialise service data.
-    DeserialiseErr(bincode::Error),
-
-    #[error("network-related error: {0}")]
-    /// Network-related error.
-    NetworkErr(reqwest::Error),
-
-    #[error("failed to parse service data")]
-    /// Failed to parse service data.
-    ParseErr,
-
-    #[error("unexpected client error")]
-    /// Unexpected client error.
-    GeneralErr,
 
     #[error("{0} not ready yet")]
     TooEarly(&'static str),
@@ -138,7 +117,7 @@ pub enum ClientError {
 /// [`Client`] is responsible for communicating with the service, deserialising
 /// its messages and delegating their processing to the underlying
 /// [`Participant`].
-pub struct Client {
+pub struct Client<C: ApiClient> {
     /// The underlying [`Participant`]
     pub(crate) participant: Participant,
 
@@ -162,71 +141,14 @@ pub struct Client {
     /// Identifier for this client
     id: u32,
 
-    /// Proxy for the service
-    proxy: Proxy,
+    /// Client for the services
+    client: C,
 }
 
-impl Default for Client {
-    fn default() -> Self {
-        Self {
-            participant: Participant::default(),
-            interval: time::interval(Duration::from_secs(1)),
-            coordinator_pk: CoordinatorPublicKey::zeroed(),
-            has_new_coord_pk_since_last_check: false,
-            global_model: None,
-            cached_model: None,
-            has_new_global_model_since_last_check: false,
-            has_new_global_model_since_last_cache: false,
-            local_model: None,
-            scalar: 1.0,
-            id: 0,
-            proxy: Proxy::new_remote("http://127.0.0.1:3030"),
-        }
-    }
-}
-
-impl Client {
-    #[allow(dead_code)]
-    /// Create a new [`Client`] that connects to a default service address.
-    ///
-    /// * `period`: time period at which to poll for service data, in seconds.
-    ///
-    /// # Errors
-    /// Returns a `ParticipantInitErr` if the underlying [`Participant`] is
-    /// unable to initialize.
-    pub(crate) fn new(period: u64) -> Result<Self, ClientError> {
-        Ok(Self {
-            participant: Participant::new().map_err(ClientError::ParticipantInitErr)?,
-            interval: time::interval(Duration::from_secs(period)),
-            ..Self::default()
-        })
-    }
-
-    /// Create a new [`Client`] with a given service handle.
-    ///
-    /// * `period`: time period at which to poll for service data, in seconds.
-    /// * `id`: an ID to assign to the [`Client`].
-    /// * `fetcher`: fetcher for in-memory service proxy.
-    /// * `message_handler`: message handler for in-memory service proxy.
-    ///
-    /// # Errors
-    /// Returns a `ParticipantInitErr` if the underlying [`Participant`] is
-    /// unable to initialize.
-    pub fn new_with_hdl(
-        period: u64,
-        id: u32,
-        fetcher: impl Fetcher + 'static + Send + Sync,
-        message_handler: impl PetMessageHandler + 'static + Send + Sync,
-    ) -> Result<Self, ClientError> {
-        Ok(Self {
-            participant: Participant::new().map_err(ClientError::ParticipantInitErr)?,
-            interval: time::interval(Duration::from_secs(period)),
-            id,
-            proxy: Proxy::new_in_mem(fetcher, message_handler),
-            ..Self::default()
-        })
-    }
-
+impl<C> Client<C>
+where
+    C: ApiClient,
+{
     /// Create a new [`Client`] with a given service address.
     ///
     /// * `period`: time period at which to poll for service data, in seconds.
@@ -236,13 +158,23 @@ impl Client {
     /// # Errors
     /// Returns a `ParticipantInitErr` if the underlying [`Participant`] is
     /// unable to initialize.
-    pub fn new_with_addr(period: u64, id: u32, addr: &str) -> Result<Self, ClientError> {
+    pub fn new(period: u64, id: u32, api: C) -> Result<Self, ClientError<C::Error>> {
         Ok(Self {
             participant: Participant::new().map_err(ClientError::ParticipantInitErr)?,
             interval: time::interval(Duration::from_secs(period)),
+            coordinator_pk: CoordinatorPublicKey::zeroed(),
+            has_new_coord_pk_since_last_check: false,
+
+            global_model: None,
+            cached_model: None,
+            has_new_global_model_since_last_check: false,
+            has_new_global_model_since_last_cache: false,
+
+            local_model: None,
+            scalar: 1.0,
+
             id,
-            proxy: Proxy::new_remote(addr),
-            ..Self::default()
+            client: api,
         })
     }
 
@@ -252,7 +184,7 @@ impl Client {
     /// # Errors
     /// A [`ClientError`] may be returned when the round is not able to complete
     /// successfully.
-    pub async fn start(&mut self) -> Result<(), ClientError> {
+    pub async fn start(&mut self) -> Result<(), ClientError<C::Error>> {
         loop {
             self.during_round().await?;
         }
@@ -264,10 +196,10 @@ impl Client {
     /// # Errors
     /// A [`ClientError`] may be returned when the round is not able to complete
     /// successfully.
-    pub async fn during_round(&mut self) -> Result<Task, ClientError> {
+    pub async fn during_round(&mut self) -> Result<Task, ClientError<C::Error>> {
         debug!(client_id = %self.id, "polling for new round parameters");
         loop {
-            let model = self.proxy.get_model().await?;
+            let model = self.client.get_model().await?;
             // update our global model where necessary
             match (model, &self.global_model) {
                 (Some(new_model), None) => self.set_global_model(new_model),
@@ -278,7 +210,7 @@ impl Client {
                 _ => trace!(client_id = %self.id, "global model still fresh"),
             }
 
-            let round_params = self.proxy.get_round_params().await?;
+            let round_params = self.client.get_round_params().await?;
             if round_params.pk != self.coordinator_pk {
                 debug!(client_id = %self.id, "new round parameters received, determining task.");
                 self.coordinator_pk = round_params.pk;
@@ -305,22 +237,22 @@ impl Client {
     }
 
     /// Work flow for unselected [`Client`]s.
-    async fn unselected(&mut self) -> Result<Task, ClientError> {
+    async fn unselected(&mut self) -> Result<Task, ClientError<C::Error>> {
         debug!(client_id = %self.id, "not selected");
         Ok(Task::None)
     }
 
     /// Work flow for [`Client`]s selected as sum participants.
-    async fn summer(&mut self) -> Result<Task, ClientError> {
+    async fn summer(&mut self) -> Result<Task, ClientError<C::Error>> {
         info!(client_id = %self.id, "selected to sum");
         let msg = self.participant.compose_sum_message(&self.coordinator_pk);
         let sealed_msg = self.participant.seal_message(&self.coordinator_pk, &msg);
 
-        self.proxy.post_message(sealed_msg).await?;
+        self.client.send_message(sealed_msg).await?;
 
         debug!(client_id = %self.id, "polling for model/mask length");
         let length = loop {
-            if let Some(length) = self.proxy.get_mask_length().await? {
+            if let Some(length) = self.client.get_mask_length().await? {
                 if length > usize::MAX as u64 {
                     return Err(ClientError::ParticipantErr(PetError::InvalidModel));
                 } else {
@@ -333,7 +265,7 @@ impl Client {
 
         debug!(client_id = %self.id, "sum message sent, polling for seed dict.");
         loop {
-            if let Some(seeds) = self.proxy.get_seeds(self.participant.pk).await? {
+            if let Some(seeds) = self.client.get_seeds(self.participant.pk).await? {
                 debug!(client_id = %self.id, "seed dict received, sending sum2 message.");
                 let msg = self
                     .participant
@@ -343,7 +275,7 @@ impl Client {
                         ClientError::ParticipantErr(e)
                     })?;
                 let sealed_msg = self.participant.seal_message(&self.coordinator_pk, &msg);
-                self.proxy.post_message(sealed_msg).await?;
+                self.client.send_message(sealed_msg).await?;
 
                 info!(client_id = %self.id, "sum participant completed a round");
                 break Ok(Task::Sum);
@@ -354,7 +286,7 @@ impl Client {
     }
 
     /// Work flow for [`Client`]s selected as update participants.
-    async fn updater(&mut self) -> Result<Task, ClientError> {
+    async fn updater(&mut self) -> Result<Task, ClientError<C::Error>> {
         info!(client_id = %self.id, "selected to update");
 
         debug!(client_id = %self.id, "polling for local model");
@@ -370,7 +302,7 @@ impl Client {
 
         debug!(client_id = %self.id, "polling for sum dict");
         loop {
-            if let Some(sums) = self.proxy.get_sums().await? {
+            if let Some(sums) = self.client.get_sums().await? {
                 debug!(client_id = %self.id, "sum dict received, sending update message.");
                 let msg = self.participant.compose_update_message(
                     self.coordinator_pk,
@@ -379,7 +311,7 @@ impl Client {
                     model,
                 );
                 let sealed_msg = self.participant.seal_message(&self.coordinator_pk, &msg);
-                self.proxy.post_message(sealed_msg).await?;
+                self.client.send_message(sealed_msg).await?;
 
                 info!(client_id = %self.id, "update participant completed a round");
                 break Ok(Task::Update);

--- a/rust/src/examples.rs
+++ b/rust/src/examples.rs
@@ -160,18 +160,23 @@ the `test-drive-net` example, for illustrative purposes.
 ```no_run
 use tokio::signal;
 use xaynet::{
-    client::{Client, ClientError},
+    client::{
+        api::{HttpApiClient, HttpApiClientError},
+        Client,
+        ClientError,
+    },
     mask::{FromPrimitives, Model},
 };
 
 #[tokio::main]
-async fn main() -> Result<(), ClientError> {
+async fn main() -> Result<(), ClientError<HttpApiClientError>> {
     let len = 4_usize;
     let model = Model::from_primitives(vec![0; len].into_iter()).unwrap();
 
     let mut clients = Vec::with_capacity(20_usize);
     for id in 0..20 {
-        let mut client = Client::new_with_addr(1, id, "http://127.0.0.1:8081")?;
+        let api_client = HttpApiClient::new("http://127.0.0.1:8081");
+        let mut client = Client::new(1, id, api_client)?;
         client.local_model = Some(model.clone());
         let join_hdl = tokio::spawn(async move {
             tokio::select! {

--- a/rust/src/sdk/api.rs
+++ b/rust/src/sdk/api.rs
@@ -167,12 +167,12 @@ pub unsafe extern "C" fn new_client(address: *const c_char, period: c_ulonglong)
 /// - `1`: client panicked due to unexpected/unhandled error
 /// - `2`: client stopped due to error [`ParticipantInitErr`]
 /// - `3`: client stopped due to error [`ParticipantErr`]
-/// - `8`: client stopped due to error [`Fetch`]
-/// - `9`: client stopped due to error [`PetMessage`]
-/// - `10`: client stopped due to error [`TooEarly`]
-/// - `11`: client stopped due to error [`RoundOutdated`]
+/// - `4`: client stopped due to error [`TooEarly`]
+/// - `5`: client stopped due to error [`RoundOutdated`]
+/// - `6`: client stopped due to error [`Api`]
 ///
 /// # Safety
+///
 /// The method dereferences from the raw pointer arguments. Therefore, the behavior of the method is
 /// undefined if the arguments don't point to valid objects.
 ///
@@ -181,10 +181,9 @@ pub unsafe extern "C" fn new_client(address: *const c_char, period: c_ulonglong)
 ///
 /// [`ParticipantInitErr`]: ../../client/enum.ClientError.html#variant.ParticipantInitErr
 /// [`ParticipantErr`]: ../../client/enum.ClientError.html#variant.ParticipantErr
-/// [`Fetch`]: ../../client/enum.ClientError.html#variant.Fetch
-/// [`PetMessage`]: ../../client/enum.ClientError.html#variant.PetMessage
 /// [`TooEarly`]: ../../client/enum.ClientError.html#variant.TooEarly
 /// [`RoundOutdated`]: ../../client/enum.ClientError.html#variant.RoundOutdated
+/// [`Api`]: ../../client/enum.ClientError.html#variant.Api
 pub unsafe extern "C" fn run_client(client: *mut FFIClient) -> c_int {
     if client.is_null() {
         return -1_i32 as c_int;

--- a/rust/src/sdk/api.rs
+++ b/rust/src/sdk/api.rs
@@ -51,7 +51,7 @@ use tokio::{
 };
 
 use crate::{
-    client::{request::HttpApiClient, Client, ClientError, Task},
+    client::{api::HttpApiClient, Client, ClientError, Task},
     mask::model::{FromPrimitives, IntoPrimitives, Model},
 };
 

--- a/rust/src/services/mod.rs
+++ b/rust/src/services/mod.rs
@@ -6,7 +6,6 @@
 //!   - [`MaskLengthService`]: for fetching the length of the model
 //!   - [`ModelService`]: for fetching the last available global model
 //!   - [`RoundParamsService`]: for fetching the current round parameters
-//!   - [`ScalarService`]: for fetching the scalar used for aggregation
 //!   - [`SeedDictService`]: for fetching the seed dictionary
 //!   - [`SumDictService`]: for fetching the sum dictionary
 //! - the services for handling PET messages from the participant:


### PR DESCRIPTION
### replace `Proxy` by the `ApiClient` trait

The trait has two implementors:

- `InMemoryApiClient` that queries the coordinator services via
  in-memory channels
- `HttpApiClient` that queries the coordinator services via HTTP

The second commit renames `crate::client::request` into `create::client::api`.