### PR TITLE
CI cargo-docs improvement

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -227,7 +227,7 @@ jobs:
 
       - name: Check the building of docs
         working-directory: ./rust
-        run: cargo +nightly doc --all-features --color always
+        run: cargo +nightly doc --all-features --no-deps --color always
 
   coverage:
     name: cargo-tarpaulin


### PR DESCRIPTION
Summary:

* enabled the flag `--no-deps`  to disable the building of documentation for dependencies

Reduced time for cargo-doc step from [6m 12s](https://github.com/xaynetwork/xaynet/runs/1050319005?check_suite_focus=true) to [4m 5s](https://github.com/xaynetwork/xaynet/runs/1050409094?check_suite_focus=true)