### PR TITLE
XN-1207 Expose MinIO accessKey and secretKey to the coordinator pod

### DIFF
--- a/k8s/coordinator/base/deployment.yaml
+++ b/k8s/coordinator/base/deployment.yaml
@@ -27,3 +27,13 @@ spec:
                   key: redis-password
             - name: XAYNET_REDIS__URL
               value: "redis://:$(REDIS_AUTH)@redis-master"
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: minio-auth
+                  key: accesskey
+            - name: MINIO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: minio-auth
+                  key: secretkey


### PR DESCRIPTION
This makes both available via MINIO_ACCESS_KEY and MINIO_SECRET_KEY env variables, respectively.