### PR TITLE
Fix cache in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,23 +20,14 @@ jobs:
           toolchain: nightly
           components: rustfmt
 
-      - name: Cache cargo registry
-        uses: actions/cache@v1
+      - name: Cache cargo
+        uses: actions/cache@v2
         with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache cargo index
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache cargo build
-        uses: actions/cache@v1
-        with:
-          path: rust/target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ${{ github.workspace }}/rust/target
+          key: ${{ runner.os }}-cargo-fmt-${{ hashFiles('**/Cargo.lock') }}
 
       - name: cargo fmt
         working-directory: ./rust
@@ -57,23 +48,14 @@ jobs:
           profile: minimal
           toolchain: stable
 
-      - name: Cache cargo registry
-        uses: actions/cache@v1
+      - name: Cache cargo
+        uses: actions/cache@v2
         with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache cargo index
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache cargo build
-        uses: actions/cache@v1
-        with:
-          path: rust/target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ${{ github.workspace }}/rust/target
+          key: ${{ runner.os }}-cargo-check-${{ hashFiles('**/Cargo.lock') }}
 
       - name: cargo check
         working-directory: ./rust
@@ -97,23 +79,14 @@ jobs:
           toolchain: stable
           components: clippy
 
-      - name: Cache cargo registry
-        uses: actions/cache@v1
+      - name: Cache cargo
+        uses: actions/cache@v2
         with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache cargo index
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache cargo build
-        uses: actions/cache@v1
-        with:
-          path: rust/target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ${{ github.workspace }}/rust/target
+          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
 
       - name: cargo clippy
         working-directory: ./rust
@@ -134,29 +107,14 @@ jobs:
           profile: minimal
           toolchain: stable
 
-      - name: Cache cargo registry
-        uses: actions/cache@v1
+      - name: Cache cargo
+        uses: actions/cache@v2
         with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache cargo index
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache cargo build
-        uses: actions/cache@v1
-        with:
-          path: rust/target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Build tests
-        working-directory: ./rust
-        env:
-          RUSTFLAGS: "-D warnings"
-        run: cargo test --no-run
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ${{ github.workspace }}/rust/target
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run unit tests
         working-directory: ./rust
@@ -180,23 +138,14 @@ jobs:
           profile: minimal
           toolchain: stable
 
-      - name: Cache cargo registry
-        uses: actions/cache@v1
+      - name: Cache cargo
+        uses: actions/cache@v2
         with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache cargo index
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache cargo build
-        uses: actions/cache@v1
-        with:
-          path: rust/target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ${{ github.workspace }}/rust/target
+          key: ${{ runner.os }}-cargo-smoke-tests-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Start docker-compose
         working-directory: ./docker
@@ -225,6 +174,15 @@ jobs:
           profile: minimal
           toolchain: nightly
 
+      - name: Cache cargo
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ${{ github.workspace }}/rust/target
+          key: ${{ runner.os }}-cargo-doc-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Check the building of docs
         working-directory: ./rust
         run: cargo +nightly doc --all-features --no-deps --color always
@@ -241,6 +199,15 @@ jobs:
         with:
           toolchain: stable
           override: true
+
+      - name: Cache cargo
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ${{ github.workspace }}/rust/target
+          key: ${{ runner.os }}-cargo-tarpaulin-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1.2

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -205,9 +205,9 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chrono"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c74d84029116787153e02106bf53e66828452a4b325cc8652b788b5967c0a0b6"
+checksum = "942f72db697d8767c22d46a598e01f2d3b475501ea43d0db4f16d90259182d0b"
 dependencies = [
  "num-integer",
  "num-traits 0.2.12",

--- a/rust/xaynet-server/Cargo.toml
+++ b/rust/xaynet-server/Cargo.toml
@@ -58,7 +58,7 @@ xaynet-core = { path = "../xaynet-core" }
 
 # optional dependencies
 influxdb = { version = "0.1.0", features = ["derive"], optional = true }
-chrono = { version = "0.4.13", optional = true }
+chrono = { version = "0.4.15", optional = true }
 
 [dev-dependencies]
 tower-test = "0.3.0"


### PR DESCRIPTION
* our current cache is broken (is tries to caches the folder `target` but our rust `target` folder is in `rust/target`)

The fix includes:
* update `cache` to `v2`
* enable cache for all rust jobs
* fix `target` path
* upgrading chrono to `0.4.15`. The key of the cache (the version) is the hash of the Cargo.lockfile, I had to create a new key cache key so I updated chrono to change the Cargo.lockfile

with a working cache each job takes round about [1 minute](https://github.com/xaynetwork/xaynet/runs/1081701622?check_suite_focus=true)