### PR TITLE
Redis integration

### DIFF
--- a/k8s/coordinator/development/config.toml
+++ b/k8s/coordinator/development/config.toml
@@ -28,4 +28,4 @@ url = "http://influxdb:8086"
 db = "metrics"
 
 [redis]
-url = "redis://redis"
+url = "redis://redis-master"

--- a/rust/xaynet-server/src/state_machine/phases/error.rs
+++ b/rust/xaynet-server/src/state_machine/phases/error.rs
@@ -1,8 +1,13 @@
-use crate::state_machine::{
-    phases::{Idle, Phase, PhaseName, PhaseState, Shared, Shutdown},
-    RoundFailed,
-    StateMachine,
+use crate::{
+    state_machine::{
+        phases::{Idle, Phase, PhaseName, PhaseState, Shared, Shutdown},
+        RoundFailed,
+        StateMachine,
+    },
+    storage::redis::RedisError,
 };
+use std::time::Duration;
+use tokio::time::delay_for;
 
 #[cfg(feature = "metrics")]
 use crate::metrics;
@@ -18,6 +23,8 @@ pub enum StateError {
     RoundError(#[from] RoundFailed),
     #[error("state failed: phase timeout: {0}")]
     TimeoutError(#[from] tokio::time::Elapsed),
+    #[error("state failed: Redis failed: {0}")]
+    Redis(#[from] RedisError),
 }
 
 impl PhaseState<StateError> {
@@ -45,6 +52,26 @@ impl Phase for PhaseState<StateError> {
 
         info!("broadcasting error phase event");
         self.shared.io.events.broadcast_phase(PhaseName::Error);
+
+        if let StateError::Redis(_) = self.inner {
+            // a simple loop that stops as soon as the redis client has reconnected to a redis
+            // instance. Reconnecting a lost connection is handled internally by
+            // redis::aio::ConnectionManager
+
+            while self
+                .shared
+                .io
+                .redis
+                .connection()
+                .await
+                .ping()
+                .await
+                .is_err()
+            {
+                info!("try to reconnect to Redis in 5 sec");
+                delay_for(Duration::from_secs(5)).await;
+            }
+        }
 
         Ok(())
     }

--- a/rust/xaynet-server/src/state_machine/phases/mod.rs
+++ b/rust/xaynet-server/src/state_machine/phases/mod.rs
@@ -294,10 +294,12 @@ impl<S> PhaseState<S> {
 mod tests {
     use super::*;
     use crate::state_machine::tests::utils;
+    use serial_test::serial;
 
-    #[test]
-    fn update_round_id() {
-        let (mut shared, event_subscriber, ..) = utils::init_shared();
+    #[tokio::test]
+    #[serial]
+    async fn integration_update_round_id() {
+        let (mut shared, event_subscriber, ..) = utils::init_shared().await;
 
         let phases = event_subscriber.phase_listener();
         // When starting the round ID should be 0

--- a/rust/xaynet-server/src/state_machine/tests/mod.rs
+++ b/rust/xaynet-server/src/state_machine/tests/mod.rs
@@ -16,9 +16,11 @@ use crate::state_machine::{
         utils::{enable_logging, generate_summer, generate_updater},
     },
 };
+use serial_test::serial;
 
 #[tokio::test]
-async fn full_round() {
+#[serial]
+async fn integration_full_round() {
     enable_logging();
     let n_updaters = 3;
     let n_summers = 2;
@@ -29,13 +31,18 @@ async fn full_round() {
     let coord_pk = coord_keys.public;
     let model_size = 4;
 
-    let (state_machine, requests, events) = StateMachineBuilder::new()
+    let (state_machine, requests, events, _) = StateMachineBuilder::new()
+        .await
         .with_round_id(42)
         .with_seed(seed.clone())
         .with_sum_ratio(sum_ratio)
         .with_update_ratio(update_ratio)
         .with_min_sum(n_summers)
         .with_min_update(n_updaters)
+        .with_min_sum_time(1)
+        .with_max_sum_time(2)
+        .with_min_update_time(1)
+        .with_max_update_time(2)
         .with_model_size(model_size)
         .build();
 

--- a/rust/xaynet-server/src/storage/redis.rs
+++ b/rust/xaynet-server/src/storage/redis.rs
@@ -44,7 +44,8 @@ use crate::{
         PublicSigningKeyWrite,
     },
 };
-use redis::{aio::ConnectionManager, AsyncCommands, IntoConnectionInfo, RedisError, RedisResult};
+pub use redis::RedisError;
+use redis::{aio::ConnectionManager, AsyncCommands, IntoConnectionInfo, RedisResult};
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,


### PR DESCRIPTION
Moves the `Sum` and `Seed` dict into Redis.

I tried to split the changes into 3 commits to make it easier to review.

# Error handling 

The error handling is kept simple as I'd love to hear your ideas before I implement anything more sophisticated.

If a Redis error occurs during the message processing, we ignore the message.
- [Sum message](https://github.com/xaynetwork/xaynet/pull/519/files#diff-a07f40c3b4b740367f7d4a72897eb2d0R135)
- [Update message](https://github.com/xaynetwork/xaynet/pull/519/files#diff-b15272399ff491c84d93d4ca104eaab1R229)

If a Redis error occurs during the message processing, we ignore the message.

If a Redis error occurs when writing / reading the state that relates to the state machine itself (e.g. `get_seed_dict`, `set_coordinator_state`), we move into the error state.

- [`get_seed_dict`](https://github.com/xaynetwork/xaynet/pull/519/files#diff-b15272399ff491c84d93d4ca104eaab1R70)
- [`set_coordinator_state`](https://github.com/xaynetwork/xaynet/pull/519/files#diff-f0a081898820862a4f5ba67d9ec8d408R49)

The state machine remains in the error state until the Redis client has successfully re-established the connection to the Redis server. 

The [ConnectionManager](https://docs.rs/redis/0.17.0/redis/aio/struct.ConnectionManager.html) who is responsible for reconnecting has an unusual behavior.

> The reconnect code will atomically swap the current (dead) connection with a future that will eventually resolve to a MultiplexedConnection or to a RedisError

> All commands that are issued after the reconnect process has been initiated, will have to await the connection future.

> If reconnecting fails, all pending commands will be failed as well. A new reconnection attempt will be triggered if the error is an I/O error.

Therefore, I had to create this [loop](https://github.com/xaynetwork/xaynet/pull/519/files#diff-7d8af3981570c8116cf43cef52e6344fR61)
