### PR TITLE
add a helper for running futures concurrently

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -974,9 +974,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90fa4cc29d25b0687b8570b0da86eac698dcb525110ad8b938fe6712baa711ec"
+checksum = "da9052a1a50244d8d5aa9bf55cbc2fb6f357c86cc52e46c62ed390a7180cf150"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -989,9 +989,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31ebc390c6913de330e418add60e1a7e5af4cb5ec600d19111b339cafcdcc027"
+checksum = "f2d31b7ec7efab6eefc7c57233bb10b847986139d88cc2f5a02a1ae6871a1846"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -999,15 +999,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "089bd0baf024d3216916546338fffe4fc8dfffdd901e33c278abb091e0d52111"
+checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0cb59f15119671c94cd9cc543dc9a50b8d5edc468b4ff5f0bb8567f66c6b48a"
+checksum = "e9e59fdc009a4b3096bf94f740a0f2424c082521f20a9b08c5c07c48d90fd9b9"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1016,9 +1016,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3868967e4e5ab86614e2176c99949eeef6cbcacaee737765f6ae693988273997"
+checksum = "28be053525281ad8259d47e4de5de657b25e7bac113458555bb4b70bc6870500"
 
 [[package]]
 name = "futures-lite"
@@ -1037,9 +1037,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95778720c3ee3c179cd0d8fd5a0f9b40aa7d745c080f86a8f8bed33c4fd89758"
+checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -1049,24 +1049,24 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e0f6be0ec0357772fd58fb751958dd600bd0b3edfd429e77793e4282831360"
+checksum = "caf5c69029bda2e743fddd0582d1083951d65cc9539aebf8812f36c3491342d6"
 
 [[package]]
 name = "futures-task"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "868090f28a925db6cb7462938c51d807546e298fb314088239f0e52fb4338b96"
+checksum = "13de07eb8ea81ae445aca7b69f5f7bf15d7bf4912d8ca37d6645c77ae8a58d86"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "futures-util"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad5e82786df758d407932aded1235e24d8e2eb438b6adafd37930c2462fb5d1"
+checksum = "632a8cd0f2a4b3fdea1657f08bde063848c3bd00f9bbf6e256b8be78802e624b"
 dependencies = [
  "futures-channel",
  "futures-core",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4098,6 +4098,7 @@ dependencies = [
  "bincode",
  "bytes 0.5.6",
  "derive_more",
+ "futures",
  "mockall",
  "num",
  "paste",

--- a/rust/xaynet-sdk/Cargo.toml
+++ b/rust/xaynet-sdk/Cargo.toml
@@ -20,7 +20,7 @@ base64 = "0.13.0"
 bincode = "1.3.1"
 derive_more = { version = "0.99.11", default-features = false, features = ["from"] }
 # TODO: remove once concurrent_futures.rs was moved to the e2e package
-futures = "0.3.10"
+futures = "0.3.12"
 paste = "1.0.4"
 serde = { version = "1.0.119", features = ["derive"] }
 sodiumoxide = "0.2.6"

--- a/rust/xaynet-sdk/Cargo.toml
+++ b/rust/xaynet-sdk/Cargo.toml
@@ -19,10 +19,15 @@ async-trait = "0.1.42"
 base64 = "0.13.0"
 bincode = "1.3.1"
 derive_more = { version = "0.99.11", default-features = false, features = ["from"] }
+# TODO: remove once concurrent_futures.rs was moved to the e2e package
+futures = "0.3.10"
 paste = "1.0.4"
 serde = { version = "1.0.119", features = ["derive"] }
 sodiumoxide = "0.2.6"
 thiserror = "1.0.23"
+# TODO (XN-1372): upgrade
+# TODO: move to dev-dependencies once concurrent_futures.rs was moved to the e2e package
+tokio = { version = "0.2.24", features = ["rt-core", "macros"] }
 tracing = "0.1.22"
 url = "2.2.0"
 xaynet-core = { path = "../xaynet-core", version = "0.1.0" }
@@ -39,8 +44,6 @@ rand = "0.8.2"
 mockall = "0.9.0"
 num = { version = "0.3.1", features = ["serde"] }
 serde_json = "1.0.61"
-# TODO (XN-1372): upgrade
-tokio = { version = "0.2.24", features = ["rt-core", "macros"] }
 # TODO (XN-1372): can't upgrade yet because of tokio
 tokio-test = "0.2.1"
 xaynet-core = { path = "../xaynet-core", features = ["testutils"] }

--- a/rust/xaynet-sdk/src/lib.rs
+++ b/rust/xaynet-sdk/src/lib.rs
@@ -201,14 +201,12 @@
 //! ```
 
 pub mod client;
-
 mod message_encoder;
-pub(crate) use self::message_encoder::MessageEncoder;
-
 pub mod settings;
-
 mod state_machine;
-pub use state_machine::{LocalModelConfig, SerializableState, StateMachine, TransitionOutcome};
-
 mod traits;
+pub(crate) mod utils;
+
+pub(crate) use self::message_encoder::MessageEncoder;
 pub use self::traits::{ModelStore, Notify, XaynetClient};
+pub use state_machine::{LocalModelConfig, SerializableState, StateMachine, TransitionOutcome};

--- a/rust/xaynet-sdk/src/utils/concurrent_futures.rs
+++ b/rust/xaynet-sdk/src/utils/concurrent_futures.rs
@@ -1,0 +1,121 @@
+use std::{
+    collections::VecDeque,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use futures::{
+    stream::{FuturesUnordered, Stream, StreamExt},
+    Future,
+};
+use tokio::{
+    task::{JoinError, JoinHandle},
+    time::delay_for,
+};
+
+/// `ConcurrentFutures` can keep a capped number of futures running concurrently, and yield their
+/// result as they finish. When the max number of concurrent futures is reached, new tasks are
+/// queued until some in-flight futures finish.
+#[pin_project]
+pub struct ConcurrentFutures<T>
+where
+    T: Future + Send + 'static,
+    T::Output: Send + 'static,
+{
+    /// in-flight futures
+    #[pin]
+    running: FuturesUnordered<JoinHandle<T::Output>>,
+    /// buffered tasks
+    pending: VecDeque<T>,
+    /// max number of concurrent futures
+    max_in_flight: usize,
+}
+
+impl<T> ConcurrentFutures<T>
+where
+    T: Future + Send + 'static,
+    T::Output: Send + 'static,
+{
+    pub fn new(max_in_flight: usize) -> Self {
+        Self {
+            running: FuturesUnordered::new(),
+            pending: VecDeque::new(),
+            max_in_flight,
+        }
+    }
+
+    pub fn push(&mut self, task: T) {
+        self.pending.push_back(task)
+    }
+}
+
+impl<T> Stream for ConcurrentFutures<T>
+where
+    T: Future + Send + 'static,
+    T::Output: Send + 'static,
+{
+    type Item = Result<T::Output, JoinError>;
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        while this.running.len() < *this.max_in_flight {
+            if let Some(pending) = this.pending.pop_front() {
+                let handle = tokio::spawn(pending);
+                this.running.push(handle);
+            } else {
+                break;
+            }
+        }
+        this.running.poll_next(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[tokio::test]
+    async fn test() {
+        let mut stream =
+            ConcurrentFutures::<Pin<Box<dyn Future<Output = u8> + Send + 'static>>>::new(2);
+
+        stream.push(Box::pin(async {
+            delay_for(Duration::from_millis(10_u64)).await;
+            1_u8
+        }));
+
+        stream.push(Box::pin(async {
+            delay_for(Duration::from_millis(25_u64)).await;
+            2_u8
+        }));
+
+        stream.push(Box::pin(async {
+            delay_for(Duration::from_millis(12_u64)).await;
+            3_u8
+        }));
+
+        stream.push(Box::pin(async {
+            delay_for(Duration::from_millis(1_u64)).await;
+            4_u8
+        }));
+
+        // poll_next hasn't been called yet so nothing is running
+        assert_eq!(stream.running.len(), 0);
+        assert_eq!(stream.pending.len(), 4);
+        assert_eq!(stream.next().await.unwrap().unwrap(), 1);
+
+        // two futures have been spawned, but one of them just finished: one is still running, two are
+        // still pending
+        assert_eq!(stream.running.len(), 1);
+        assert_eq!(stream.pending.len(), 2);
+        assert_eq!(stream.next().await.unwrap().unwrap(), 3);
+
+        // three futures have been spawned, two finished: one is still running, one is still pending
+        assert_eq!(stream.running.len(), 1);
+        assert_eq!(stream.pending.len(), 1);
+        assert_eq!(stream.next().await.unwrap().unwrap(), 4);
+
+        // four futures have been spawn, three finished: one is still running
+        assert_eq!(stream.next().await.unwrap().unwrap(), 2);
+        assert_eq!(stream.running.len(), 0);
+        assert_eq!(stream.pending.len(), 0);
+    }
+}

--- a/rust/xaynet-sdk/src/utils/mod.rs
+++ b/rust/xaynet-sdk/src/utils/mod.rs
@@ -1,0 +1,2 @@
+// TODO: move to the e2e package
+pub mod concurrent_futures;

--- a/rust/xaynet-server/Cargo.toml
+++ b/rust/xaynet-server/Cargo.toml
@@ -31,7 +31,7 @@ derive_more = { version = "0.99.11", default-features = false, features = [
     "into",
 ] }
 displaydoc = "0.1.7"
-futures = "0.3.11"
+futures = "0.3.12"
 hex = "0.4.2"
 http = "0.2.3"
 influxdb = "0.3.0"


### PR DESCRIPTION
This will allow clients to start sending multiple chunks concurrently.

[`FuturesUnordered`](https://docs.rs/futures-util/0.3.5/futures_util/stream/futures_unordered/struct.FuturesUnordered.html)
allows us to poll multiple futures, but if we want to really run them
_concurrently_ we need to spawn them first. So this type is just a thin
wrapper around `FuturesUnordered`.