### PR TITLE
XN-904 tls server auth

### DIFF
--- a/configs/config.toml
+++ b/configs/config.toml
@@ -29,3 +29,7 @@ db = "metrics"
 
 [redis]
 url = "redis://127.0.0.1/"
+
+[tls]
+# cert = 
+# key = 

--- a/configs/config.toml
+++ b/configs/config.toml
@@ -3,8 +3,8 @@ filter = "xaynet=debug,http=warn,info"
 
 [api]
 bind_address = "127.0.0.1:8081"
-# tls_certificate = 
-# tls_key = 
+tls_certificate = "/app/ssl/tls.pem"
+tls_key = "/app/ssl/tls.key"
 
 [pet]
 min_sum_count = 1

--- a/configs/config.toml
+++ b/configs/config.toml
@@ -3,6 +3,8 @@ filter = "xaynet=debug,http=warn,info"
 
 [api]
 bind_address = "127.0.0.1:8081"
+# tls_certificate = 
+# tls_key = 
 
 [pet]
 min_sum_count = 1
@@ -29,7 +31,3 @@ db = "metrics"
 
 [redis]
 url = "redis://127.0.0.1/"
-
-[tls]
-# cert = 
-# key = 

--- a/configs/docker-dev.toml
+++ b/configs/docker-dev.toml
@@ -29,3 +29,7 @@ db = "metrics"
 
 [redis]
 url = "redis://redis"
+
+[tls]
+# cert = 
+# key = 

--- a/configs/docker-dev.toml
+++ b/configs/docker-dev.toml
@@ -3,6 +3,8 @@ filter = "xaynet=debug,http=warn,info"
 
 [api]
 bind_address = "0.0.0.0:8081"
+# tls_certificate = 
+# tls_key = 
 
 [pet]
 min_sum_count = 1
@@ -29,7 +31,3 @@ db = "metrics"
 
 [redis]
 url = "redis://redis"
-
-[tls]
-# cert = 
-# key = 

--- a/configs/docker-dev.toml
+++ b/configs/docker-dev.toml
@@ -3,8 +3,8 @@ filter = "xaynet=debug,http=warn,info"
 
 [api]
 bind_address = "0.0.0.0:8081"
-# tls_certificate = 
-# tls_key = 
+tls_certificate = "/app/ssl/tls.pem"
+tls_key = "/app/ssl/tls.key"
 
 [pet]
 min_sum_count = 1

--- a/configs/docker-release.toml
+++ b/configs/docker-release.toml
@@ -29,3 +29,7 @@ db = "metrics"
 
 [redis]
 url = "redis://redis"
+
+[tls]
+# cert = 
+# key = 

--- a/configs/docker-release.toml
+++ b/configs/docker-release.toml
@@ -3,8 +3,8 @@ filter = "info"
 
 [api]
 bind_address = "0.0.0.0:8081"
-# tls_certificate = 
-# tls_key = 
+tls_certificate = "/app/ssl/tls.pem"
+tls_key = "/app/ssl/tls.key"
 
 [pet]
 min_sum_count = 1

--- a/configs/docker-release.toml
+++ b/configs/docker-release.toml
@@ -3,6 +3,8 @@ filter = "info"
 
 [api]
 bind_address = "0.0.0.0:8081"
+# tls_certificate = 
+# tls_key = 
 
 [pet]
 min_sum_count = 1
@@ -29,7 +31,3 @@ db = "metrics"
 
 [redis]
 url = "redis://redis"
-
-[tls]
-# cert = 
-# key = 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2582,6 +2582,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "url",
+ "validator_derive",
  "validator_types",
 ]
 
@@ -2915,7 +2916,6 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "validator",
- "validator_derive",
  "warp",
  "xaynet-client",
  "xaynet-core",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2656,6 +2656,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-rustls",
  "tokio-tungstenite",
  "tower-service",
  "tracing",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1014,10 +1014,22 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log",
- "miow",
+ "miow 0.2.1",
  "net2",
  "slab",
  "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio-named-pipes"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
+dependencies = [
+ "log",
+ "mio",
+ "miow 0.3.5",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1041,6 +1053,16 @@ dependencies = [
  "net2",
  "winapi 0.2.8",
  "ws2_32-sys",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
+dependencies = [
+ "socket2",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2127,6 +2149,7 @@ dependencies = [
  "libc",
  "memchr",
  "mio",
+ "mio-named-pipes",
  "mio-uds",
  "num_cpus",
  "pin-project-lite",

--- a/rust/examples/Cargo.toml
+++ b/rust/examples/Cargo.toml
@@ -13,6 +13,10 @@ tracing-subscriber = "0.2.12"
 sodiumoxide = "0.2.6"
 tokio = "0.2.22"
 
+[features]
+default = []
+tls = ["xaynet-client/tls"]
+
 [[example]]
 name = "test-drive-net"
 path = "test-drive-net.rs"

--- a/rust/examples/Cargo.toml
+++ b/rust/examples/Cargo.toml
@@ -11,7 +11,7 @@ tracing = "0.1.19"
 structopt = "0.3.17"
 tracing-subscriber = "0.2.12"
 sodiumoxide = "0.2.6"
-tokio = "0.2.22"
+tokio = { version = "0.2.22", features = ["full"] }
 
 [features]
 default = []

--- a/rust/examples/mobile-client.rs
+++ b/rust/examples/mobile-client.rs
@@ -39,6 +39,7 @@ struct Opt {
 
     #[cfg_attr(
         feature = "tls",
+        cfg(feature = "tls"),
         structopt(
             short,
             long,

--- a/rust/examples/mobile-client.rs
+++ b/rust/examples/mobile-client.rs
@@ -129,7 +129,7 @@ fn main() -> Result<(), ()> {
 
     // create a new client
     let client =
-        MobileClient::init(&opt.url, &opt.certificates, get_participant_settings()).unwrap();
+        MobileClient::init(&opt.url, get_participant_settings(), &opt.certificates).unwrap();
     // serialize the current client state (and save it on the phone)
     let mut bytes = client.serialize();
 
@@ -137,7 +137,7 @@ fn main() -> Result<(), ()> {
     loop {
         // load local model
         let model = Model::from_primitives(vec![1; opt.len as usize].into_iter()).unwrap();
-        bytes = perform_task(&opt.url, &opt.certificates, &bytes, model);
+        bytes = perform_task(&opt.url, &bytes, model, &opt.certificates);
         pause();
     }
 }
@@ -146,11 +146,11 @@ fn main() -> Result<(), ()> {
 // app is active or in a background task)
 fn perform_task(
     url: &str,
-    certificates: &Option<Vec<PathBuf>>,
     bytes: &[u8],
     model: Model,
+    certificates: &Option<Vec<PathBuf>>,
 ) -> Vec<u8> {
-    let mut client = MobileClient::restore(url, certificates, bytes).unwrap();
+    let mut client = MobileClient::restore(url, bytes, certificates).unwrap();
     println!("task: {:?}", &client.get_current_state());
 
     client.set_local_model(model);

--- a/rust/examples/mobile-client.rs
+++ b/rust/examples/mobile-client.rs
@@ -114,7 +114,7 @@ fn main() -> Result<(), ()> {
         .init();
 
     // create a new client
-    let client = MobileClient::init(&opt.url, get_participant_settings()).unwrap();
+    let client = MobileClient::init(&opt.url, None, None, get_participant_settings()).unwrap();
     // serialize the current client state (and save it on the phone)
     let mut bytes = client.serialize();
 
@@ -130,7 +130,7 @@ fn main() -> Result<(), ()> {
 // perform the participant task (this function should be triggered regularly on the phone while the
 // app is active or in a background task)
 fn perform_task(url: &str, bytes: &[u8], model: Model) -> Vec<u8> {
-    let mut client = MobileClient::restore(url, bytes).unwrap();
+    let mut client = MobileClient::restore(url, None, None, bytes).unwrap();
     println!("task: {:?}", &client.get_current_state());
 
     client.set_local_model(model);

--- a/rust/examples/test-drive-net.rs
+++ b/rust/examples/test-drive-net.rs
@@ -50,7 +50,11 @@ async fn main() -> Result<(), ClientError<HttpApiClientError>> {
 
     let mut clients = Vec::with_capacity(opt.nb_client as usize);
     for id in 0..opt.nb_client {
-        let mut client = Client::new(opt.period, id, HttpApiClient::new(&opt.url))?;
+        let mut client = Client::new(
+            opt.period,
+            id,
+            HttpApiClient::new(&opt.url, None).map_err(ClientError::Api)?,
+        )?;
         client.local_model = Some(model.clone());
         let join_hdl = tokio::spawn(async move {
             tokio::select! {

--- a/rust/examples/test-drive-net.rs
+++ b/rust/examples/test-drive-net.rs
@@ -38,20 +38,12 @@ struct Opt {
     nb_client: u32,
 
     #[structopt(
-        short = "der",
+        short,
         long,
         parse(from_os_str),
-        help = "The list of trusted DER encoded TLS server certificates"
+        help = "The list of trusted DER and PEM encoded TLS server certificates"
     )]
-    der_certificates: Option<Vec<PathBuf>>,
-
-    #[structopt(
-        short = "pem",
-        long,
-        parse(from_os_str),
-        help = "The list of trusted PEM encoded TLS server certificates"
-    )]
-    pem_certificates: Option<Vec<PathBuf>>,
+    certificates: Option<Vec<PathBuf>>,
 }
 
 /// Test-drive script of a (local, but networked) federated
@@ -71,8 +63,7 @@ async fn main() -> Result<(), ClientError<HttpApiClientError>> {
     let model = Model::from_primitives(vec![0; len].into_iter()).unwrap();
 
     let certificates =
-        HttpApiClient::certificates_from_paths(opt.der_certificates, opt.pem_certificates)
-            .map_err(ClientError::Api)?;
+        HttpApiClient::certificates_from(&opt.certificates).map_err(ClientError::Api)?;
     let mut clients = Vec::with_capacity(opt.nb_client as usize);
     for id in 0..opt.nb_client {
         let mut client = Client::new(

--- a/rust/examples/test-drive-net.rs
+++ b/rust/examples/test-drive-net.rs
@@ -1,9 +1,12 @@
+use std::path::PathBuf;
+
 #[macro_use]
 extern crate tracing;
 
 use structopt::StructOpt;
 use tokio::signal;
 use tracing_subscriber::*;
+
 use xaynet_client::{
     api::{HttpApiClient, HttpApiClientError},
     Client,
@@ -20,16 +23,35 @@ struct Opt {
         help = "The URL of the coordinator"
     )]
     url: String,
+
     #[structopt(default_value = "4", short, help = "The length of the model")]
     len: u32,
+
     #[structopt(
         default_value = "1",
         short,
         help = "The time period at which to poll for service data, in seconds"
     )]
     period: u64,
+
     #[structopt(default_value = "10", short, help = "The number of clients")]
     nb_client: u32,
+
+    #[structopt(
+        short = "der",
+        long,
+        parse(from_os_str),
+        help = "The list of trusted DER encoded TLS server certificates"
+    )]
+    der_certificates: Option<Vec<PathBuf>>,
+
+    #[structopt(
+        short = "pem",
+        long,
+        parse(from_os_str),
+        help = "The list of trusted PEM encoded TLS server certificates"
+    )]
+    pem_certificates: Option<Vec<PathBuf>>,
 }
 
 /// Test-drive script of a (local, but networked) federated
@@ -48,12 +70,15 @@ async fn main() -> Result<(), ClientError<HttpApiClientError>> {
     let len = opt.len as usize;
     let model = Model::from_primitives(vec![0; len].into_iter()).unwrap();
 
+    let certificates =
+        HttpApiClient::certificates_from_paths(opt.der_certificates, opt.pem_certificates)
+            .map_err(ClientError::Api)?;
     let mut clients = Vec::with_capacity(opt.nb_client as usize);
     for id in 0..opt.nb_client {
         let mut client = Client::new(
             opt.period,
             id,
-            HttpApiClient::new(&opt.url, None).map_err(ClientError::Api)?,
+            HttpApiClient::new(&opt.url, certificates.clone()).map_err(ClientError::Api)?,
         )?;
         client.local_model = Some(model.clone());
         let join_hdl = tokio::spawn(async move {

--- a/rust/xaynet-client/Cargo.toml
+++ b/rust/xaynet-client/Cargo.toml
@@ -20,12 +20,12 @@ thiserror = "1.0.20"
 tracing = "0.1.19"
 async-trait = "0.1.40"
 xaynet-core = { path = "../xaynet-core", version = "0.1.0" }
-reqwest = { version = "0.10.8", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.10.8", default-features = false }
 
 [dev-dependencies]
 tower-test = "0.3.0"
 tokio-test = "0.2.1"
 
 [features]
-default = ["reqwest/default-tls"]
-rustls = ["reqwest/rustls-tls"]
+default = []
+tls = ["reqwest/rustls-tls"]

--- a/rust/xaynet-client/Cargo.toml
+++ b/rust/xaynet-client/Cargo.toml
@@ -20,10 +20,7 @@ thiserror = "1.0.20"
 tracing = "0.1.19"
 async-trait = "0.1.40"
 xaynet-core = { path = "../xaynet-core", version = "0.1.0" }
-
-[dependencies.reqwest]
-version = "0.10.8"
-default-features = false
+reqwest = { version = "0.10.8", default-features = false, features = ["rustls-tls"] }
 
 [dev-dependencies]
 tower-test = "0.3.0"

--- a/rust/xaynet-client/src/api/http.rs
+++ b/rust/xaynet-client/src/api/http.rs
@@ -32,7 +32,6 @@ impl HttpApiClient {
     where
         S: Into<String>,
     {
-        // Client::new() panicked here before as well, this needs propper error handling later on
         let client = if let Some(certificates) = certificates {
             let mut builder = ClientBuilder::new().use_rustls_tls();
             for certificate in certificates {

--- a/rust/xaynet-client/src/api/http.rs
+++ b/rust/xaynet-client/src/api/http.rs
@@ -25,7 +25,10 @@ impl HttpApiClient {
     ///
     /// # Warning
     /// If no trusted root `certificate`s are provided, then every server will be trusted.
-    pub fn new<S>(address: S, certificates: Option<Vec<Certificate>>) -> Self
+    pub fn new<S>(
+        address: S,
+        certificates: Option<Vec<Certificate>>,
+    ) -> Result<Self, HttpApiClientError>
     where
         S: Into<String>,
     {
@@ -35,19 +38,19 @@ impl HttpApiClient {
             for certificate in certificates {
                 builder = builder.add_root_certificate(certificate);
             }
-            builder.build().unwrap()
+            builder.build().map_err(HttpApiClientError::Http)?
         } else {
             ClientBuilder::new()
                 .use_rustls_tls()
                 .danger_accept_invalid_certs(true)
                 .build()
-                .unwrap()
+                .map_err(HttpApiClientError::Http)?
         };
 
-        Self {
+        Ok(Self {
             client,
             address: address.into(),
-        }
+        })
     }
 }
 

--- a/rust/xaynet-client/src/api/http.rs
+++ b/rust/xaynet-client/src/api/http.rs
@@ -12,7 +12,11 @@ use reqwest::Certificate;
 
 use crate::api::ApiClient;
 use xaynet_core::{
-    common::RoundParameters, crypto::ByteObject, mask::Model, SumDict, SumParticipantPublicKey,
+    common::RoundParameters,
+    crypto::ByteObject,
+    mask::Model,
+    SumDict,
+    SumParticipantPublicKey,
     UpdateSeedDict,
 };
 

--- a/rust/xaynet-client/src/api/http.rs
+++ b/rust/xaynet-client/src/api/http.rs
@@ -78,7 +78,7 @@ impl HttpApiClient {
                         )
                     })
                     .collect::<Result<Vec<_>, HttpApiClientError>>()
-                    .map(|certificates| Some(certificates))
+                    .map(Some)
             }
         } else {
             Ok(None)

--- a/rust/xaynet-client/src/lib.rs
+++ b/rust/xaynet-client/src/lib.rs
@@ -38,6 +38,7 @@
 //! [`compose_sum2_message`]: #method.compose_sum2_message
 //! [`start()`]: #method.start
 //! [`during_round()`]: #method.during_round
+
 #[macro_use]
 extern crate async_trait;
 #[macro_use]

--- a/rust/xaynet-client/src/mobile_client/mod.rs
+++ b/rust/xaynet-client/src/mobile_client/mod.rs
@@ -53,8 +53,8 @@ impl MobileClient {
     /// Fails if the crypto module cannot be initialized.
     pub fn init(
         url: &str,
-        der_certificates: Option<&[&[u8]]>,
-        pem_certificates: Option<&[&[u8]]>,
+        der_certificates: Option<Vec<&[u8]>>,
+        pem_certificates: Option<Vec<&[u8]>>,
         participant_settings: ParticipantSettings,
     ) -> Result<Self, MobileClientError> {
         // It is critical that the initialization of sodiumoxide is successful.
@@ -82,8 +82,8 @@ impl MobileClient {
     /// or if the crypto module cannot be initialized.
     pub fn restore(
         url: &str,
-        der_certificates: Option<&[&[u8]]>,
-        pem_certificates: Option<&[&[u8]]>,
+        der_certificates: Option<Vec<&[u8]>>,
+        pem_certificates: Option<Vec<&[u8]>>,
         bytes: &[u8],
     ) -> Result<Self, MobileClientError> {
         let client_state: ClientStateMachine = bincode::deserialize(bytes)?;
@@ -97,21 +97,21 @@ impl MobileClient {
 
     fn new(
         url: &str,
-        der_certificates: Option<&[&[u8]]>,
-        pem_certificates: Option<&[&[u8]]>,
+        der_certificates: Option<Vec<&[u8]>>,
+        pem_certificates: Option<Vec<&[u8]>>,
         client_state: ClientStateMachine,
     ) -> Self {
         let mut certificates = Vec::new();
         if let Some(der_certificates) = der_certificates {
             for certificate in der_certificates {
                 // safe unwrap: this never fails for reqwest's rustls-tls feature
-                certificates.push(Certificate::from_der(*certificate).unwrap())
+                certificates.push(Certificate::from_der(certificate).unwrap())
             }
         }
         if let Some(pem_certificates) = pem_certificates {
             for certificate in pem_certificates {
                 // safe unwrap: this never fails for reqwest's rustls-tls feature
-                certificates.push(Certificate::from_pem(*certificate).unwrap())
+                certificates.push(Certificate::from_pem(certificate).unwrap())
             }
         }
         let certificates = if certificates.is_empty() {

--- a/rust/xaynet-client/src/mobile_client/mod.rs
+++ b/rust/xaynet-client/src/mobile_client/mod.rs
@@ -54,8 +54,8 @@ impl MobileClient {
     /// Fails if the crypto module cannot be initialized.
     pub fn init(
         url: &str,
-        certificates: &Option<Vec<PathBuf>>,
         participant_settings: ParticipantSettings,
+        certificates: &Option<Vec<PathBuf>>,
     ) -> Result<Self, MobileClientError> {
         // It is critical that the initialization of sodiumoxide is successful.
         // We'd better not run the client than having a broken crypto.
@@ -64,7 +64,7 @@ impl MobileClient {
         // https://doc.libsodium.org/usage
         // https://github.com/jedisct1/libsodium/issues/908
         let client_state = ClientStateMachine::new(participant_settings)?;
-        Self::new(url, certificates, client_state)
+        Self::new(url, client_state, certificates)
     }
 
     /// Restores a client from its serialized state.
@@ -77,17 +77,17 @@ impl MobileClient {
     /// or if the crypto module cannot be initialized.
     pub fn restore(
         url: &str,
-        certificates: &Option<Vec<PathBuf>>,
         bytes: &[u8],
+        certificates: &Option<Vec<PathBuf>>,
     ) -> Result<Self, MobileClientError> {
         let client_state: ClientStateMachine = bincode::deserialize(bytes)?;
-        Self::new(url, certificates, client_state)
+        Self::new(url, client_state, certificates)
     }
 
     fn new(
         url: &str,
-        certificates: &Option<Vec<PathBuf>>,
         client_state: ClientStateMachine,
+        certificates: &Option<Vec<PathBuf>>,
     ) -> Result<Self, MobileClientError> {
         let certificates =
             HttpApiClient::certificates_from(certificates).map_err(MobileClientError::Api)?;

--- a/rust/xaynet-ffi/Cargo.toml
+++ b/rust/xaynet-ffi/Cargo.toml
@@ -11,9 +11,13 @@ homepage = "https://xaynet.dev/"
 
 [dependencies]
 ffi-support = "0.4.2"
-xaynet-client = { path = "../xaynet-client", default-features = false, features = ["tls"], version = "0.1.0" }
+xaynet-client = { path = "../xaynet-client", default-features = false, version = "0.1.0" }
 xaynet-core = { path = "../xaynet-core", version = "0.1.0" }
 
 [lib]
 name = "xaynet_sdk"
 crate-type = ["staticlib", "cdylib"]
+
+[features]
+default = []
+tls = ["xaynet-client/tls"]

--- a/rust/xaynet-ffi/Cargo.toml
+++ b/rust/xaynet-ffi/Cargo.toml
@@ -11,10 +11,7 @@ homepage = "https://xaynet.dev/"
 
 [dependencies]
 ffi-support = "0.4.2"
-# By default, `reqwest` uses `openssl`, but this requires compiled `openssl`
-# libraries for the target systems we use.
-# As a [workaround](https://github.com/bbqsrc/cargo-ndk/issues/9) we use `rustls-tls` for now.
-xaynet-client = { path = "../xaynet-client", default-features = false, features = ["rustls"], version = "0.1.0" }
+xaynet-client = { path = "../xaynet-client", default-features = false, features = ["tls"], version = "0.1.0" }
 xaynet-core = { path = "../xaynet-core", version = "0.1.0" }
 
 [lib]

--- a/rust/xaynet-ffi/src/lib.rs
+++ b/rust/xaynet-ffi/src/lib.rs
@@ -59,7 +59,7 @@ use xaynet_core::{
 
 #[allow(unused_unsafe)]
 /// Converts raw certificate path strings to rust paths.
-unsafe fn raw_certificates_to_paths<'a>(
+unsafe fn raw_certificates_to_paths(
     certificates: *const FfiStr,
     certificates_len: c_uint,
 ) -> Result<Option<Vec<PathBuf>>, ()> {

--- a/rust/xaynet-server/Cargo.toml
+++ b/rust/xaynet-server/Cargo.toml
@@ -43,8 +43,7 @@ anyhow = "1.0.32"
 bitflags = "1.2.1"
 warp = { version = "0.2.5", features = ["tls"] }
 config = "0.10.1"
-validator = "0.11.0"
-validator_derive = "0.11.0"
+validator = { version = "0.11.0", features = ["derive"] }
 structopt = "0.3.17"
 paste = "1.0.1"
 tower = "0.3.1"

--- a/rust/xaynet-server/Cargo.toml
+++ b/rust/xaynet-server/Cargo.toml
@@ -41,7 +41,7 @@ bincode = "1.3.1"
 thiserror = "1.0.20"
 anyhow = "1.0.32"
 bitflags = "1.2.1"
-warp = "0.2.5"
+warp = { version = "0.2.5", features = ["tls"] }
 config = "0.10.1"
 validator = "0.11.0"
 validator_derive = "0.11.0"

--- a/rust/xaynet-server/Cargo.toml
+++ b/rust/xaynet-server/Cargo.toml
@@ -41,7 +41,7 @@ bincode = "1.3.1"
 thiserror = "1.0.20"
 anyhow = "1.0.32"
 bitflags = "1.2.1"
-warp = { version = "0.2.5", features = ["tls"] }
+warp = { version = "0.2.5" }
 config = "0.10.1"
 validator = { version = "0.11.0", features = ["derive"] }
 structopt = "0.3.17"
@@ -77,4 +77,5 @@ path = "src/bin/main.rs"
 
 [features]
 default = []
+tls = ["warp/tls"]
 metrics = ["influxdb", "chrono"]

--- a/rust/xaynet-server/Cargo.toml
+++ b/rust/xaynet-server/Cargo.toml
@@ -41,7 +41,7 @@ bincode = "1.3.1"
 thiserror = "1.0.20"
 anyhow = "1.0.32"
 bitflags = "1.2.1"
-warp = { version = "0.2.5" }
+warp = "0.2.5"
 config = "0.10.1"
 validator = { version = "0.11.0", features = ["derive"] }
 structopt = "0.3.17"

--- a/rust/xaynet-server/src/bin/main.rs
+++ b/rust/xaynet-server/src/bin/main.rs
@@ -90,7 +90,7 @@ async fn main() {
         _ = state_machine.run() => {
             warn!("shutting down: Service terminated");
         }
-        _ = rest::serve(api_settings.bind_address, fetcher, message_handler) => {
+        _ = rest::serve(api_settings.bind_address, None, fetcher, message_handler) => {
             warn!("shutting down: REST server terminated");
         }
         _ =  signal::ctrl_c() => {}

--- a/rust/xaynet-server/src/bin/main.rs
+++ b/rust/xaynet-server/src/bin/main.rs
@@ -4,11 +4,7 @@ use structopt::StructOpt;
 use tokio::signal;
 use tracing_subscriber::*;
 use xaynet_server::{
-    rest,
-    services,
-    settings::Settings,
-    state_machine::StateMachine,
-    storage::redis,
+    rest, services, settings::Settings, state_machine::StateMachine, storage::redis,
 };
 
 #[cfg(feature = "metrics")]
@@ -37,7 +33,6 @@ async fn main() {
         model: model_settings,
         metrics: metrics_settings,
         redis: redis_settings,
-        tls: tls_settings,
     } = Settings::new(opt.config_path).unwrap_or_else(|err| {
         eprintln!("{}", err);
         process::exit(1);
@@ -92,7 +87,7 @@ async fn main() {
         _ = state_machine.run() => {
             warn!("shutting down: Service terminated");
         }
-        _ = rest::serve(api_settings.bind_address, tls_settings, fetcher, message_handler) => {
+        _ = rest::serve(api_settings, fetcher, message_handler) => {
             warn!("shutting down: REST server terminated");
         }
         _ =  signal::ctrl_c() => {}

--- a/rust/xaynet-server/src/bin/main.rs
+++ b/rust/xaynet-server/src/bin/main.rs
@@ -1,4 +1,5 @@
 use std::{path::PathBuf, process};
+
 use structopt::StructOpt;
 use tokio::signal;
 use tracing_subscriber::*;
@@ -36,6 +37,7 @@ async fn main() {
         model: model_settings,
         metrics: metrics_settings,
         redis: redis_settings,
+        tls: tls_settings,
     } = Settings::new(opt.config_path).unwrap_or_else(|err| {
         eprintln!("{}", err);
         process::exit(1);
@@ -90,7 +92,7 @@ async fn main() {
         _ = state_machine.run() => {
             warn!("shutting down: Service terminated");
         }
-        _ = rest::serve(api_settings.bind_address, None, fetcher, message_handler) => {
+        _ = rest::serve(api_settings.bind_address, tls_settings, fetcher, message_handler) => {
             warn!("shutting down: REST server terminated");
         }
         _ =  signal::ctrl_c() => {}

--- a/rust/xaynet-server/src/bin/main.rs
+++ b/rust/xaynet-server/src/bin/main.rs
@@ -4,7 +4,11 @@ use structopt::StructOpt;
 use tokio::signal;
 use tracing_subscriber::*;
 use xaynet_server::{
-    rest, services, settings::Settings, state_machine::StateMachine, storage::redis,
+    rest,
+    services,
+    settings::Settings,
+    state_machine::StateMachine,
+    storage::redis,
 };
 
 #[cfg(feature = "metrics")]

--- a/rust/xaynet-server/src/examples.rs
+++ b/rust/xaynet-server/src/examples.rs
@@ -169,7 +169,7 @@ async fn main() -> Result<(), ClientError<HttpApiClientError>> {
 
     let mut clients = Vec::with_capacity(20_usize);
     for id in 0..20 {
-        let api_client = HttpApiClient::new("http://127.0.0.1:8081", None).map_err(ClientError::Api)?;
+        let api_client = HttpApiClient::new("http://127.0.0.1:8081").map_err(ClientError::Api)?;
         let mut client = Client::new(1, id, api_client)?;
         client.local_model = Some(model.clone());
         let join_hdl = tokio::spawn(async move {

--- a/rust/xaynet-server/src/examples.rs
+++ b/rust/xaynet-server/src/examples.rs
@@ -169,7 +169,7 @@ async fn main() -> Result<(), ClientError<HttpApiClientError>> {
 
     let mut clients = Vec::with_capacity(20_usize);
     for id in 0..20 {
-        let api_client = HttpApiClient::new("http://127.0.0.1:8081").map_err(ClientError::Api)?;
+        let api_client = HttpApiClient::new("http://127.0.0.1:8081", None).map_err(ClientError::Api)?;
         let mut client = Client::new(1, id, api_client)?;
         client.local_model = Some(model.clone());
         let join_hdl = tokio::spawn(async move {

--- a/rust/xaynet-server/src/examples.rs
+++ b/rust/xaynet-server/src/examples.rs
@@ -169,7 +169,7 @@ async fn main() -> Result<(), ClientError<HttpApiClientError>> {
 
     let mut clients = Vec::with_capacity(20_usize);
     for id in 0..20 {
-        let api_client = HttpApiClient::new("http://127.0.0.1:8081");
+        let api_client = HttpApiClient::new("http://127.0.0.1:8081").map_err(ClientError::Api)?;
         let mut client = Client::new(1, id, api_client)?;
         client.local_model = Some(model.clone());
         let join_hdl = tokio::spawn(async move {

--- a/rust/xaynet-server/src/lib.rs
+++ b/rust/xaynet-server/src/lib.rs
@@ -21,9 +21,6 @@ extern crate serde;
 extern crate tracing;
 
 #[macro_use]
-extern crate validator_derive;
-
-#[macro_use]
 extern crate xaynet_macros;
 
 pub mod examples;

--- a/rust/xaynet-server/src/rest.rs
+++ b/rust/xaynet-server/src/rest.rs
@@ -8,8 +8,10 @@ use warp::{
     Filter,
 };
 
-use crate::services::{fetchers::Fetcher, messages::PetMessageHandler};
-use crate::settings::ApiSettings;
+use crate::{
+    services::{fetchers::Fetcher, messages::PetMessageHandler},
+    settings::ApiSettings,
+};
 use xaynet_core::{crypto::ByteObject, ParticipantPublicKey};
 
 /// Starts a HTTP server at the given address, listening to GET requests for

--- a/rust/xaynet-server/src/settings.rs
+++ b/rust/xaynet-server/src/settings.rs
@@ -611,6 +611,7 @@ where
 mod tests {
     use super::*;
 
+    #[cfg(not(feature = "tls"))]
     #[test]
     fn test_settings_new() {
         assert!(Settings::new(PathBuf::from("../../configs/config.toml")).is_ok());

--- a/rust/xaynet-server/src/settings.rs
+++ b/rust/xaynet-server/src/settings.rs
@@ -617,8 +617,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::net::SocketAddr;
-    use std::str::FromStr;
+    use std::{net::SocketAddr, str::FromStr};
 
     use super::*;
 

--- a/rust/xaynet-server/src/settings.rs
+++ b/rust/xaynet-server/src/settings.rs
@@ -629,3 +629,79 @@ impl From<TlsSettings> for Option<(PathBuf, PathBuf)> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_settings_new() {
+        assert!(Settings::new(PathBuf::from("../../configs/config.toml")).is_ok());
+        assert!(Settings::new(PathBuf::from("")).is_err());
+    }
+
+    #[test]
+    fn test_validate_pet() {
+        assert!(validate_pet(&PetSettings::default()).is_ok());
+
+        // phase times
+        assert!(validate_pet(&PetSettings {
+            min_sum_time: 2,
+            max_sum_time: 1,
+            ..PetSettings::default()
+        })
+        .is_err());
+        assert!(validate_pet(&PetSettings {
+            min_update_time: 2,
+            max_update_time: 1,
+            ..PetSettings::default()
+        })
+        .is_err());
+
+        // fractions
+        assert!(validate_pet(&PetSettings {
+            sum: 0.,
+            ..PetSettings::default()
+        })
+        .is_err());
+        assert!(validate_pet(&PetSettings {
+            sum: 1.,
+            ..PetSettings::default()
+        })
+        .is_err());
+        assert!(validate_pet(&PetSettings {
+            update: 0.,
+            ..PetSettings::default()
+        })
+        .is_err());
+        assert!(validate_pet(&PetSettings {
+            update: 1.,
+            ..PetSettings::default()
+        })
+        .is_err());
+    }
+
+    #[test]
+    fn test_validate_tls() {
+        assert!(validate_tls(&TlsSettings {
+            cert: Some(String::new()),
+            key: Some(String::new())
+        })
+        .is_ok());
+        assert!(validate_tls(&TlsSettings {
+            cert: None,
+            key: None
+        })
+        .is_ok());
+        assert!(validate_tls(&TlsSettings {
+            cert: Some(String::new()),
+            key: None
+        })
+        .is_err());
+        assert!(validate_tls(&TlsSettings {
+            cert: None,
+            key: Some(String::new())
+        })
+        .is_err());
+    }
+}


### PR DESCRIPTION
Optional TLS server authentication:
- enable TLS on server and client side, make certificates optional (i.e. http if no certs are provided and https if certs are provided)
- update the ffi code for the mobile client
- update the server and client examples (trivially without certs for now)
- add some error handling on client initialization
- make certificate inputs configurable via paths for server and client
- gate the certificates behind a `tls` feature flag

We need to generate some actual certificates to run this stuff in a testing session, but there is a separate ticket for that.