### PR TITLE
Add retry and timeouts to redis commands

### DIFF
--- a/configs/config.toml
+++ b/configs/config.toml
@@ -31,3 +31,4 @@ db = "metrics"
 
 [redis]
 url = "redis://127.0.0.1/"
+timeout = 5

--- a/configs/docker-dev.toml
+++ b/configs/docker-dev.toml
@@ -31,3 +31,4 @@ db = "metrics"
 
 [redis]
 url = "redis://redis"
+timeout = 5

--- a/configs/docker-release.toml
+++ b/configs/docker-release.toml
@@ -31,3 +31,4 @@ db = "metrics"
 
 [redis]
 url = "redis://redis"
+timeout = 5

--- a/k8s/coordinator/development/config.toml
+++ b/k8s/coordinator/development/config.toml
@@ -34,3 +34,4 @@ db = "metrics"
 # `XAYNET_REDIS__URL` depends on the enviroment variable `REDIS_AUTH`,
 # which is defined as a Kubernetes secret and exposed to the coordinator pod.
 # See: k8s/coordinator/base/deployment.yaml
+timeout = 5

--- a/rust/xaynet-server/src/bin/main.rs
+++ b/rust/xaynet-server/src/bin/main.rs
@@ -64,7 +64,7 @@ async fn main() {
         )
     };
 
-    let redis = redis::Client::new(redis_settings.url, 100)
+    let redis = redis::Client::new(redis_settings.url, 100, redis_settings.timeout)
         .await
         .expect("failed to establish a connection to Redis");
     redis

--- a/rust/xaynet-server/src/settings.rs
+++ b/rust/xaynet-server/src/settings.rs
@@ -37,6 +37,7 @@ pub struct Settings {
     pub model: ModelSettings,
     #[validate]
     pub metrics: MetricsSettings,
+    #[validate]
     pub redis: RedisSettings,
 }
 
@@ -506,7 +507,7 @@ pub struct InfluxSettings {
     pub db: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Validate)]
 /// Redis settings.
 pub struct RedisSettings {
     /// The URL where Redis is running.
@@ -527,6 +528,24 @@ pub struct RedisSettings {
     /// ```
     #[serde(deserialize_with = "deserialize_redis_url")]
     pub url: ConnectionInfo,
+
+    /// The timeout for a redis command in seconds. The value must be greater or equal
+    /// to `1` (i.e. `timeout >= 1`).
+    ///
+    /// # Examples
+    ///
+    /// **TOML**
+    /// ```text
+    /// [redis]
+    /// timeout = 5
+    /// ```
+    ///
+    /// **Environment variable**
+    /// ```text
+    /// XAYNET_REDIS__TIMEOUT=5
+    /// ```
+    #[validate(range(min = 1))]
+    pub timeout: u64,
 }
 
 fn deserialize_redis_url<'de, D>(deserializer: D) -> Result<ConnectionInfo, D::Error>

--- a/rust/xaynet-server/src/state_machine/mod.rs
+++ b/rust/xaynet-server/src/state_machine/mod.rs
@@ -141,7 +141,7 @@ pub enum StateMachineError {
     #[error("the request could not be processed due to an internal error")]
     InternalError,
 
-    #[error("Redis failed: {0}")]
+    #[error("redis failed: {0}")]
     Redis(#[from] RedisError),
 
     #[error("{0}")]

--- a/rust/xaynet-server/src/state_machine/phases/error.rs
+++ b/rust/xaynet-server/src/state_machine/phases/error.rs
@@ -36,7 +36,7 @@ impl Phase for PhaseState<StateError> {
     const NAME: PhaseName = PhaseName::Error;
 
     async fn run(&mut self) -> Result<(), StateError> {
-        error!("state transition failed! error: {:?}", self.inner);
+        error!("{}", self.inner);
 
         metrics!(
             self.shared.io.metrics_tx,

--- a/rust/xaynet-server/src/state_machine/phases/mod.rs
+++ b/rust/xaynet-server/src/state_machine/phases/mod.rs
@@ -168,7 +168,7 @@ where
         let res = self.handle_request(req).await;
 
         if let Err(ref err) = res {
-            error!("failed to handle message: {:?}", err);
+            error!("failed to handle message: {}", err);
             metrics!(
                 self.shared.io.metrics_tx,
                 metrics::message::rejected::increment(self.shared.state.round_id, Self::NAME)

--- a/rust/xaynet-server/src/state_machine/phases/mod.rs
+++ b/rust/xaynet-server/src/state_machine/phases/mod.rs
@@ -202,7 +202,6 @@ where
             metrics!(self.shared.io.metrics_tx, metrics::phase::update(phase));
 
             if let Err(err) = self.run().await {
-                warn!("phase failed: {:?}", err);
                 return Some(self.into_error_state(err));
             }
 

--- a/rust/xaynet-server/src/state_machine/tests/utils.rs
+++ b/rust/xaynet-server/src/state_machine/tests/utils.rs
@@ -81,7 +81,9 @@ pub fn model_settings() -> ModelSettings {
 }
 
 pub async fn init_shared() -> (Shared, EventSubscriber, RequestSender, redis::Client) {
-    let redis = redis::Client::new("redis://127.0.0.1/", 10).await.unwrap();
+    let redis = redis::Client::new("redis://127.0.0.1/", 10, 10)
+        .await
+        .unwrap();
     redis.connection().await.flush_db().await.unwrap();
 
     let coordinator_state =

--- a/rust/xaynet-server/src/storage/impls.rs
+++ b/rust/xaynet-server/src/storage/impls.rs
@@ -334,3 +334,18 @@ pub enum SumDictDeleteError {
     #[error("sum participant does not exist")]
     DoesNotExist,
 }
+
+#[macro_export]
+macro_rules! retry {
+    ($future: expr, $duration: expr) => {
+        loop {
+            match $future.await {
+                Ok(res) => break res,
+                Err(err) => error!("redis failed {:?}", err),
+            };
+
+            info!("retry in {:?} seconds", $duration);
+            tokio::time::delay_for(std::time::Duration::from_secs($duration)).await;
+        }
+    };
+}

--- a/rust/xaynet-server/src/storage/impls.rs
+++ b/rust/xaynet-server/src/storage/impls.rs
@@ -124,13 +124,9 @@ macro_rules! impl_bincode_redis_traits {
         impl FromRedisValue for $ty {
             fn from_redis_value(v: &Value) -> RedisResult<$ty> {
                 match *v {
-                    Value::Data(ref bytes) => bincode::deserialize(bytes).map_err(|e| {
-                        redis_type_error("Invalid CoordinatorState", Some(e.to_string()))
-                    }),
-                    _ => Err(redis_type_error(
-                        "Response not CoordinatorState compatible",
-                        None,
-                    )),
+                    Value::Data(ref bytes) => bincode::deserialize(bytes)
+                        .map_err(|e| redis_type_error("Invalid data", Some(e.to_string()))),
+                    _ => Err(redis_type_error("Response not bincode compatible", None)),
                 }
             }
         }

--- a/rust/xaynet-server/src/storage/redis.rs
+++ b/rust/xaynet-server/src/storage/redis.rs
@@ -150,7 +150,7 @@ where
 fn into_redis_err(err: tokio::time::Elapsed) -> RedisError {
     RedisError::from((
         ErrorKind::ExtensionError,
-        "redis command timeout",
+        "execute redis command",
         err.to_string(),
     ))
 }


### PR DESCRIPTION
**Summary**

- adds a timeout to all Redis commands (except for the test methods). 
- adds a retry macro for Redis Adds a repeating macro for Redis operations that are not called in the `handle_message` method.

By inserting the timeout for redis commands, we can be certain that the state machine can never stop / block. However, this introduces a new problem. Just because the redis operation timed out and was dropped on the rust side, does not mean that the redis operation was not performed on redis. This can mean, that in phases such as sum, update or sum2 the number of successfully processed messages is lower than in redis. One way to solve this problem would be to check at the end of the phase whether the numbers match.

A more elegant implementation would be to include the function / macro in the `Connection` struct.

```rust
client.connection().with_timeout(123).with_retry().aquire().redis_command().await;
```

However, this requires major changes to the `Connection` struct and I would rather tackle it in a separate PR.
