### PR TITLE
XN-1146 Setup SSL certificate data in Kubernetes

### DIFF
--- a/k8s/coordinator/development/cert-volume-mount.yaml
+++ b/k8s/coordinator/development/cert-volume-mount.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coordinator-deployment
+spec:
+  template:
+    spec:
+      volumes:
+        - name: tls-certificate
+          secret:
+            secretName: dev-coordinator
+            items:
+              - key: tls.key
+                path: tls.key
+                mode: 0600
+              - key: tls.crt
+                path: tls.crt
+                mode: 0644
+      containers:
+        - name: coordinator
+          volumeMounts:
+            - name: tls-certificate 
+              mountPath: "/app/ssl"
+              readOnly: true

--- a/k8s/coordinator/development/cert-volume-mount.yaml
+++ b/k8s/coordinator/development/cert-volume-mount.yaml
@@ -14,7 +14,7 @@ spec:
                 path: tls.key
                 mode: 0400
               - key: tls.crt
-                path: tls.crt
+                path: tls.pem
                 mode: 0444
       containers:
         - name: coordinator

--- a/k8s/coordinator/development/cert-volume-mount.yaml
+++ b/k8s/coordinator/development/cert-volume-mount.yaml
@@ -12,10 +12,10 @@ spec:
             items:
               - key: tls.key
                 path: tls.key
-                mode: 0600
+                mode: 0400
               - key: tls.crt
                 path: tls.crt
-                mode: 0644
+                mode: 0444
       containers:
         - name: coordinator
           volumeMounts:

--- a/k8s/coordinator/development/kustomization.yaml
+++ b/k8s/coordinator/development/kustomization.yaml
@@ -19,5 +19,6 @@ bases:
 patchesStrategicMerge:
   - history-limit.yaml
   - config-volume-mount.yaml
+  - cert-volume-mount.yaml
 resources:
   - ingress.yaml


### PR DESCRIPTION
This mounts the letsencrypt certificate (key and crt) into `/app/ssl/tls.key` and `/app/ssl/tls.crt`, respectively.
Whenever the letsencrypt certificates are renewed, the files inside the container are automatically updated.