### PR TITLE
remove expected-participants parameter

### DIFF
--- a/configs/config.toml
+++ b/configs/config.toml
@@ -13,7 +13,6 @@ max_sum_time = 3600
 max_update_time = 3600
 sum = 0.5
 update = 0.9
-expected_participants = 10
 
 [mask]
 group_type = "Prime"

--- a/configs/docker-dev.toml
+++ b/configs/docker-dev.toml
@@ -13,7 +13,6 @@ max_sum_time = 3600
 max_update_time = 3600
 sum = 0.01
 update = 0.1
-expected_participants = 10
 
 [mask]
 group_type = "Prime"

--- a/configs/docker-release.toml
+++ b/configs/docker-release.toml
@@ -13,7 +13,6 @@ max_sum_time = 3600
 max_update_time = 3600
 sum = 0.01
 update = 0.1
-expected_participants = 10
 
 [mask]
 group_type = "Prime"

--- a/k8s/coordinator/development/config.toml
+++ b/k8s/coordinator/development/config.toml
@@ -13,7 +13,6 @@ max_sum_time = 3600
 max_update_time = 3600
 sum = 0.5
 update = 0.9
-expected_participants = 10
 
 [mask]
 group_type = "Prime"

--- a/rust/xaynet-server/src/settings.rs
+++ b/rust/xaynet-server/src/settings.rs
@@ -236,24 +236,6 @@ pub struct PetSettings {
     /// XAYNET_PET__UPDATE=0.01
     /// ```
     pub update: f64,
-
-    #[validate(range(min = 1))]
-    /// The total number of participants that are expected by the coordinator. The value must be a
-    /// positive integer (i.e. `expected_participants >= 1`).
-    ///
-    /// # Examples
-    ///
-    /// **TOML**
-    /// ```text
-    /// [pet]
-    /// expected_participants = 10
-    /// ```
-    ///
-    /// **Environment variable**
-    /// ```text
-    /// XAYNET_PET__EXPECTED_PARTICIPANTS=10
-    /// ```
-    pub expected_participants: usize,
 }
 
 impl Default for PetSettings {
@@ -267,7 +249,6 @@ impl Default for PetSettings {
             max_update_time: 604800_u64,
             sum: 0.01_f64,
             update: 0.1_f64,
-            expected_participants: 10,
         }
     }
 }

--- a/rust/xaynet-server/src/state_machine/coordinator.rs
+++ b/rust/xaynet-server/src/state_machine/coordinator.rs
@@ -30,8 +30,6 @@ pub struct CoordinatorState {
     pub max_sum_time: u64,
     /// The maximum time (in seconds) permitted for processing update messages.
     pub max_update_time: u64,
-    /// The number of expected participants.
-    pub expected_participants: usize,
     /// The masking configuration.
     pub mask_config: MaskConfig,
     /// The size of the model.
@@ -62,7 +60,6 @@ impl CoordinatorState {
             min_update_time: pet_settings.min_update_time,
             max_sum_time: pet_settings.max_sum_time,
             max_update_time: pet_settings.max_update_time,
-            expected_participants: pet_settings.expected_participants,
             mask_config: mask_settings.into(),
             model_size: model_settings.size,
         }

--- a/rust/xaynet-server/src/state_machine/phases/sum2.rs
+++ b/rust/xaynet-server/src/state_machine/phases/sum2.rs
@@ -1,6 +1,8 @@
 use xaynet_core::{
     mask::{Aggregation, MaskObject},
-    PetError, SumDict, SumParticipantPublicKey,
+    PetError,
+    SumDict,
+    SumParticipantPublicKey,
 };
 
 use crate::state_machine::{

--- a/rust/xaynet-server/src/state_machine/phases/sum2.rs
+++ b/rust/xaynet-server/src/state_machine/phases/sum2.rs
@@ -1,8 +1,6 @@
 use xaynet_core::{
     mask::{Aggregation, MaskObject},
-    PetError,
-    SumDict,
-    SumParticipantPublicKey,
+    PetError, SumDict, SumParticipantPublicKey,
 };
 
 use crate::state_machine::{
@@ -281,7 +279,6 @@ mod test {
             .with_update_ratio(update_ratio)
             .with_min_sum(n_summers)
             .with_min_update(n_updaters)
-            .with_expected_participants(n_updaters + n_summers)
             .with_mask_config(utils::mask_settings().into())
             .build();
         assert!(state_machine.is_sum2());

--- a/rust/xaynet-server/src/state_machine/phases/update.rs
+++ b/rust/xaynet-server/src/state_machine/phases/update.rs
@@ -2,11 +2,7 @@ use std::sync::Arc;
 
 use xaynet_core::{
     mask::{Aggregation, MaskObject},
-    LocalSeedDict,
-    PetError,
-    SeedDict,
-    SumDict,
-    UpdateParticipantPublicKey,
+    LocalSeedDict, PetError, SeedDict, SumDict, UpdateParticipantPublicKey,
 };
 
 use crate::state_machine::{
@@ -283,8 +279,7 @@ mod test {
         common::RoundSeed,
         crypto::{ByteObject, EncryptKeyPair},
         mask::{FromPrimitives, MaskObject, Model},
-        SumDict,
-        UpdateSeedDict,
+        SumDict, UpdateSeedDict,
     };
 
     #[tokio::test]
@@ -328,7 +323,6 @@ mod test {
             .with_update_ratio(update_ratio)
             .with_min_sum(n_summers)
             .with_min_update(n_updaters)
-            .with_expected_participants(n_updaters + n_summers)
             .with_mask_config(utils::mask_settings().into())
             .build();
 

--- a/rust/xaynet-server/src/state_machine/phases/update.rs
+++ b/rust/xaynet-server/src/state_machine/phases/update.rs
@@ -2,7 +2,11 @@ use std::sync::Arc;
 
 use xaynet_core::{
     mask::{Aggregation, MaskObject},
-    LocalSeedDict, PetError, SeedDict, SumDict, UpdateParticipantPublicKey,
+    LocalSeedDict,
+    PetError,
+    SeedDict,
+    SumDict,
+    UpdateParticipantPublicKey,
 };
 
 use crate::state_machine::{
@@ -279,7 +283,8 @@ mod test {
         common::RoundSeed,
         crypto::{ByteObject, EncryptKeyPair},
         mask::{FromPrimitives, MaskObject, Model},
-        SumDict, UpdateSeedDict,
+        SumDict,
+        UpdateSeedDict,
     };
 
     #[tokio::test]

--- a/rust/xaynet-server/src/state_machine/tests/builder.rs
+++ b/rust/xaynet-server/src/state_machine/tests/builder.rs
@@ -90,11 +90,6 @@ where
         self
     }
 
-    pub fn with_expected_participants(mut self, expected_participants: usize) -> Self {
-        self.shared.state.expected_participants = expected_participants;
-        self
-    }
-
     pub fn with_seed(mut self, seed: RoundSeed) -> Self {
         self.shared.state.round_params.seed = seed;
         self

--- a/rust/xaynet-server/src/state_machine/tests/mod.rs
+++ b/rust/xaynet-server/src/state_machine/tests/mod.rs
@@ -36,7 +36,6 @@ async fn full_round() {
         .with_update_ratio(update_ratio)
         .with_min_sum(n_summers)
         .with_min_update(n_updaters)
-        .with_expected_participants(n_updaters + n_summers)
         .with_model_size(model_size)
         .build();
 

--- a/rust/xaynet-server/src/state_machine/tests/utils.rs
+++ b/rust/xaynet-server/src/state_machine/tests/utils.rs
@@ -3,8 +3,7 @@ use xaynet_core::{
     crypto::ByteObject,
     mask::{BoundType, DataType, GroupType, MaskObject, ModelType},
     message::{Message, Payload, Sum, Update},
-    LocalSeedDict,
-    SumParticipantEphemeralPublicKey,
+    LocalSeedDict, SumParticipantEphemeralPublicKey,
 };
 
 use crate::{
@@ -67,7 +66,6 @@ pub fn pet_settings() -> PetSettings {
         update: 0.5,
         min_sum_count: 1,
         min_update_count: 3,
-        expected_participants: 10,
         ..Default::default()
     }
 }

--- a/rust/xaynet-server/src/state_machine/tests/utils.rs
+++ b/rust/xaynet-server/src/state_machine/tests/utils.rs
@@ -3,7 +3,8 @@ use xaynet_core::{
     crypto::ByteObject,
     mask::{BoundType, DataType, GroupType, MaskObject, ModelType},
     message::{Message, Payload, Sum, Update},
-    LocalSeedDict, SumParticipantEphemeralPublicKey,
+    LocalSeedDict,
+    SumParticipantEphemeralPublicKey,
 };
 
 use crate::{


### PR DESCRIPTION
Previously, the coordinator used an `expected_participants` parameter (for the expected number of participants) to calculate the model scalar. Now that scalars are determined by the participants (as part of the [generalised scalar extension](#496 )), this parameter is no longer needed. 