### PR TITLE
enable integration tests in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -120,11 +120,10 @@ jobs:
         working-directory: ./rust
         env:
           RUSTFLAGS: "-D warnings"
-        run: cargo test
+        run: cargo test -- --skip integration
 
   smoke-test:
     name: cargo-smoke-test
-    if: false
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -155,7 +154,7 @@ jobs:
         working-directory: ./rust
         env:
           RUSTFLAGS: "-D warnings"
-        run: cargo test -- --test-threads=1 --ignored
+        run: cargo test integration -- --test-threads=1
 
       - name: Stop docker-compose
         working-directory: ./docker
@@ -212,7 +211,7 @@ jobs:
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1.2
         with:
-          args: '--manifest-path rust/Cargo.toml --all-features --force-clean --lib --ignore-tests --exclude-files src/vendor/*'
+          args: '--manifest-path rust/Cargo.toml --all-features --force-clean --lib --ignore-tests --exclude-files src/vendor/* -- --skip integration'
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1.0.12


### PR DESCRIPTION
Summary:

* enabled integration tests in ci
(to mark a test as "integration test" you have to add the prefix integration to the function name e.g. integration_set_and_get_coordinator_state)