### PR TITLE
Refactor add sum participant result

### DIFF
--- a/rust/xaynet-server/src/state_machine/mod.rs
+++ b/rust/xaynet-server/src/state_machine/mod.rs
@@ -117,7 +117,7 @@ use self::{
 };
 use crate::{
     settings::{MaskSettings, ModelSettings, PetSettings},
-    storage::{redis, RedisError, SeedDictUpdateError},
+    storage::{redis, RedisError, SeedDictUpdateError, SumDictAddError},
 };
 use derive_more::From;
 use thiserror::Error;
@@ -144,8 +144,11 @@ pub enum StateMachineError {
     #[error("Redis failed: {0}")]
     Redis(#[from] RedisError),
 
-    #[error("Pet error: {0}")]
-    Pet(#[from] SeedDictUpdateError),
+    #[error("{0}")]
+    SeedDictUpdate(#[from] SeedDictUpdateError),
+
+    #[error("{0}")]
+    SumDictAdd(#[from] SumDictAddError),
 }
 
 pub type StateMachineResult = Result<(), StateMachineError>;

--- a/rust/xaynet-server/src/state_machine/phases/sum.rs
+++ b/rust/xaynet-server/src/state_machine/phases/sum.rs
@@ -1,14 +1,11 @@
 use std::sync::Arc;
 
-use crate::{
-    state_machine::{
-        events::DictionaryUpdate,
-        phases::{Handler, Phase, PhaseName, PhaseState, Shared, StateError, Update},
-        requests::{StateMachineRequest, SumRequest},
-        StateMachine,
-        StateMachineError,
-    },
-    storage::AddSumParticipant,
+use crate::state_machine::{
+    events::DictionaryUpdate,
+    phases::{Handler, Phase, PhaseName, PhaseState, Shared, StateError, Update},
+    requests::{StateMachineRequest, SumRequest},
+    StateMachine,
+    StateMachineError,
 };
 
 #[cfg(feature = "metrics")]
@@ -125,19 +122,16 @@ impl PhaseState<Sum> {
             ephm_pk,
         } = req;
 
-        let result = self
-            .shared
+        self.shared
             .io
             .redis
             .connection()
             .await
             .add_sum_participant(&participant_pk, &ephm_pk)
-            .await?;
+            .await?
+            .into_inner()?;
 
-        if let AddSumParticipant::Ok = result {
-            self.inner.sum_count += 1;
-        };
-
+        self.inner.sum_count += 1;
         Ok(())
     }
 

--- a/rust/xaynet-server/src/storage/mod.rs
+++ b/rust/xaynet-server/src/storage/mod.rs
@@ -2,7 +2,7 @@ pub(crate) mod impls;
 pub mod redis;
 
 pub use self::{
-    impls::{AddSumParticipant, SeedDictUpdate, SeedDictUpdateError},
+    impls::{SeedDictUpdate, SeedDictUpdateError, SumDictAdd, SumDictAddError},
     redis::RedisError,
 };
 


### PR DESCRIPTION
A small PR that aligns the sum participant result with the `SeedDictUpdate` result. 

Next sprint, I would like to rethink the error handling in the state machine and maybe change it because the error handling slowly becomes a bit confusing.