### PR TITLE
Remove exclude-files flag

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -191,7 +191,7 @@ jobs:
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1.2
         with:
-          args: '--manifest-path rust/Cargo.toml --all-features --force-clean --lib --ignore-tests --exclude-files src/vendor/*'
+          args: '--manifest-path rust/Cargo.toml --all-features --force-clean --lib --ignore-tests'
 
       - name: Stop docker-compose
         working-directory: ./docker


### PR DESCRIPTION
Removes the `--exclude-files` flag from the `cargo-tarpaulin` command. The excluded files do not exist anymore. 