### PR TITLE
Reduce timeouts in CI jobs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   lint:
     name: cargo-fmt
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -35,6 +36,7 @@ jobs:
 
   check:
     name: cargo-check
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -65,6 +67,7 @@ jobs:
 
   clippy:
     name: cargo-clippy
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -94,6 +97,7 @@ jobs:
 
   test:
     name: cargo-test
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -132,6 +136,7 @@ jobs:
 
   docs:
     name: cargo-doc
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -158,6 +163,7 @@ jobs:
 
   coverage:
     name: cargo-tarpaulin
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Sometimes a CI job gets stuck and runs until the default timeout of [360 minutes](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes) is reached. This leads to our ci workers being unnecessarily blocked. This PR reduces the timeout to 20 min.

long running jobs:
- [16m](https://github.com/xaynetwork/xaynet/actions/runs/255776137)
- [4h 53m 12s](https://github.com/xaynetwork/xaynet/actions/runs/260711801)
- [2h 40m 16s](https://github.com/xaynetwork/xaynet/actions/runs/255577029)
