### PR TITLE
fix extended coverage of masking tests

### DIFF
--- a/rust/xaynet-core/src/mask/seed.rs
+++ b/rust/xaynet-core/src/mask/seed.rs
@@ -64,13 +64,14 @@ impl MaskSeed {
         config_one: MaskConfig,
     ) -> MaskObject {
         let mut prng = ChaCha20Rng::from_seed(self.as_array());
+
+        let rand_int = generate_integer(&mut prng, &config_one.order());
+        let scalar_mask = MaskOne::new(config_one, rand_int);
+
         let rand_ints = iter::repeat_with(|| generate_integer(&mut prng, &config_many.order()))
             .take(len)
             .collect();
         let model_mask = MaskMany::new(config_many, rand_ints);
-
-        let rand_int = generate_integer(&mut prng, &config_one.order());
-        let scalar_mask = MaskOne::new(config_one, rand_int);
 
         MaskObject::new(model_mask, scalar_mask)
     }


### PR DESCRIPTION
#524 introduced various changes to tidy the API especially around the generalised scalar extension. As such, the masking tests (several hundred tests generated by the macros `test_masking`, `test_aggregation` and `test_masking_and_aggregation`) now cover the (un)masking and aggregation of the scalar as well.

An issue was discovered in #524 where the unmasked scalar sum appeared larger than expected. This lead to "closeness checks" of model weights to exceed the desired tolerance, and so those tests (at least, those based on `test_masking` and `test_masking_and_aggregation`) were temporarily relaxed. This PR contains a fix for that issue, which was due to an inconsistency in the use of the PRNG in masking vs unmasking.

All masking tests are now reinstated, although a related issue has been found with a few test cases of `test_masking_and_aggregation`. Again, closeness checks break for those cases - for now, a slightly fewer number of models are aggregated to keep the difference within tolerance.

On a separate note, this PR also contains a more complete implementation of `MaskObjectBuffer`.