### PR TITLE
re-introduce the coordinator public key in the message header

### DIFF
--- a/rust/xaynet-client/src/mobile_client/client.rs
+++ b/rust/xaynet-client/src/mobile_client/client.rs
@@ -117,7 +117,7 @@ impl ClientState<Sum> {
     async fn run<T: ApiClient>(&mut self, api: &mut T) -> Result<(), ClientError<T::Error>> {
         self.check_round_freshness(api).await?;
 
-        let sum_msg = self.participant.compose_sum_message();
+        let sum_msg = self.participant.compose_sum_message(self.round_params.pk);
         let sealed_msg = self
             .participant
             .seal_message(&self.round_params.pk, &sum_msg);
@@ -179,9 +179,12 @@ impl ClientState<Update> {
             .await?
             .ok_or(ClientError::TooEarly("sum dict"))?;
 
-        let upd_msg = self
-            .participant
-            .compose_update_message(&sums, scalar, local_model);
+        let upd_msg = self.participant.compose_update_message(
+            self.round_params.pk,
+            &sums,
+            scalar,
+            local_model,
+        );
         let sealed_msg = self
             .participant
             .seal_message(&self.round_params.pk, &upd_msg);
@@ -233,7 +236,7 @@ impl ClientState<Sum2> {
 
         let sum2_msg = self
             .participant
-            .compose_sum2_message(&seeds, length as usize)
+            .compose_sum2_message(self.round_params.pk, &seeds, length as usize)
             .map_err(|e| {
                 error!("failed to compose sum2 message with seeds: {:?}", &seeds);
                 ClientError::ParticipantErr(e)

--- a/rust/xaynet-client/src/mobile_client/participant/sum.rs
+++ b/rust/xaynet-client/src/mobile_client/participant/sum.rs
@@ -3,6 +3,7 @@ use crate::mobile_client::participant::Sum2;
 use xaynet_core::{
     crypto::EncryptKeyPair,
     message::{Message, Sum as SumMessage},
+    CoordinatorPublicKey,
     ParticipantTaskSignature,
     SumParticipantEphemeralPublicKey,
     SumParticipantEphemeralSecretKey,
@@ -29,10 +30,11 @@ impl Participant<Sum> {
     }
 
     /// Compose a sum message given the coordinator public key.
-    pub fn compose_sum_message(&mut self) -> Message {
+    pub fn compose_sum_message(&mut self, coordinator_pk: CoordinatorPublicKey) -> Message {
         Message {
             signature: None,
             participant_pk: self.state.keys.public,
+            coordinator_pk,
             payload: SumMessage {
                 sum_signature: self.inner.sum_signature,
                 ephm_pk: self.inner.ephm_pk,

--- a/rust/xaynet-client/src/mobile_client/participant/sum2.rs
+++ b/rust/xaynet-client/src/mobile_client/participant/sum2.rs
@@ -2,6 +2,7 @@ use super::{Participant, ParticipantState};
 use xaynet_core::{
     mask::{Aggregation, MaskObject, MaskSeed},
     message::{Message, Sum2 as Sum2Message},
+    CoordinatorPublicKey,
     ParticipantPublicKey,
     ParticipantTaskSignature,
     PetError,
@@ -42,6 +43,7 @@ impl Participant<Sum2> {
     /// seed dictionary, or computing the global mask.
     pub fn compose_sum2_message(
         &self,
+        coordinator_pk: CoordinatorPublicKey,
         seed_dict: &UpdateSeedDict,
         mask_len: usize,
     ) -> Result<Message, PetError> {
@@ -50,6 +52,7 @@ impl Participant<Sum2> {
         Ok(Message {
             signature: None,
             participant_pk: self.state.keys.public,
+            coordinator_pk,
             payload: Sum2Message {
                 sum_signature: self.inner.sum_signature,
                 model_mask,

--- a/rust/xaynet-client/src/mobile_client/participant/update.rs
+++ b/rust/xaynet-client/src/mobile_client/participant/update.rs
@@ -2,6 +2,7 @@ use super::{Participant, ParticipantState};
 use xaynet_core::{
     mask::{MaskObject, MaskSeed, Masker, Model},
     message::{Message, Update as UpdateMessage},
+    CoordinatorPublicKey,
     LocalSeedDict,
     ParticipantTaskSignature,
     SumDict,
@@ -31,6 +32,7 @@ impl Participant<Update> {
     /// dictionary, model scalar and local model update.
     pub fn compose_update_message(
         &self,
+        coordinator_pk: CoordinatorPublicKey,
         sum_dict: &SumDict,
         scalar: f64,
         local_model: Model,
@@ -41,6 +43,7 @@ impl Participant<Update> {
         Message {
             signature: None,
             participant_pk: self.state.keys.public,
+            coordinator_pk,
             payload: UpdateMessage {
                 sum_signature: self.inner.sum_signature,
                 update_signature: self.inner.update_signature,

--- a/rust/xaynet-client/src/participant.rs
+++ b/rust/xaynet-client/src/participant.rs
@@ -118,13 +118,15 @@ impl Participant {
         self.task
     }
 
-    /// Compose a sum message given the coordinator public key.
-    pub fn compose_sum_message(&mut self) -> Message {
+    /// Compose a sum message that embeds the given coordinator public
+    /// key.
+    pub fn compose_sum_message(&mut self, coordinator_pk: CoordinatorPublicKey) -> Message {
         self.gen_ephm_keypair();
 
         Message {
             signature: None,
             participant_pk: self.pk,
+            coordinator_pk,
             payload: Sum {
                 sum_signature: self.sum_signature,
                 ephm_pk: self.ephm_pk,
@@ -137,6 +139,7 @@ impl Participant {
     /// dictionary, model scalar and local model update.
     pub fn compose_update_message(
         &self,
+        coordinator_pk: CoordinatorPublicKey,
         sum_dict: &SumDict,
         scalar: f64,
         local_model: Model,
@@ -147,6 +150,7 @@ impl Participant {
         Message {
             signature: None,
             participant_pk: self.pk,
+            coordinator_pk,
             payload: Update {
                 sum_signature: self.sum_signature,
                 update_signature: self.update_signature,
@@ -167,6 +171,7 @@ impl Participant {
     /// seed dictionary, or computing the global mask.
     pub fn compose_sum2_message(
         &self,
+        coordinator_pk: CoordinatorPublicKey,
         seed_dict: &UpdateSeedDict,
         mask_len: usize,
     ) -> Result<Message, PetError> {
@@ -176,6 +181,7 @@ impl Participant {
         Ok(Message {
             signature: None,
             participant_pk: self.pk,
+            coordinator_pk,
             payload: Sum2 {
                 sum_signature: self.sum_signature,
                 model_mask,

--- a/rust/xaynet-server/src/services/tests/utils.rs
+++ b/rust/xaynet-server/src/services/tests/utils.rs
@@ -42,6 +42,7 @@ pub fn new_sum_message(
     let message = Message {
         signature: None,
         participant_pk: participant_signing_keys.public.clone(),
+        coordinator_pk: round_params.pk,
         payload: Sum {
             sum_signature,
             ephm_pk: participant_ephm_pk.clone(),

--- a/rust/xaynet-server/src/state_machine/phases/sum.rs
+++ b/rust/xaynet-server/src/state_machine/phases/sum.rs
@@ -202,7 +202,7 @@ mod test {
         // eligible, so after processing it, we should go to the
         // update phase
         let mut summer = utils::generate_summer(&seed, 1.0, 0.0);
-        let sum_msg = summer.compose_sum_message();
+        let sum_msg = summer.compose_sum_message(round_params.pk);
         let request_fut = async { request_tx.msg(&sum_msg).await.unwrap() };
         let transition_fut = async { state_machine.next().await.unwrap() };
 

--- a/rust/xaynet-server/src/state_machine/phases/sum2.rs
+++ b/rust/xaynet-server/src/state_machine/phases/sum2.rs
@@ -230,7 +230,7 @@ mod test {
     };
     use xaynet_core::{
         common::RoundSeed,
-        crypto::ByteObject,
+        crypto::{ByteObject, EncryptKeyPair},
         mask::{FromPrimitives, Model},
         SumDict,
     };
@@ -242,11 +242,12 @@ mod test {
         let seed = RoundSeed::generate();
         let sum_ratio = 0.5;
         let update_ratio = 1.0;
+        let coord_keys = EncryptKeyPair::generate();
         let model_size = 4;
 
         // Generate a sum dictionary with a single sum participant
         let mut summer = utils::generate_summer(&seed, sum_ratio, update_ratio);
-        let ephm_pk = utils::ephm_pk(&summer.compose_sum_message());
+        let ephm_pk = utils::ephm_pk(&summer.compose_sum_message(coord_keys.public));
         let mut sum_dict = SumDict::new();
         sum_dict.insert(summer.pk, ephm_pk);
 
@@ -254,7 +255,8 @@ mod test {
         let updater = utils::generate_updater(&seed, sum_ratio, update_ratio);
         let scalar = 1.0 / (n_updaters as f64 * update_ratio);
         let model = Model::from_primitives(vec![0; model_size].into_iter()).unwrap();
-        let msg = updater.compose_update_message(&sum_dict, scalar, model.clone());
+        let msg =
+            updater.compose_update_message(coord_keys.public, &sum_dict, scalar, model.clone());
         let masked_model = utils::masked_model(&msg);
         let masked_scalar = utils::masked_scalar(&msg);
         let local_seed_dict = utils::local_seed_dict(&msg);
@@ -286,7 +288,7 @@ mod test {
 
         // Create a sum2 request.
         let msg = summer
-            .compose_sum2_message(&local_seed_dict, masked_model.data.len())
+            .compose_sum2_message(coord_keys.public, &local_seed_dict, masked_model.data.len())
             .unwrap();
 
         // Have the state machine process the request


### PR DESCRIPTION
This key is actually necessary for security reasons (see [0] Donald
T. Davis, "Defective Sign & Encrypt in S/MIME, PKCS#7, MOSS, PEM, PGP,
and XML.", Proc. Usenix Tech. Conf. 2001 (Boston, Mass., June 25-30,
2001))

However we still need to implement these checks in the coordinator

[0]: http://world.std.com/~dtd/#sign_encrypt