### PR TITLE
Include integration tests in test coverage

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -114,47 +114,17 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             ${{ github.workspace }}/rust/target
-          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Run unit tests
-        working-directory: ./rust
-        env:
-          RUSTFLAGS: "-D warnings"
-        run: cargo test -- --skip integration
-
-  smoke-test:
-    name: cargo-smoke-test
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-
-      - name: Cache cargo
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ${{ github.workspace }}/rust/target
-          key: ${{ runner.os }}-cargo-smoke-tests-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-tests-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Start docker-compose
         working-directory: ./docker
         run: docker-compose up -d influxdb minio redis
 
-      - name: Run smoke tests
+      - name: Run tests
         working-directory: ./rust
         env:
           RUSTFLAGS: "-D warnings"
-        run: cargo test integration -- --test-threads=1
+        run: cargo test
 
       - name: Stop docker-compose
         working-directory: ./docker
@@ -208,10 +178,18 @@ jobs:
             ${{ github.workspace }}/rust/target
           key: ${{ runner.os }}-cargo-tarpaulin-${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Start docker-compose
+        working-directory: ./docker
+        run: docker-compose up -d influxdb minio redis
+
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1.2
         with:
-          args: '--manifest-path rust/Cargo.toml --all-features --force-clean --lib --ignore-tests --exclude-files src/vendor/* -- --skip integration'
+          args: '--manifest-path rust/Cargo.toml --all-features --force-clean --lib --ignore-tests --exclude-files src/vendor/*'
+
+      - name: Stop docker-compose
+        working-directory: ./docker
+        run: docker-compose down
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1.0.12

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -880,6 +880,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
 
 [[package]]
+name = "lock_api"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1226,6 +1235,30 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
+dependencies = [
+ "cfg-if",
+ "cloudabi",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1856,6 +1889,28 @@ dependencies = [
  "itoa",
  "serde 1.0.114",
  "url",
+]
+
+[[package]]
+name = "serial_test"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b15f74add9a9d4a3eb2bf739c9a427d266d3895b53d992c3a7c234fec2ff1f1"
+dependencies = [
+ "lazy_static",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65f59259be9fc1bf677d06cc1456e97756004a1a5a577480f71430bd7c17ba33"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2862,6 +2917,7 @@ dependencies = [
  "rayon",
  "redis",
  "serde 1.0.114",
+ "serial_test",
  "sodiumoxide",
  "structopt",
  "thiserror",

--- a/rust/xaynet-server/Cargo.toml
+++ b/rust/xaynet-server/Cargo.toml
@@ -64,6 +64,11 @@ chrono = { version = "0.4.15", optional = true }
 [dev-dependencies]
 tower-test = "0.3.0"
 tokio-test = "0.2.1"
+# We can't run tarpaulin with the flag `--test-threads=1` because it can 
+# trigger a segfault
+# https://github.com/xd009642/tarpaulin/issues/317
+# A workaround is to use `serial_test`
+serial_test = "0.5.0"
 xaynet-client = { path = "../xaynet-client" }
 
 [[bin]]


### PR DESCRIPTION
Summary:

* included integration tests in test coverage
I had to add the dev-dependency `serial_test` to make this work because running tarpaulin with the flag `--test-threads=1` can cause a [segfault](https://github.com/xd009642/tarpaulin/issues/317).
`serial_test` guarantees that tests which are annotated with `#[serial]` are executed in serial. 
This even improves our test setup as we can now execute both the integration tests and the unit tests with a single run of `cargo test`, with the unit tests running in parallel and the integration tests running in serial.

* merged the jobs test and smoke-test into one job