### PR TITLE
Mobile client multipart

### DIFF
--- a/rust/xaynet-client/src/mobile_client/client.rs
+++ b/rust/xaynet-client/src/mobile_client/client.rs
@@ -64,7 +64,7 @@ impl<Type> ClientState<Type> {
         payload: Payload,
     ) -> Result<(), ClientError<T::Error>> {
         // Unwrapping is fine because this only errors out if the
-        // payload if a Chunk, which we never create in the client.
+        // payload is a Chunk, which we never create in the client.
         let encoder = MessageEncoder::<'_, Type>::new(
             &self.participant,
             payload,

--- a/rust/xaynet-client/src/mobile_client/client.rs
+++ b/rust/xaynet-client/src/mobile_client/client.rs
@@ -9,12 +9,23 @@ use crate::{
         Sum2,
         Update,
     },
+    utils::multipart::MessageEncoder,
     ClientError,
 };
 use derive_more::From;
-use xaynet_core::{common::RoundParameters, crypto::ByteObject, mask::Model, InitError};
+use xaynet_core::{
+    common::RoundParameters,
+    crypto::ByteObject,
+    mask::Model,
+    message::Payload,
+    InitError,
+};
 
 use crate::PetError;
+
+// TODO: figure out the final size of an encrypted message for a given
+// payload size. This is totally arbitrary atm...
+const MAX_PAYLOAD_SIZE: usize = 1000;
 
 #[async_trait]
 pub trait LocalModel {
@@ -45,6 +56,27 @@ impl<Type> ClientState<Type> {
     fn reset(self) -> ClientState<Awaiting> {
         warn!("reset client");
         ClientState::<Awaiting>::new(self.participant.reset(), self.round_params)
+    }
+
+    async fn send_message<T: ApiClient>(
+        &self,
+        api: &mut T,
+        payload: Payload,
+    ) -> Result<(), ClientError<T::Error>> {
+        // Unwrapping is fine because this only errors out if the
+        // payload if a Chunk, which we never create in the client.
+        let encoder = MessageEncoder::<'_, Type>::new(
+            &self.participant,
+            payload,
+            self.round_params.pk,
+            MAX_PAYLOAD_SIZE,
+        )
+        .unwrap();
+        for part in encoder {
+            let data = self.round_params.pk.encrypt(part.as_slice());
+            api.send_message(data).await?;
+        }
+        Ok(())
     }
 }
 
@@ -119,13 +151,9 @@ impl ClientState<Sum> {
     async fn run<T: ApiClient>(&mut self, api: &mut T) -> Result<(), ClientError<T::Error>> {
         self.check_round_freshness(api).await?;
 
-        let sum_msg = self.participant.compose_sum_message(self.round_params.pk);
-        let sealed_msg = self
-            .participant
-            .seal_message(&self.round_params.pk, &sum_msg);
-
+        let msg = self.participant.compose_sum_message();
         debug!("sending sum message");
-        api.send_message(sealed_msg).await?;
+        self.send_message(api, msg).await?;
         debug!("sum message sent");
         Ok(())
     }
@@ -178,15 +206,9 @@ impl ClientState<Update> {
             .await?
             .ok_or(ClientError::TooEarly("sum dict"))?;
 
-        let upd_msg =
-            self.participant
-                .compose_update_message(self.round_params.pk, &sums, local_model);
-        let sealed_msg = self
-            .participant
-            .seal_message(&self.round_params.pk, &upd_msg);
-
+        let msg = self.participant.compose_update_message(&sums, local_model);
         debug!("sending update message");
-        api.send_message(sealed_msg).await?;
+        self.send_message(api, msg).await?;
         info!("update participant completed a round");
         Ok(())
     }
@@ -230,19 +252,16 @@ impl ClientState<Sum2> {
             .await?
             .ok_or(ClientError::TooEarly("seeds"))?;
 
-        let sum2_msg = self
+        let msg = self
             .participant
-            .compose_sum2_message(self.round_params.pk, &seeds, length as usize)
+            .compose_sum2_message(&seeds, length as usize)
             .map_err(|e| {
                 error!("failed to compose sum2 message with seeds: {:?}", &seeds);
                 ClientError::ParticipantErr(e)
             })?;
-        let sealed_msg = self
-            .participant
-            .seal_message(&self.round_params.pk, &sum2_msg);
 
         debug!("sending sum2 message");
-        api.send_message(sealed_msg).await?;
+        self.send_message(api, msg).await?;
         info!("sum participant completed a round");
         Ok(())
     }

--- a/rust/xaynet-client/src/mobile_client/participant/sum.rs
+++ b/rust/xaynet-client/src/mobile_client/participant/sum.rs
@@ -2,8 +2,7 @@ use super::{Participant, ParticipantState};
 use crate::mobile_client::participant::Sum2;
 use xaynet_core::{
     crypto::EncryptKeyPair,
-    message::{Message, Sum as SumMessage},
-    CoordinatorPublicKey,
+    message::{Payload, Sum as SumMessage},
     ParticipantTaskSignature,
     SumParticipantEphemeralPublicKey,
     SumParticipantEphemeralSecretKey,
@@ -30,15 +29,12 @@ impl Participant<Sum> {
     }
 
     /// Compose a sum message given the coordinator public key.
-    pub fn compose_sum_message(&mut self, coordinator_pk: CoordinatorPublicKey) -> Message {
-        Message::new_sum(
-            self.state.keys.public,
-            coordinator_pk,
-            SumMessage {
-                sum_signature: self.inner.sum_signature,
-                ephm_pk: self.inner.ephm_pk,
-            },
-        )
+    pub fn compose_sum_message(&self) -> Payload {
+        SumMessage {
+            sum_signature: self.inner.sum_signature,
+            ephm_pk: self.inner.ephm_pk,
+        }
+        .into()
     }
 }
 

--- a/rust/xaynet-client/src/mobile_client/participant/sum2.rs
+++ b/rust/xaynet-client/src/mobile_client/participant/sum2.rs
@@ -1,8 +1,7 @@
 use super::{Participant, ParticipantState};
 use xaynet_core::{
     mask::{Aggregation, MaskObject, MaskSeed},
-    message::{Message, Sum2 as Sum2Message},
-    CoordinatorPublicKey,
+    message::{Payload, Sum2 as Sum2Message},
     ParticipantPublicKey,
     ParticipantTaskSignature,
     SumParticipantEphemeralPublicKey,
@@ -45,18 +44,16 @@ impl Participant<Sum2> {
     /// seed dictionary, or computing the global mask.
     pub fn compose_sum2_message(
         &self,
-        coordinator_pk: CoordinatorPublicKey,
         seed_dict: &UpdateSeedDict,
         mask_len: usize,
-    ) -> Result<Message, PetError> {
+    ) -> Result<Payload, PetError> {
         let mask_seeds = self.get_seeds(seed_dict)?;
         let mask = self.compute_global_mask(mask_seeds, mask_len)?;
-        let payload = Sum2Message {
+        let sum2 = Sum2Message {
             sum_signature: self.inner.sum_signature,
             model_mask: mask,
         };
-        let message = Message::new_sum2(self.state.keys.public, coordinator_pk, payload);
-        Ok(message)
+        Ok(sum2.into())
     }
 
     pub fn get_participant_pk(&self) -> ParticipantPublicKey {

--- a/rust/xaynet-client/src/mobile_client/participant/update.rs
+++ b/rust/xaynet-client/src/mobile_client/participant/update.rs
@@ -1,8 +1,7 @@
 use super::{Participant, ParticipantState};
 use xaynet_core::{
     mask::{MaskObject, MaskSeed, Masker, Model},
-    message::{Message, Update as UpdateMessage},
-    CoordinatorPublicKey,
+    message::{Payload, Update as UpdateMessage},
     LocalSeedDict,
     ParticipantTaskSignature,
     SumDict,
@@ -30,22 +29,16 @@ impl Participant<Update> {
 
     /// Compose an update message given the coordinator public key, sum
     /// dictionary, model scalar and local model update.
-    pub fn compose_update_message(
-        &self,
-        coordinator_pk: CoordinatorPublicKey,
-        sum_dict: &SumDict,
-
-        local_model: Model,
-    ) -> Message {
+    pub fn compose_update_message(&self, sum_dict: &SumDict, local_model: Model) -> Payload {
         let (mask_seed, masked_model) = self.mask_model(local_model);
         let local_seed_dict = Self::create_local_seed_dict(sum_dict, &mask_seed);
-        let payload = UpdateMessage {
+        UpdateMessage {
             sum_signature: self.inner.sum_signature,
             update_signature: self.inner.update_signature,
             masked_model,
             local_seed_dict,
-        };
-        Message::new_update(self.state.keys.public, coordinator_pk, payload)
+        }
+        .into()
     }
 
     /// Generate a mask seed and mask a local model.

--- a/rust/xaynet-client/src/utils/multipart/mod.rs
+++ b/rust/xaynet-client/src/utils/multipart/mod.rs
@@ -2,3 +2,4 @@ mod chunker;
 pub(self) use chunker::Chunker;
 
 mod encoder;
+pub use encoder::MessageEncoder;


### PR DESCRIPTION
This is a minimalistic implementation of multipart messages for the mobile client. The following limitations will be addressed in follow-up PRs:

- there is no retry mechanism. If a chunk cannot be sent, the client doesn't try to re-send it.
- chunks are sent sequentially. We could make it possible to send several chunks in parallel
- if a chunk cannot be sent, the client doesn't try to send the next chunks
- the maximum chunk size is currently hard-coded

This is based on https://github.com/xaynetwork/xaynet/pull/543