### PR TITLE
Disable patch checks for codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,3 @@
+coverage:
+  status:
+    patch: off


### PR DESCRIPTION
As explained [here](https://docs.codecov.io/docs/commit-status#disabling-a-status).