### PR TITLE
mask object and unmasking improvements

### DIFF
--- a/rust/xaynet-client/src/utils/multipart/encoder.rs
+++ b/rust/xaynet-client/src/utils/multipart/encoder.rs
@@ -280,9 +280,9 @@ mod tests {
             weights.push(BigUint::from(i));
         }
 
-        let masked_model = MaskVect::new(mask_config(), weights);
-        let masked_scalar = MaskUnit::new(mask_config(), BigUint::from(0_u32));
-        let obj = MaskObject::new(masked_model, masked_scalar);
+        let masked_model = MaskVect::new_unchecked(mask_config(), weights);
+        let masked_scalar = MaskUnit::new_unchecked(mask_config(), BigUint::from(0_u32));
+        let obj = MaskObject::new_unchecked(masked_model, masked_scalar);
 
         // Check that our calculations are correct
         assert_eq!(obj.buffer_length(), len);

--- a/rust/xaynet-client/src/utils/multipart/encoder.rs
+++ b/rust/xaynet-client/src/utils/multipart/encoder.rs
@@ -208,9 +208,9 @@ mod tests {
             EncryptedMaskSeed,
             GroupType,
             MaskConfig,
-            MaskMany,
             MaskObject,
-            MaskOne,
+            MaskUnit,
+            MaskVect,
             ModelType,
         },
         message::{FromBytes, Update},
@@ -280,8 +280,8 @@ mod tests {
             weights.push(BigUint::from(i));
         }
 
-        let masked_model = MaskMany::new(mask_config(), weights);
-        let masked_scalar = MaskOne::new(mask_config(), BigUint::from(0_u32));
+        let masked_model = MaskVect::new(mask_config(), weights);
+        let masked_scalar = MaskUnit::new(mask_config(), BigUint::from(0_u32));
         let obj = MaskObject::new(masked_model, masked_scalar);
 
         // Check that our calculations are correct

--- a/rust/xaynet-core/src/mask/masking.rs
+++ b/rust/xaynet-core/src/mask/masking.rs
@@ -21,7 +21,7 @@ use crate::{
     mask::{
         config::MaskConfig,
         model::{float_to_ratio_bounded, Model},
-        object::{MaskMany, MaskObject, MaskOne},
+        object::{MaskObject, MaskOne, MaskVect},
         seed::MaskSeed,
     },
 };
@@ -399,7 +399,7 @@ impl Masker {
                 (shifted + rand_int) % &order
             })
             .collect();
-        let masked_model = MaskMany::new(config_model, masked_weights);
+        let masked_model = MaskVect::new(config_model, masked_weights);
 
         // mask the scalar
         // PANIC_SAFE: shifted scalar is guaranteed to be non-negative
@@ -629,7 +629,7 @@ mod tests {
                         let integers = iter::repeat_with(|| generate_integer(&mut prng, &order))
                             .take($len as usize)
                             .collect::<Vec<_>>();
-                        let model = MaskMany::new(config, integers);
+                        let model = MaskVect::new(config, integers);
                         let scalar = MaskOne::empty(config);
                         MaskObject::new(model, scalar)
                     });

--- a/rust/xaynet-core/src/mask/masking.rs
+++ b/rust/xaynet-core/src/mask/masking.rs
@@ -497,7 +497,7 @@ mod tests {
                     // c. unmask the model and check it against the original one.
                     let (mask_seed, masked_model) =
                         Masker::new(config.clone(), config.clone()).mask(1_f64, model.clone());
-                    assert_eq!(masked_model.vector.data.len(), model.len());
+                    assert_eq!(masked_model.vect.data.len(), model.len());
                     assert!(masked_model.is_valid());
 
                     let mask = mask_seed.derive_mask(model.len(), config.clone(), config.clone());
@@ -626,7 +626,7 @@ mod tests {
                             .take($len as usize)
                             .collect::<Vec<_>>();
                         let model = MaskVect::new(config, integers);
-                        let scalar = MaskOne::empty(config);
+                        let scalar = MaskUnit::default(config);
                         MaskObject::new(model, scalar)
                     });
 
@@ -642,9 +642,9 @@ mod tests {
                         aggregated_masked_model.aggregate(masked_model);
 
                         assert_eq!(aggregated_masked_model.nb_models, nb);
-                        assert_eq!(aggregated_masked_model.object.vector.data.len(), $len as usize);
-                        assert_eq!(aggregated_masked_model.object.vector.config, config);
-                        assert_eq!(aggregated_masked_model.object.scalar.config, config);
+                        assert_eq!(aggregated_masked_model.object.vect.data.len(), $len as usize);
+                        assert_eq!(aggregated_masked_model.object.vect.config, config);
+                        assert_eq!(aggregated_masked_model.object.unit.config, config);
                         assert!(aggregated_masked_model.object.is_valid());
                     }
                 }

--- a/rust/xaynet-core/src/mask/masking.rs
+++ b/rust/xaynet-core/src/mask/masking.rs
@@ -21,7 +21,7 @@ use crate::{
     mask::{
         config::MaskConfig,
         model::{float_to_ratio_bounded, Model},
-        object::{MaskObject, MaskOne, MaskVect},
+        object::{MaskObject, MaskUnit, MaskVect},
         seed::MaskSeed,
     },
 };
@@ -408,7 +408,7 @@ impl Masker {
             .to_biguint()
             .unwrap();
         let masked = (shifted + random_int) % config_scalar.order();
-        let masked_scalar = MaskOne::new(config_scalar, masked);
+        let masked_scalar = MaskUnit::new(config_scalar, masked);
 
         (seed, MaskObject::new(masked_model, masked_scalar))
     }

--- a/rust/xaynet-core/src/mask/mod.rs
+++ b/rust/xaynet-core/src/mask/mod.rs
@@ -199,12 +199,6 @@ pub use self::{
     },
     masking::{Aggregation, AggregationError, Masker, UnmaskingError},
     model::{FromPrimitives, IntoPrimitives, Model, ModelCastError, PrimitiveCastError},
-    object::{
-        serialization::MaskManyBuffer,
-        InvalidMaskObjectError,
-        MaskMany,
-        MaskObject,
-        MaskOne,
-    },
+    object::{serialization::MaskManyBuffer, InvalidMaskObjectError, MaskObject, MaskVect},
     seed::{EncryptedMaskSeed, MaskSeed},
 };

--- a/rust/xaynet-core/src/mask/mod.rs
+++ b/rust/xaynet-core/src/mask/mod.rs
@@ -199,6 +199,6 @@ pub use self::{
     },
     masking::{Aggregation, AggregationError, Masker, UnmaskingError},
     model::{FromPrimitives, IntoPrimitives, Model, ModelCastError, PrimitiveCastError},
-    object::{serialization::MaskVectBuffer, InvalidMaskObjectError, MaskObject, MaskVect},
+    object::{serialization::vect::MaskVectBuffer, InvalidMaskObjectError, MaskObject, MaskVect},
     seed::{EncryptedMaskSeed, MaskSeed},
 };

--- a/rust/xaynet-core/src/mask/mod.rs
+++ b/rust/xaynet-core/src/mask/mod.rs
@@ -199,6 +199,6 @@ pub use self::{
     },
     masking::{Aggregation, AggregationError, Masker, UnmaskingError},
     model::{FromPrimitives, IntoPrimitives, Model, ModelCastError, PrimitiveCastError},
-    object::{serialization::MaskManyBuffer, InvalidMaskObjectError, MaskObject, MaskVect},
+    object::{serialization::MaskVectBuffer, InvalidMaskObjectError, MaskObject, MaskVect},
     seed::{EncryptedMaskSeed, MaskSeed},
 };

--- a/rust/xaynet-core/src/mask/mod.rs
+++ b/rust/xaynet-core/src/mask/mod.rs
@@ -199,6 +199,12 @@ pub use self::{
     },
     masking::{Aggregation, AggregationError, Masker, UnmaskingError},
     model::{FromPrimitives, IntoPrimitives, Model, ModelCastError, PrimitiveCastError},
-    object::{serialization::vect::MaskVectBuffer, InvalidMaskObjectError, MaskObject, MaskVect},
+    object::{
+        serialization::vect::MaskVectBuffer,
+        InvalidMaskObjectError,
+        MaskObject,
+        MaskUnit,
+        MaskVect,
+    },
     seed::{EncryptedMaskSeed, MaskSeed},
 };

--- a/rust/xaynet-core/src/mask/object/mod.rs
+++ b/rust/xaynet-core/src/mask/object/mod.rs
@@ -27,7 +27,7 @@ pub struct MaskVect {
 
 impl MaskVect {
     /// Creates a new mask vector from the given data and masking configuration.
-    pub fn new(config: MaskConfig, data: Vec<BigUint>) -> Self {
+    pub fn new_unchecked(config: MaskConfig, data: Vec<BigUint>) -> Self {
         Self { data, config }
     }
 
@@ -35,11 +35,8 @@ impl MaskVect {
     ///
     /// # Errors
     /// Fails if the elements of the mask object don't conform to the given masking configuration.
-    pub fn new_checked(
-        config: MaskConfig,
-        data: Vec<BigUint>,
-    ) -> Result<Self, InvalidMaskObjectError> {
-        let obj = Self::new(config, data);
+    pub fn new(config: MaskConfig, data: Vec<BigUint>) -> Result<Self, InvalidMaskObjectError> {
+        let obj = Self::new_unchecked(config, data);
         if obj.is_valid() {
             Ok(obj)
         } else {
@@ -71,19 +68,19 @@ pub struct MaskUnit {
 
 impl From<&MaskUnit> for MaskVect {
     fn from(mask_unit: &MaskUnit) -> Self {
-        Self::new(mask_unit.config, vec![mask_unit.data.clone()])
+        Self::new_unchecked(mask_unit.config, vec![mask_unit.data.clone()])
     }
 }
 
 impl From<MaskUnit> for MaskVect {
     fn from(mask_unit: MaskUnit) -> Self {
-        Self::new(mask_unit.config, vec![mask_unit.data])
+        Self::new_unchecked(mask_unit.config, vec![mask_unit.data])
     }
 }
 
 impl MaskUnit {
     /// Creates a new mask unit from the given mask and masking configuration.
-    pub fn new(config: MaskConfig, data: BigUint) -> Self {
+    pub fn new_unchecked(config: MaskConfig, data: BigUint) -> Self {
         Self { data, config }
     }
 
@@ -91,8 +88,8 @@ impl MaskUnit {
     ///
     /// # Errors
     /// Fails if the mask unit doesn't conform to the given masking configuration.
-    pub fn new_checked(config: MaskConfig, data: BigUint) -> Result<Self, InvalidMaskObjectError> {
-        let obj = Self::new(config, data);
+    pub fn new(config: MaskConfig, data: BigUint) -> Result<Self, InvalidMaskObjectError> {
+        let obj = Self::new_unchecked(config, data);
         if obj.is_valid() {
             Ok(obj)
         } else {
@@ -123,19 +120,19 @@ pub struct MaskObject {
 
 impl MaskObject {
     /// Creates a new mask object from the given vector and unit.
-    pub fn new(vect: MaskVect, unit: MaskUnit) -> Self {
+    pub fn new_unchecked(vect: MaskVect, unit: MaskUnit) -> Self {
         Self { vect, unit }
     }
 
     /// Creates a new mask object from the given vector, unit and masking configurations.
-    pub fn new_checked(
+    pub fn new(
         config_v: MaskConfig,
         data_v: Vec<BigUint>,
         config_s: MaskConfig,
         data_s: BigUint,
     ) -> Result<Self, InvalidMaskObjectError> {
-        let vect = MaskVect::new_checked(config_v, data_v)?;
-        let unit = MaskUnit::new_checked(config_s, data_s)?;
+        let vect = MaskVect::new(config_v, data_v)?;
+        let unit = MaskUnit::new(config_s, data_s)?;
         Ok(Self { vect, unit })
     }
 

--- a/rust/xaynet-core/src/mask/object/mod.rs
+++ b/rust/xaynet-core/src/mask/object/mod.rs
@@ -128,19 +128,6 @@ impl MaskObject {
     }
 
     /// Creates a new mask object from the given vector, unit and masking configurations.
-    pub fn new_unchecked(
-        config_v: MaskConfig,
-        data_v: Vec<BigUint>,
-        config_s: MaskConfig,
-        data_s: BigUint,
-    ) -> Self {
-        Self {
-            vect: MaskVect::new(config_v, data_v),
-            unit: MaskUnit::new(config_s, data_s),
-        }
-    }
-
-    /// Creates a new mask object from the given vector, unit and masking configurations.
     pub fn new_checked(
         config_v: MaskConfig,
         data_v: Vec<BigUint>,

--- a/rust/xaynet-core/src/mask/object/mod.rs
+++ b/rust/xaynet-core/src/mask/object/mod.rs
@@ -65,24 +65,24 @@ impl MaskVect {
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Serialize, Deserialize)]
 /// A mask object which represents either a mask or a masked scalar.
-pub struct MaskOne {
+pub struct MaskUnit {
     pub data: BigUint,
     pub config: MaskConfig,
 }
 
-impl From<&MaskOne> for MaskVect {
-    fn from(mask_one: &MaskOne) -> Self {
+impl From<&MaskUnit> for MaskVect {
+    fn from(mask_one: &MaskUnit) -> Self {
         Self::new(mask_one.config, vec![mask_one.data.clone()])
     }
 }
 
-impl From<MaskOne> for MaskVect {
-    fn from(mask_one: MaskOne) -> Self {
+impl From<MaskUnit> for MaskVect {
+    fn from(mask_one: MaskUnit) -> Self {
         Self::new(mask_one.config, vec![mask_one.data])
     }
 }
 
-impl MaskOne {
+impl MaskUnit {
     /// Creates a new mask object from the given masking configuration and the mask
     /// or masked scalar.
     pub fn new(config: MaskConfig, data: BigUint) -> Self {
@@ -120,12 +120,12 @@ impl MaskOne {
 /// A mask object wrapper around a `MaskMany`, `MaskOne` pair.
 pub struct MaskObject {
     pub vector: MaskVect,
-    pub scalar: MaskOne,
+    pub scalar: MaskUnit,
 }
 
 impl MaskObject {
     // TODO doc
-    pub fn new(vector: MaskVect, scalar: MaskOne) -> Self {
+    pub fn new(vector: MaskVect, scalar: MaskUnit) -> Self {
         Self { vector, scalar }
     }
 
@@ -138,7 +138,7 @@ impl MaskObject {
     ) -> Self {
         Self {
             vector: MaskVect::new(config_v, data_v),
-            scalar: MaskOne::new(config_s, data_s),
+            scalar: MaskUnit::new(config_s, data_s),
         }
     }
 
@@ -150,14 +150,14 @@ impl MaskObject {
         data_s: BigUint,
     ) -> Result<Self, InvalidMaskObjectError> {
         let vector = MaskVect::new_checked(config_v, data_v)?;
-        let scalar = MaskOne::new_checked(config_s, data_s)?;
+        let scalar = MaskUnit::new_checked(config_s, data_s)?;
         Ok(Self { vector, scalar })
     }
 
     pub fn empty(config_many: MaskConfig, config_one: MaskConfig, size: usize) -> Self {
         Self {
             vector: MaskVect::empty(config_many, size),
-            scalar: MaskOne::empty(config_one),
+            scalar: MaskUnit::empty(config_one),
         }
     }
 

--- a/rust/xaynet-core/src/mask/object/mod.rs
+++ b/rust/xaynet-core/src/mask/object/mod.rs
@@ -119,14 +119,14 @@ impl MaskUnit {
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Serialize, Deserialize)]
 /// A mask object wrapper around a `MaskMany`, `MaskOne` pair.
 pub struct MaskObject {
-    pub vector: MaskVect,
-    pub scalar: MaskUnit,
+    pub vect: MaskVect,
+    pub unit: MaskUnit,
 }
 
 impl MaskObject {
     // TODO doc
-    pub fn new(vector: MaskVect, scalar: MaskUnit) -> Self {
-        Self { vector, scalar }
+    pub fn new(vect: MaskVect, unit: MaskUnit) -> Self {
+        Self { vect, unit }
     }
 
     // TODO perhaps no need
@@ -137,8 +137,8 @@ impl MaskObject {
         data_s: BigUint,
     ) -> Self {
         Self {
-            vector: MaskVect::new(config_v, data_v),
-            scalar: MaskUnit::new(config_s, data_s),
+            vect: MaskVect::new(config_v, data_v),
+            unit: MaskUnit::new(config_s, data_s),
         }
     }
 
@@ -149,20 +149,20 @@ impl MaskObject {
         config_s: MaskConfig,
         data_s: BigUint,
     ) -> Result<Self, InvalidMaskObjectError> {
-        let vector = MaskVect::new_checked(config_v, data_v)?;
-        let scalar = MaskUnit::new_checked(config_s, data_s)?;
-        Ok(Self { vector, scalar })
+        let vect = MaskVect::new_checked(config_v, data_v)?;
+        let unit = MaskUnit::new_checked(config_s, data_s)?;
+        Ok(Self { vect, unit })
     }
 
     pub fn empty(config_many: MaskConfig, config_one: MaskConfig, size: usize) -> Self {
         Self {
-            vector: MaskVect::empty(config_many, size),
-            scalar: MaskUnit::empty(config_one),
+            vect: MaskVect::empty(config_many, size),
+            unit: MaskUnit::empty(config_one),
         }
     }
 
     // TODO doc
     pub fn is_valid(&self) -> bool {
-        self.vector.is_valid() && self.scalar.is_valid()
+        self.vect.is_valid() && self.unit.is_valid()
     }
 }

--- a/rust/xaynet-core/src/mask/object/mod.rs
+++ b/rust/xaynet-core/src/mask/object/mod.rs
@@ -20,12 +20,12 @@ pub struct InvalidMaskObjectError;
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Serialize, Deserialize)]
 /// A mask object which represents either a mask or a masked model.
-pub struct MaskMany {
+pub struct MaskVect {
     pub data: Vec<BigUint>,
     pub config: MaskConfig,
 }
 
-impl MaskMany {
+impl MaskVect {
     /// Creates a new mask object from the given masking configuration and the elements of the mask
     /// or masked model.
     pub fn new(config: MaskConfig, data: Vec<BigUint>) -> Self {
@@ -70,13 +70,13 @@ pub struct MaskOne {
     pub config: MaskConfig,
 }
 
-impl From<&MaskOne> for MaskMany {
+impl From<&MaskOne> for MaskVect {
     fn from(mask_one: &MaskOne) -> Self {
         Self::new(mask_one.config, vec![mask_one.data.clone()])
     }
 }
 
-impl From<MaskOne> for MaskMany {
+impl From<MaskOne> for MaskVect {
     fn from(mask_one: MaskOne) -> Self {
         Self::new(mask_one.config, vec![mask_one.data])
     }
@@ -119,13 +119,13 @@ impl MaskOne {
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Serialize, Deserialize)]
 /// A mask object wrapper around a `MaskMany`, `MaskOne` pair.
 pub struct MaskObject {
-    pub vector: MaskMany,
+    pub vector: MaskVect,
     pub scalar: MaskOne,
 }
 
 impl MaskObject {
     // TODO doc
-    pub fn new(vector: MaskMany, scalar: MaskOne) -> Self {
+    pub fn new(vector: MaskVect, scalar: MaskOne) -> Self {
         Self { vector, scalar }
     }
 
@@ -137,7 +137,7 @@ impl MaskObject {
         data_s: BigUint,
     ) -> Self {
         Self {
-            vector: MaskMany::new(config_v, data_v),
+            vector: MaskVect::new(config_v, data_v),
             scalar: MaskOne::new(config_s, data_s),
         }
     }
@@ -149,14 +149,14 @@ impl MaskObject {
         config_s: MaskConfig,
         data_s: BigUint,
     ) -> Result<Self, InvalidMaskObjectError> {
-        let vector = MaskMany::new_checked(config_v, data_v)?;
+        let vector = MaskVect::new_checked(config_v, data_v)?;
         let scalar = MaskOne::new_checked(config_s, data_s)?;
         Ok(Self { vector, scalar })
     }
 
     pub fn empty(config_many: MaskConfig, config_one: MaskConfig, size: usize) -> Self {
         Self {
-            vector: MaskMany::empty(config_many, size),
+            vector: MaskVect::empty(config_many, size),
             scalar: MaskOne::empty(config_one),
         }
     }

--- a/rust/xaynet-core/src/mask/object/serialization.rs
+++ b/rust/xaynet-core/src/mask/object/serialization.rs
@@ -369,30 +369,30 @@ impl FromBytes for MaskUnit {
 
 impl ToBytes for MaskObject {
     fn buffer_length(&self) -> usize {
-        self.vector.buffer_length() + self.scalar.buffer_length()
+        self.vect.buffer_length() + self.unit.buffer_length()
     }
 
     fn to_bytes<T: AsMut<[u8]> + AsRef<[u8]>>(&self, buffer: &mut T) {
         let mut writer = MaskObjectBuffer::new_unchecked(buffer.as_mut());
-        self.vector.to_bytes(&mut writer.vector_mut());
-        self.scalar.to_bytes(&mut writer.scalar_mut());
+        self.vect.to_bytes(&mut writer.vector_mut());
+        self.unit.to_bytes(&mut writer.scalar_mut());
     }
 }
 
 impl FromBytes for MaskObject {
     fn from_byte_slice<T: AsRef<[u8]>>(buffer: &T) -> Result<Self, DecodeError> {
         let reader = MaskObjectBuffer::new(buffer.as_ref())?;
-        let vector = MaskVect::from_byte_slice(&reader.vector()).context("invalid vector part")?;
-        let scalar = MaskUnit::from_byte_slice(&reader.scalar()).context("invalid scalar part")?;
-        Ok(Self { vector, scalar })
+        let vect = MaskVect::from_byte_slice(&reader.vector()).context("invalid vector part")?;
+        let unit = MaskUnit::from_byte_slice(&reader.scalar()).context("invalid scalar part")?;
+        Ok(Self { vect, unit })
     }
 
     fn from_byte_stream<I: Iterator<Item = u8> + ExactSizeIterator>(
         iter: &mut I,
     ) -> Result<Self, DecodeError> {
-        let vector = MaskVect::from_byte_stream(iter).context("invalid vector part")?;
-        let scalar = MaskUnit::from_byte_stream(iter).context("invalid scalar part")?;
-        Ok(Self { vector, scalar })
+        let vect = MaskVect::from_byte_stream(iter).context("invalid vector part")?;
+        let unit = MaskUnit::from_byte_stream(iter).context("invalid scalar part")?;
+        Ok(Self { vect, unit })
     }
 }
 

--- a/rust/xaynet-core/src/mask/object/serialization/mod.rs
+++ b/rust/xaynet-core/src/mask/object/serialization/mod.rs
@@ -145,9 +145,9 @@ pub(crate) mod tests {
     use super::*;
     use crate::mask::{
         config::{BoundType, DataType, GroupType, MaskConfig, ModelType},
+        object::serialization::vect::tests::{mask_unit, mask_vect},
         MaskObject,
     };
-    use num::BigUint;
 
     pub fn mask_config() -> (MaskConfig, Vec<u8>) {
         // config.order() = 20_000_000_000_001 with this config, so the data
@@ -160,41 +160,6 @@ pub(crate) mod tests {
         };
         let bytes = vec![0x00, 0x02, 0x00, 0x03];
         (config, bytes)
-    }
-
-    pub fn mask_vect() -> (MaskVect, Vec<u8>) {
-        let (config, mut bytes) = mask_config();
-        let data = vec![
-            BigUint::from(1_u8),
-            BigUint::from(2_u8),
-            BigUint::from(3_u8),
-            BigUint::from(4_u8),
-        ];
-        let mask_vect = MaskVect::new(config, data);
-
-        bytes.extend(vec![
-            // number of elements
-            0x00, 0x00, 0x00, 0x04, // data (1 weight => 6 bytes with this config)
-            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, // 1
-            0x02, 0x00, 0x00, 0x00, 0x00, 0x00, // 2
-            0x03, 0x00, 0x00, 0x00, 0x00, 0x00, // 3
-            0x04, 0x00, 0x00, 0x00, 0x00, 0x00, // 4
-        ]);
-
-        (mask_vect, bytes)
-    }
-
-    pub fn mask_unit() -> (MaskUnit, Vec<u8>) {
-        let (config, mut bytes) = mask_config();
-        let data = BigUint::from(1_u8);
-        let mask_unit = MaskUnit::new(config, data);
-
-        bytes.extend(vec![
-            // number of elements
-            0x00, 0x00, 0x00, 0x01, // data
-            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, // 1
-        ]);
-        (mask_unit, bytes)
     }
 
     pub fn mask_object() -> (MaskObject, Vec<u8>) {
@@ -225,52 +190,6 @@ pub(crate) mod tests {
         let (expected, bytes) = mask_object();
         assert_eq!(
             MaskObject::from_byte_stream(&mut bytes.into_iter()).unwrap(),
-            expected
-        );
-    }
-
-    #[test]
-    fn serialize_mask_vect() {
-        let (mask_vect, expected) = mask_vect();
-        let mut buf = vec![0xff; expected.len()];
-        mask_vect.to_bytes(&mut buf);
-        assert_eq!(buf, expected);
-    }
-
-    #[test]
-    fn deserialize_mask_vect() {
-        let (expected, bytes) = mask_vect();
-        assert_eq!(MaskVect::from_byte_slice(&&bytes[..]).unwrap(), expected);
-    }
-
-    #[test]
-    fn deserialize_mask_vect_from_stream() {
-        let (expected, bytes) = mask_vect();
-        assert_eq!(
-            MaskVect::from_byte_stream(&mut bytes.into_iter()).unwrap(),
-            expected
-        );
-    }
-
-    #[test]
-    fn serialize_mask_unit() {
-        let (mask_unit, expected) = mask_unit();
-        let mut buf = vec![0xff; expected.len()];
-        mask_unit.to_bytes(&mut buf);
-        assert_eq!(buf, expected);
-    }
-
-    #[test]
-    fn deserialize_mask_unit() {
-        let (expected, bytes) = mask_unit();
-        assert_eq!(MaskUnit::from_byte_slice(&&bytes[..]).unwrap(), expected);
-    }
-
-    #[test]
-    fn deserialize_mask_unit_from_stream() {
-        let (expected, bytes) = mask_unit();
-        assert_eq!(
-            MaskUnit::from_byte_stream(&mut bytes.into_iter()).unwrap(),
             expected
         );
     }

--- a/rust/xaynet-core/src/mask/object/serialization/mod.rs
+++ b/rust/xaynet-core/src/mask/object/serialization/mod.rs
@@ -165,7 +165,7 @@ pub(crate) mod tests {
     pub fn mask_object() -> (MaskObject, Vec<u8>) {
         let (mask_vect, mask_vect_bytes) = mask_vect();
         let (mask_unit, mask_unit_bytes) = mask_unit();
-        let obj = MaskObject::new(mask_vect, mask_unit);
+        let obj = MaskObject::new_unchecked(mask_vect, mask_unit);
         let bytes = [mask_vect_bytes.as_slice(), mask_unit_bytes.as_slice()].concat();
 
         (obj, bytes)

--- a/rust/xaynet-core/src/mask/object/serialization/mod.rs
+++ b/rust/xaynet-core/src/mask/object/serialization/mod.rs
@@ -1,0 +1,277 @@
+//! Serialization of masked objects.
+//!
+//! See the [mask module] documentation since this is a private module anyways.
+//!
+//! [mask module]: ../index.html
+
+pub(crate) mod vect;
+
+use anyhow::Context;
+
+use crate::{
+    mask::object::{serialization::vect::MaskVectBuffer, MaskObject, MaskUnit, MaskVect},
+    message::{
+        traits::{FromBytes, ToBytes},
+        DecodeError,
+    },
+};
+
+// target dependent maximum number of mask object elements
+#[cfg(target_pointer_width = "16")]
+const MAX_NB: u32 = u16::MAX as u32;
+
+/// A buffer for serialized mask objects.
+pub struct MaskObjectBuffer<T> {
+    inner: T,
+}
+
+impl<T: AsRef<[u8]>> MaskObjectBuffer<T> {
+    /// Creates a new buffer from `bytes`.
+    ///
+    /// # Errors
+    /// Fails if the `bytes` don't conform to the required buffer length for mask objects.
+    pub fn new(bytes: T) -> Result<Self, DecodeError> {
+        let buffer = Self { inner: bytes };
+        buffer
+            .check_buffer_length()
+            .context("not a valid MaskObject")?;
+        Ok(buffer)
+    }
+
+    /// Creates a new buffer from `bytes`.
+    pub fn new_unchecked(bytes: T) -> Self {
+        Self { inner: bytes }
+    }
+
+    /// Checks if this buffer conforms to the required buffer length for mask objects.
+    ///
+    /// # Errors
+    /// Fails if the buffer is too small.
+    pub fn check_buffer_length(&self) -> Result<(), DecodeError> {
+        let inner = self.inner.as_ref();
+        // check length of vector field
+        MaskVectBuffer::new(&inner[0..]).context("invalid vector field")?;
+        // check length of scalar field
+        // TODO possible change to MaskOneBuffer in the future once implemented
+        MaskVectBuffer::new(&inner[self.unit_offset()..]).context("invalid unit field")?;
+        Ok(())
+    }
+
+    /// Gets the vector part.
+    ///
+    /// # Panics
+    /// May panic if this buffer is unchecked.
+    pub fn vect(&self) -> &[u8] {
+        let len = self.unit_offset();
+        &self.inner.as_ref()[0..len]
+    }
+
+    /// Gets the offset of the unit field.
+    pub fn unit_offset(&self) -> usize {
+        let vect_buf = MaskVectBuffer::new_unchecked(&self.inner.as_ref()[0..]);
+        vect_buf.len()
+    }
+
+    /// Gets the unit part.
+    ///
+    /// # Panics
+    /// May panic if this buffer is unchecked.
+    pub fn unit(&self) -> &[u8] {
+        let offset = self.unit_offset();
+        &self.inner.as_ref()[offset..]
+    }
+
+    /// Gets the expected number of bytes of this buffer.
+    ///
+    /// # Panics
+    /// May panic if this buffer is unchecked.
+    pub fn len(&self) -> usize {
+        let unit_offset = self.unit_offset();
+        let unit_buf = MaskVectBuffer::new_unchecked(&self.inner.as_ref()[unit_offset..]);
+        unit_offset + unit_buf.len()
+    }
+}
+
+impl<T: AsRef<[u8]> + AsMut<[u8]>> MaskObjectBuffer<T> {
+    /// Gets the vector part.
+    ///
+    /// # Panics
+    /// May panic if this buffer is unchecked.
+    pub fn vect_mut(&mut self) -> &mut [u8] {
+        &mut self.inner.as_mut()[0..]
+    }
+
+    /// Gets the unit part.
+    ///
+    /// # Panics
+    /// May panic if this buffer is unchecked.
+    pub fn unit_mut(&mut self) -> &mut [u8] {
+        let offset = self.unit_offset();
+        &mut self.inner.as_mut()[offset..]
+    }
+}
+
+impl ToBytes for MaskObject {
+    fn buffer_length(&self) -> usize {
+        self.vect.buffer_length() + self.unit.buffer_length()
+    }
+
+    fn to_bytes<T: AsMut<[u8]> + AsRef<[u8]>>(&self, buffer: &mut T) {
+        let mut writer = MaskObjectBuffer::new_unchecked(buffer.as_mut());
+        self.vect.to_bytes(&mut writer.vect_mut());
+        self.unit.to_bytes(&mut writer.unit_mut());
+    }
+}
+
+impl FromBytes for MaskObject {
+    fn from_byte_slice<T: AsRef<[u8]>>(buffer: &T) -> Result<Self, DecodeError> {
+        let reader = MaskObjectBuffer::new(buffer.as_ref())?;
+        let vect = MaskVect::from_byte_slice(&reader.vect()).context("invalid vector part")?;
+        let unit = MaskUnit::from_byte_slice(&reader.unit()).context("invalid unit part")?;
+        Ok(Self { vect, unit })
+    }
+
+    fn from_byte_stream<I: Iterator<Item = u8> + ExactSizeIterator>(
+        iter: &mut I,
+    ) -> Result<Self, DecodeError> {
+        let vect = MaskVect::from_byte_stream(iter).context("invalid vector part")?;
+        let unit = MaskUnit::from_byte_stream(iter).context("invalid unit part")?;
+        Ok(Self { vect, unit })
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use crate::mask::{
+        config::{BoundType, DataType, GroupType, MaskConfig, ModelType},
+        MaskObject,
+    };
+    use num::BigUint;
+
+    pub fn mask_config() -> (MaskConfig, Vec<u8>) {
+        // config.order() = 20_000_000_000_001 with this config, so the data
+        // should be stored on 6 bytes.
+        let config = MaskConfig {
+            group_type: GroupType::Integer,
+            data_type: DataType::I32,
+            bound_type: BoundType::B0,
+            model_type: ModelType::M3,
+        };
+        let bytes = vec![0x00, 0x02, 0x00, 0x03];
+        (config, bytes)
+    }
+
+    pub fn mask_vect() -> (MaskVect, Vec<u8>) {
+        let (config, mut bytes) = mask_config();
+        let data = vec![
+            BigUint::from(1_u8),
+            BigUint::from(2_u8),
+            BigUint::from(3_u8),
+            BigUint::from(4_u8),
+        ];
+        let mask_vect = MaskVect::new(config, data);
+
+        bytes.extend(vec![
+            // number of elements
+            0x00, 0x00, 0x00, 0x04, // data (1 weight => 6 bytes with this config)
+            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, // 1
+            0x02, 0x00, 0x00, 0x00, 0x00, 0x00, // 2
+            0x03, 0x00, 0x00, 0x00, 0x00, 0x00, // 3
+            0x04, 0x00, 0x00, 0x00, 0x00, 0x00, // 4
+        ]);
+
+        (mask_vect, bytes)
+    }
+
+    pub fn mask_unit() -> (MaskUnit, Vec<u8>) {
+        let (config, mut bytes) = mask_config();
+        let data = BigUint::from(1_u8);
+        let mask_unit = MaskUnit::new(config, data);
+
+        bytes.extend(vec![
+            // number of elements
+            0x00, 0x00, 0x00, 0x01, // data
+            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, // 1
+        ]);
+        (mask_unit, bytes)
+    }
+
+    pub fn mask_object() -> (MaskObject, Vec<u8>) {
+        let (mask_vect, mask_vect_bytes) = mask_vect();
+        let (mask_unit, mask_unit_bytes) = mask_unit();
+        let obj = MaskObject::new(mask_vect, mask_unit);
+        let bytes = [mask_vect_bytes.as_slice(), mask_unit_bytes.as_slice()].concat();
+
+        (obj, bytes)
+    }
+
+    #[test]
+    fn serialize_mask_object() {
+        let (mask_object, expected) = mask_object();
+        let mut buf = vec![0xff; 46];
+        mask_object.to_bytes(&mut buf);
+        assert_eq!(buf, expected);
+    }
+
+    #[test]
+    fn deserialize_mask_object() {
+        let (expected, bytes) = mask_object();
+        assert_eq!(MaskObject::from_byte_slice(&&bytes[..]).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_mask_object_from_stream() {
+        let (expected, bytes) = mask_object();
+        assert_eq!(
+            MaskObject::from_byte_stream(&mut bytes.into_iter()).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn serialize_mask_vect() {
+        let (mask_vect, expected) = mask_vect();
+        let mut buf = vec![0xff; expected.len()];
+        mask_vect.to_bytes(&mut buf);
+        assert_eq!(buf, expected);
+    }
+
+    #[test]
+    fn deserialize_mask_vect() {
+        let (expected, bytes) = mask_vect();
+        assert_eq!(MaskVect::from_byte_slice(&&bytes[..]).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_mask_vect_from_stream() {
+        let (expected, bytes) = mask_vect();
+        assert_eq!(
+            MaskVect::from_byte_stream(&mut bytes.into_iter()).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn serialize_mask_unit() {
+        let (mask_unit, expected) = mask_unit();
+        let mut buf = vec![0xff; expected.len()];
+        mask_unit.to_bytes(&mut buf);
+        assert_eq!(buf, expected);
+    }
+
+    #[test]
+    fn deserialize_mask_unit() {
+        let (expected, bytes) = mask_unit();
+        assert_eq!(MaskUnit::from_byte_slice(&&bytes[..]).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_mask_unit_from_stream() {
+        let (expected, bytes) = mask_unit();
+        assert_eq!(
+            MaskUnit::from_byte_stream(&mut bytes.into_iter()).unwrap(),
+            expected
+        );
+    }
+}

--- a/rust/xaynet-core/src/mask/object/serialization/vect.rs
+++ b/rust/xaynet-core/src/mask/object/serialization/vect.rs
@@ -1,4 +1,4 @@
-//! Serialization of masked objects.
+//! Serialization of masked vectors.
 //!
 //! See the [mask module] documentation since this is a private module anyways.
 //!
@@ -12,7 +12,7 @@ use num::bigint::BigUint;
 use crate::{
     mask::{
         config::{serialization::MASK_CONFIG_BUFFER_LEN, MaskConfig},
-        object::{MaskObject, MaskUnit, MaskVect},
+        object::{MaskUnit, MaskVect},
     },
     message::{
         traits::{FromBytes, ToBytes},
@@ -31,78 +31,6 @@ const MAX_NB: u32 = u16::MAX as u32;
 /// A buffer for serialized mask vectors.
 pub struct MaskVectBuffer<T> {
     inner: T,
-}
-
-/// A buffer for serialized mask objects.
-pub struct MaskObjectBuffer<T> {
-    inner: T,
-}
-
-impl<T: AsRef<[u8]>> MaskObjectBuffer<T> {
-    /// Creates a new buffer from `bytes`.
-    ///
-    /// # Errors
-    /// Fails if the `bytes` don't conform to the required buffer length for mask objects.
-    pub fn new(bytes: T) -> Result<Self, DecodeError> {
-        let buffer = Self { inner: bytes };
-        buffer
-            .check_buffer_length()
-            .context("not a valid MaskObject")?;
-        Ok(buffer)
-    }
-
-    /// Creates a new buffer from `bytes`.
-    pub fn new_unchecked(bytes: T) -> Self {
-        Self { inner: bytes }
-    }
-
-    /// Checks if this buffer conforms to the required buffer length for mask objects.
-    ///
-    /// # Errors
-    /// Fails if the buffer is too small.
-    pub fn check_buffer_length(&self) -> Result<(), DecodeError> {
-        let inner = self.inner.as_ref();
-        // check length of vector field
-        MaskVectBuffer::new(&inner[0..]).context("invalid vector field")?;
-        // check length of scalar field
-        // TODO possible change to MaskOneBuffer in the future once implemented
-        MaskVectBuffer::new(&inner[self.unit_offset()..]).context("invalid unit field")?;
-        Ok(())
-    }
-
-    /// Gets the vector part.
-    ///
-    /// # Panics
-    /// May panic if this buffer is unchecked.
-    pub fn vect(&self) -> &[u8] {
-        let len = self.unit_offset();
-        &self.inner.as_ref()[0..len]
-    }
-
-    /// Gets the offset of the scalar field.
-    pub fn unit_offset(&self) -> usize {
-        let vect_buf = MaskVectBuffer::new_unchecked(&self.inner.as_ref()[0..]);
-        vect_buf.len()
-    }
-
-    /// Gets the scalar part.
-    ///
-    /// # Panics
-    /// May panic if this buffer is unchecked.
-    pub fn unit(&self) -> &[u8] {
-        let offset = self.unit_offset();
-        &self.inner.as_ref()[offset..]
-    }
-
-    /// Gets the expected number of bytes of this buffer.
-    ///
-    /// # Panics
-    /// May panic if this buffer is unchecked.
-    pub fn len(&self) -> usize {
-        let unit_offset = self.unit_offset();
-        let unit_buf = MaskVectBuffer::new_unchecked(&self.inner.as_ref()[unit_offset..]);
-        unit_offset + unit_buf.len()
-    }
 }
 
 #[allow(clippy::len_without_is_empty)]
@@ -209,16 +137,6 @@ impl<T: AsRef<[u8]>> MaskVectBuffer<T> {
     /// May panic if this buffer is unchecked.
     pub fn data(&self) -> &[u8] {
         &self.inner.as_ref()[NUMBERS_FIELD.end..self.len()]
-    }
-}
-
-impl<T: AsRef<[u8]> + AsMut<[u8]>> MaskObjectBuffer<T> {
-    pub fn vect_mut(&mut self) -> &mut [u8] {
-        &mut self.inner.as_mut()[0..]
-    }
-    pub fn unit_mut(&mut self) -> &mut [u8] {
-        let offset = self.unit_offset();
-        &mut self.inner.as_mut()[offset..]
     }
 }
 
@@ -364,169 +282,5 @@ impl FromBytes for MaskUnit {
                 vec_len
             ))
         }
-    }
-}
-
-impl ToBytes for MaskObject {
-    fn buffer_length(&self) -> usize {
-        self.vect.buffer_length() + self.unit.buffer_length()
-    }
-
-    fn to_bytes<T: AsMut<[u8]> + AsRef<[u8]>>(&self, buffer: &mut T) {
-        let mut writer = MaskObjectBuffer::new_unchecked(buffer.as_mut());
-        self.vect.to_bytes(&mut writer.vect_mut());
-        self.unit.to_bytes(&mut writer.unit_mut());
-    }
-}
-
-impl FromBytes for MaskObject {
-    fn from_byte_slice<T: AsRef<[u8]>>(buffer: &T) -> Result<Self, DecodeError> {
-        let reader = MaskObjectBuffer::new(buffer.as_ref())?;
-        let vect = MaskVect::from_byte_slice(&reader.vect()).context("invalid vector part")?;
-        let unit = MaskUnit::from_byte_slice(&reader.unit()).context("invalid unit part")?;
-        Ok(Self { vect, unit })
-    }
-
-    fn from_byte_stream<I: Iterator<Item = u8> + ExactSizeIterator>(
-        iter: &mut I,
-    ) -> Result<Self, DecodeError> {
-        let vect = MaskVect::from_byte_stream(iter).context("invalid vector part")?;
-        let unit = MaskUnit::from_byte_stream(iter).context("invalid unit part")?;
-        Ok(Self { vect, unit })
-    }
-}
-
-#[cfg(test)]
-pub(crate) mod tests {
-    use super::*;
-    use crate::mask::{
-        config::{BoundType, DataType, GroupType, MaskConfig, ModelType},
-        MaskObject,
-    };
-
-    pub fn mask_config() -> (MaskConfig, Vec<u8>) {
-        // config.order() = 20_000_000_000_001 with this config, so the data
-        // should be stored on 6 bytes.
-        let config = MaskConfig {
-            group_type: GroupType::Integer,
-            data_type: DataType::I32,
-            bound_type: BoundType::B0,
-            model_type: ModelType::M3,
-        };
-        let bytes = vec![0x00, 0x02, 0x00, 0x03];
-        (config, bytes)
-    }
-
-    pub fn mask_vect() -> (MaskVect, Vec<u8>) {
-        let (config, mut bytes) = mask_config();
-        let data = vec![
-            BigUint::from(1_u8),
-            BigUint::from(2_u8),
-            BigUint::from(3_u8),
-            BigUint::from(4_u8),
-        ];
-        let mask_vect = MaskVect::new(config, data);
-
-        bytes.extend(vec![
-            // number of elements
-            0x00, 0x00, 0x00, 0x04, // data (1 weight => 6 bytes with this config)
-            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, // 1
-            0x02, 0x00, 0x00, 0x00, 0x00, 0x00, // 2
-            0x03, 0x00, 0x00, 0x00, 0x00, 0x00, // 3
-            0x04, 0x00, 0x00, 0x00, 0x00, 0x00, // 4
-        ]);
-
-        (mask_vect, bytes)
-    }
-
-    pub fn mask_unit() -> (MaskUnit, Vec<u8>) {
-        let (config, mut bytes) = mask_config();
-        let data = BigUint::from(1_u8);
-        let mask_unit = MaskUnit::new(config, data);
-
-        bytes.extend(vec![
-            // number of elements
-            0x00, 0x00, 0x00, 0x01, // data
-            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, // 1
-        ]);
-        (mask_unit, bytes)
-    }
-
-    pub fn mask_object() -> (MaskObject, Vec<u8>) {
-        let (mask_vect, mask_vect_bytes) = mask_vect();
-        let (mask_unit, mask_unit_bytes) = mask_unit();
-        let obj = MaskObject::new(mask_vect, mask_unit);
-        let bytes = [mask_vect_bytes.as_slice(), mask_unit_bytes.as_slice()].concat();
-
-        (obj, bytes)
-    }
-
-    #[test]
-    fn serialize_mask_object() {
-        let (mask_object, expected) = mask_object();
-        let mut buf = vec![0xff; 46];
-        mask_object.to_bytes(&mut buf);
-        assert_eq!(buf, expected);
-    }
-
-    #[test]
-    fn deserialize_mask_object() {
-        let (expected, bytes) = mask_object();
-        assert_eq!(MaskObject::from_byte_slice(&&bytes[..]).unwrap(), expected);
-    }
-
-    #[test]
-    fn deserialize_mask_object_from_stream() {
-        let (expected, bytes) = mask_object();
-        assert_eq!(
-            MaskObject::from_byte_stream(&mut bytes.into_iter()).unwrap(),
-            expected
-        );
-    }
-
-    #[test]
-    fn serialize_mask_vect() {
-        let (mask_vect, expected) = mask_vect();
-        let mut buf = vec![0xff; expected.len()];
-        mask_vect.to_bytes(&mut buf);
-        assert_eq!(buf, expected);
-    }
-
-    #[test]
-    fn deserialize_mask_vect() {
-        let (expected, bytes) = mask_vect();
-        assert_eq!(MaskVect::from_byte_slice(&&bytes[..]).unwrap(), expected);
-    }
-
-    #[test]
-    fn deserialize_mask_vect_from_stream() {
-        let (expected, bytes) = mask_vect();
-        assert_eq!(
-            MaskVect::from_byte_stream(&mut bytes.into_iter()).unwrap(),
-            expected
-        );
-    }
-
-    #[test]
-    fn serialize_mask_unit() {
-        let (mask_unit, expected) = mask_unit();
-        let mut buf = vec![0xff; expected.len()];
-        mask_unit.to_bytes(&mut buf);
-        assert_eq!(buf, expected);
-    }
-
-    #[test]
-    fn deserialize_mask_unit() {
-        let (expected, bytes) = mask_unit();
-        assert_eq!(MaskUnit::from_byte_slice(&&bytes[..]).unwrap(), expected);
-    }
-
-    #[test]
-    fn deserialize_mask_unit_from_stream() {
-        let (expected, bytes) = mask_unit();
-        assert_eq!(
-            MaskUnit::from_byte_stream(&mut bytes.into_iter()).unwrap(),
-            expected
-        );
     }
 }

--- a/rust/xaynet-core/src/mask/object/serialization/vect.rs
+++ b/rust/xaynet-core/src/mask/object/serialization/vect.rs
@@ -260,7 +260,10 @@ impl FromBytes for MaskUnit {
         let mut mask_vect = MaskVect::from_byte_slice(buffer)?;
         let vec_len = mask_vect.data.len();
         if vec_len == 1 {
-            Ok(MaskUnit::new(mask_vect.config, mask_vect.data.remove(0)))
+            Ok(MaskUnit::new_unchecked(
+                mask_vect.config,
+                mask_vect.data.remove(0),
+            ))
         } else {
             Err(anyhow!(
                 "invalid data length: expected 1 but got {}",
@@ -275,7 +278,10 @@ impl FromBytes for MaskUnit {
         let mut mask_vect = MaskVect::from_byte_stream(iter)?;
         let vec_len = mask_vect.data.len();
         if vec_len == 1 {
-            Ok(MaskUnit::new(mask_vect.config, mask_vect.data.remove(0)))
+            Ok(MaskUnit::new_unchecked(
+                mask_vect.config,
+                mask_vect.data.remove(0),
+            ))
         } else {
             Err(anyhow!(
                 "invalid data length: expected 1 but got {}",
@@ -298,7 +304,7 @@ pub(crate) mod tests {
             BigUint::from(3_u8),
             BigUint::from(4_u8),
         ];
-        let mask_vect = MaskVect::new(config, data);
+        let mask_vect = MaskVect::new_unchecked(config, data);
 
         bytes.extend(vec![
             // number of elements
@@ -315,7 +321,7 @@ pub(crate) mod tests {
     pub fn mask_unit() -> (MaskUnit, Vec<u8>) {
         let (config, mut bytes) = mask_config();
         let data = BigUint::from(1_u8);
-        let mask_unit = MaskUnit::new(config, data);
+        let mask_unit = MaskUnit::new_unchecked(config, data);
 
         bytes.extend(vec![
             // number of elements

--- a/rust/xaynet-core/src/mask/object/serialization/vect.rs
+++ b/rust/xaynet-core/src/mask/object/serialization/vect.rs
@@ -284,3 +284,90 @@ impl FromBytes for MaskUnit {
         }
     }
 }
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use crate::mask::object::serialization::tests::mask_config;
+
+    pub fn mask_vect() -> (MaskVect, Vec<u8>) {
+        let (config, mut bytes) = mask_config();
+        let data = vec![
+            BigUint::from(1_u8),
+            BigUint::from(2_u8),
+            BigUint::from(3_u8),
+            BigUint::from(4_u8),
+        ];
+        let mask_vect = MaskVect::new(config, data);
+
+        bytes.extend(vec![
+            // number of elements
+            0x00, 0x00, 0x00, 0x04, // data (1 weight => 6 bytes with this config)
+            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, // 1
+            0x02, 0x00, 0x00, 0x00, 0x00, 0x00, // 2
+            0x03, 0x00, 0x00, 0x00, 0x00, 0x00, // 3
+            0x04, 0x00, 0x00, 0x00, 0x00, 0x00, // 4
+        ]);
+
+        (mask_vect, bytes)
+    }
+
+    pub fn mask_unit() -> (MaskUnit, Vec<u8>) {
+        let (config, mut bytes) = mask_config();
+        let data = BigUint::from(1_u8);
+        let mask_unit = MaskUnit::new(config, data);
+
+        bytes.extend(vec![
+            // number of elements
+            0x00, 0x00, 0x00, 0x01, // data
+            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, // 1
+        ]);
+        (mask_unit, bytes)
+    }
+
+    #[test]
+    fn serialize_mask_vect() {
+        let (mask_vect, expected) = mask_vect();
+        let mut buf = vec![0xff; expected.len()];
+        mask_vect.to_bytes(&mut buf);
+        assert_eq!(buf, expected);
+    }
+
+    #[test]
+    fn deserialize_mask_vect() {
+        let (expected, bytes) = mask_vect();
+        assert_eq!(MaskVect::from_byte_slice(&&bytes[..]).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_mask_vect_from_stream() {
+        let (expected, bytes) = mask_vect();
+        assert_eq!(
+            MaskVect::from_byte_stream(&mut bytes.into_iter()).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn serialize_mask_unit() {
+        let (mask_unit, expected) = mask_unit();
+        let mut buf = vec![0xff; expected.len()];
+        mask_unit.to_bytes(&mut buf);
+        assert_eq!(buf, expected);
+    }
+
+    #[test]
+    fn deserialize_mask_unit() {
+        let (expected, bytes) = mask_unit();
+        assert_eq!(MaskUnit::from_byte_slice(&&bytes[..]).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_mask_unit_from_stream() {
+        let (expected, bytes) = mask_unit();
+        assert_eq!(
+            MaskUnit::from_byte_stream(&mut bytes.into_iter()).unwrap(),
+            expected
+        );
+    }
+}

--- a/rust/xaynet-core/src/mask/seed.rs
+++ b/rust/xaynet-core/src/mask/seed.rs
@@ -16,7 +16,7 @@ use crate::{
     crypto::{encrypt::SEALBYTES, prng::generate_integer, ByteObject},
     mask::{
         config::MaskConfig,
-        object::{MaskMany, MaskObject, MaskOne},
+        object::{MaskObject, MaskOne, MaskVect},
     },
     SumParticipantEphemeralPublicKey,
     SumParticipantEphemeralSecretKey,
@@ -71,7 +71,7 @@ impl MaskSeed {
         let rand_ints = iter::repeat_with(|| generate_integer(&mut prng, &config_many.order()))
             .take(len)
             .collect();
-        let model_mask = MaskMany::new(config_many, rand_ints);
+        let model_mask = MaskVect::new(config_many, rand_ints);
 
         MaskObject::new(model_mask, scalar_mask)
     }

--- a/rust/xaynet-core/src/mask/seed.rs
+++ b/rust/xaynet-core/src/mask/seed.rs
@@ -166,9 +166,9 @@ mod tests {
         };
         let seed = MaskSeed::generate();
         let mask = seed.derive_mask(10, config, config);
-        assert_eq!(mask.vector.data.len(), 10);
+        assert_eq!(mask.vect.data.len(), 10);
         assert!(mask
-            .vector
+            .vect
             .data
             .iter()
             .all(|integer| integer < &config.order()));

--- a/rust/xaynet-core/src/mask/seed.rs
+++ b/rust/xaynet-core/src/mask/seed.rs
@@ -16,7 +16,7 @@ use crate::{
     crypto::{encrypt::SEALBYTES, prng::generate_integer, ByteObject},
     mask::{
         config::MaskConfig,
-        object::{MaskObject, MaskOne, MaskVect},
+        object::{MaskObject, MaskUnit, MaskVect},
     },
     SumParticipantEphemeralPublicKey,
     SumParticipantEphemeralSecretKey,
@@ -66,7 +66,7 @@ impl MaskSeed {
         let mut prng = ChaCha20Rng::from_seed(self.as_array());
 
         let rand_int = generate_integer(&mut prng, &config_one.order());
-        let scalar_mask = MaskOne::new(config_one, rand_int);
+        let scalar_mask = MaskUnit::new(config_one, rand_int);
 
         let rand_ints = iter::repeat_with(|| generate_integer(&mut prng, &config_many.order()))
             .take(len)

--- a/rust/xaynet-core/src/mask/seed.rs
+++ b/rust/xaynet-core/src/mask/seed.rs
@@ -66,14 +66,14 @@ impl MaskSeed {
         let mut prng = ChaCha20Rng::from_seed(self.as_array());
 
         let rand_int = generate_integer(&mut prng, &config_one.order());
-        let scalar_mask = MaskUnit::new(config_one, rand_int);
+        let scalar_mask = MaskUnit::new_unchecked(config_one, rand_int);
 
         let rand_ints = iter::repeat_with(|| generate_integer(&mut prng, &config_many.order()))
             .take(len)
             .collect();
-        let model_mask = MaskVect::new(config_many, rand_ints);
+        let model_mask = MaskVect::new_unchecked(config_many, rand_ints);
 
-        MaskObject::new(model_mask, scalar_mask)
+        MaskObject::new_unchecked(model_mask, scalar_mask)
     }
 }
 

--- a/rust/xaynet-core/src/message/payload/sum2.rs
+++ b/rust/xaynet-core/src/message/payload/sum2.rs
@@ -10,7 +10,7 @@ use anyhow::{anyhow, Context};
 
 use crate::{
     crypto::ByteObject,
-    mask::object::{serialization::MaskManyBuffer, MaskObject, MaskOne, MaskVect},
+    mask::object::{serialization::MaskManyBuffer, MaskObject, MaskUnit, MaskVect},
     message::{
         traits::{FromBytes, ToBytes},
         utils::range,
@@ -184,7 +184,7 @@ impl FromBytes for Sum2 {
                 .context("invalid sum signature")?,
             model_mask: MaskObject::new(
                 MaskVect::from_byte_slice(&reader.model_mask()).context("invalid model mask")?,
-                MaskOne::from_byte_slice(&reader.scalar_mask()).context("invalid scalar mask")?,
+                MaskUnit::from_byte_slice(&reader.scalar_mask()).context("invalid scalar mask")?,
             ),
         })
     }
@@ -205,7 +205,7 @@ pub(in crate::message) mod tests_helpers {
     use super::*;
     pub(in crate::message) use crate::mask::object::serialization::tests::{
         mask_object,
-        mask_one,
+        mask_unit,
         mask_vect,
     };
 
@@ -244,7 +244,7 @@ pub(in crate::message) mod tests {
         let actual_model_mask = &buffer.model_mask()[..expected_len];
         assert_eq!(actual_model_mask, expected_model_mask);
 
-        assert_eq!(buffer.scalar_mask(), &helpers::mask_one().1[..]);
+        assert_eq!(buffer.scalar_mask(), &helpers::mask_unit().1[..]);
     }
 
     #[test]
@@ -259,7 +259,7 @@ pub(in crate::message) mod tests {
             buffer.model_mask_mut()[..model_mask.len()].copy_from_slice(&model_mask[..]);
             buffer
                 .scalar_mask_mut()
-                .copy_from_slice(&helpers::mask_one().1[..]);
+                .copy_from_slice(&helpers::mask_unit().1[..]);
         }
         assert_eq!(&bytes[..], &helpers::sum2().1[..]);
     }

--- a/rust/xaynet-core/src/message/payload/sum2.rs
+++ b/rust/xaynet-core/src/message/payload/sum2.rs
@@ -10,7 +10,7 @@ use anyhow::{anyhow, Context};
 
 use crate::{
     crypto::ByteObject,
-    mask::object::{serialization::MaskManyBuffer, MaskMany, MaskObject, MaskOne},
+    mask::object::{serialization::MaskManyBuffer, MaskObject, MaskOne, MaskVect},
     message::{
         traits::{FromBytes, ToBytes},
         utils::range,
@@ -183,7 +183,7 @@ impl FromBytes for Sum2 {
             sum_signature: ParticipantTaskSignature::from_byte_slice(&reader.sum_signature())
                 .context("invalid sum signature")?,
             model_mask: MaskObject::new(
-                MaskMany::from_byte_slice(&reader.model_mask()).context("invalid model mask")?,
+                MaskVect::from_byte_slice(&reader.model_mask()).context("invalid model mask")?,
                 MaskOne::from_byte_slice(&reader.scalar_mask()).context("invalid scalar mask")?,
             ),
         })
@@ -204,9 +204,9 @@ impl FromBytes for Sum2 {
 pub(in crate::message) mod tests_helpers {
     use super::*;
     pub(in crate::message) use crate::mask::object::serialization::tests::{
-        mask_many,
         mask_object,
         mask_one,
+        mask_vect,
     };
 
     pub fn signature() -> (ParticipantTaskSignature, Vec<u8>) {
@@ -239,7 +239,7 @@ pub(in crate::message) mod tests {
         let buffer = Sum2Buffer::new(&bytes).unwrap();
         assert_eq!(buffer.sum_signature(), &helpers::signature().1[..]);
 
-        let expected_model_mask = helpers::mask_many().1;
+        let expected_model_mask = helpers::mask_vect().1;
         let expected_len = expected_model_mask.len();
         let actual_model_mask = &buffer.model_mask()[..expected_len];
         assert_eq!(actual_model_mask, expected_model_mask);
@@ -255,7 +255,7 @@ pub(in crate::message) mod tests {
             buffer
                 .sum_signature_mut()
                 .copy_from_slice(&helpers::signature().1[..]);
-            let model_mask = helpers::mask_many().1;
+            let model_mask = helpers::mask_vect().1;
             buffer.model_mask_mut()[..model_mask.len()].copy_from_slice(&model_mask[..]);
             buffer
                 .scalar_mask_mut()

--- a/rust/xaynet-core/src/message/payload/sum2.rs
+++ b/rust/xaynet-core/src/message/payload/sum2.rs
@@ -199,10 +199,9 @@ impl FromBytes for Sum2 {
 #[cfg(test)]
 pub(in crate::message) mod tests_helpers {
     use super::*;
-    pub(in crate::message) use crate::mask::object::serialization::tests::{
-        mask_object,
-        mask_unit,
-        mask_vect,
+    pub(in crate::message) use crate::mask::object::serialization::{
+        tests::mask_object,
+        vect::tests::{mask_unit, mask_vect},
     };
 
     pub fn signature() -> (ParticipantTaskSignature, Vec<u8>) {

--- a/rust/xaynet-core/src/message/payload/sum2.rs
+++ b/rust/xaynet-core/src/message/payload/sum2.rs
@@ -159,19 +159,15 @@ pub struct Sum2 {
 impl ToBytes for Sum2 {
     fn buffer_length(&self) -> usize {
         SUM_SIGNATURE_RANGE.end
-            + self.model_mask.vector.buffer_length()
-            + self.model_mask.scalar.buffer_length()
+            + self.model_mask.vect.buffer_length()
+            + self.model_mask.unit.buffer_length()
     }
 
     fn to_bytes<T: AsMut<[u8]> + AsRef<[u8]>>(&self, buffer: &mut T) {
         let mut writer = Sum2Buffer::new_unchecked(buffer.as_mut());
         self.sum_signature.to_bytes(&mut writer.sum_signature_mut());
-        self.model_mask
-            .vector
-            .to_bytes(&mut writer.model_mask_mut());
-        self.model_mask
-            .scalar
-            .to_bytes(&mut writer.scalar_mask_mut());
+        self.model_mask.vect.to_bytes(&mut writer.model_mask_mut());
+        self.model_mask.unit.to_bytes(&mut writer.scalar_mask_mut());
     }
 }
 

--- a/rust/xaynet-core/src/message/payload/sum2.rs
+++ b/rust/xaynet-core/src/message/payload/sum2.rs
@@ -10,7 +10,7 @@ use anyhow::{anyhow, Context};
 
 use crate::{
     crypto::ByteObject,
-    mask::object::{serialization::MaskManyBuffer, MaskObject, MaskUnit, MaskVect},
+    mask::object::{serialization::MaskVectBuffer, MaskObject, MaskUnit, MaskVect},
     message::{
         traits::{FromBytes, ToBytes},
         utils::range,
@@ -62,11 +62,11 @@ impl<T: AsRef<[u8]>> Sum2Buffer<T> {
         }
 
         // Check the length of the model mask field
-        let _ = MaskManyBuffer::new(&self.inner.as_ref()[self.model_mask_offset()..])
+        let _ = MaskVectBuffer::new(&self.inner.as_ref()[self.model_mask_offset()..])
             .context("invalid model mask field")?;
 
         // Check the length of the scalar mask field
-        let _ = MaskManyBuffer::new(&self.inner.as_ref()[self.scalar_mask_offset()..])
+        let _ = MaskVectBuffer::new(&self.inner.as_ref()[self.scalar_mask_offset()..])
             .context("invalid scalar mask field")?;
 
         Ok(())
@@ -80,7 +80,7 @@ impl<T: AsRef<[u8]>> Sum2Buffer<T> {
     /// Gets the offset of the scalar mask field.
     fn scalar_mask_offset(&self) -> usize {
         let model_mask =
-            MaskManyBuffer::new_unchecked(&self.inner.as_ref()[self.model_mask_offset()..]);
+            MaskVectBuffer::new_unchecked(&self.inner.as_ref()[self.model_mask_offset()..]);
         self.model_mask_offset() + model_mask.len()
     }
 }

--- a/rust/xaynet-core/src/message/payload/sum2.rs
+++ b/rust/xaynet-core/src/message/payload/sum2.rs
@@ -10,7 +10,7 @@ use anyhow::{anyhow, Context};
 
 use crate::{
     crypto::ByteObject,
-    mask::object::{serialization::MaskVectBuffer, MaskObject, MaskUnit, MaskVect},
+    mask::object::{serialization::vect::MaskVectBuffer, MaskObject, MaskUnit, MaskVect},
     message::{
         traits::{FromBytes, ToBytes},
         utils::range,

--- a/rust/xaynet-core/src/message/payload/update.rs
+++ b/rust/xaynet-core/src/message/payload/update.rs
@@ -223,8 +223,8 @@ pub struct Update {
 impl ToBytes for Update {
     fn buffer_length(&self) -> usize {
         UPDATE_SIGNATURE_RANGE.end
-            + self.masked_model.vector.buffer_length()
-            + self.masked_model.scalar.buffer_length()
+            + self.masked_model.vect.buffer_length()
+            + self.masked_model.unit.buffer_length()
             + self.local_seed_dict.buffer_length()
     }
 
@@ -234,10 +234,10 @@ impl ToBytes for Update {
         self.update_signature
             .to_bytes(&mut writer.update_signature_mut());
         self.masked_model
-            .vector
+            .vect
             .to_bytes(&mut writer.masked_model_mut());
         self.masked_model
-            .scalar
+            .unit
             .to_bytes(&mut writer.masked_scalar_mut());
         self.local_seed_dict
             .to_bytes(&mut writer.local_seed_dict_mut());

--- a/rust/xaynet-core/src/message/payload/update.rs
+++ b/rust/xaynet-core/src/message/payload/update.rs
@@ -223,8 +223,7 @@ pub struct Update {
 impl ToBytes for Update {
     fn buffer_length(&self) -> usize {
         UPDATE_SIGNATURE_RANGE.end
-            + self.masked_model.vect.buffer_length()
-            + self.masked_model.unit.buffer_length()
+            + self.masked_model.buffer_length()
             + self.local_seed_dict.buffer_length()
     }
 
@@ -233,12 +232,7 @@ impl ToBytes for Update {
         self.sum_signature.to_bytes(&mut writer.sum_signature_mut());
         self.update_signature
             .to_bytes(&mut writer.update_signature_mut());
-        self.masked_model
-            .vect
-            .to_bytes(&mut writer.masked_model_mut());
-        self.masked_model
-            .unit
-            .to_bytes(&mut writer.masked_scalar_mut());
+        self.masked_model.to_bytes(&mut writer.masked_model_mut());
         self.local_seed_dict
             .to_bytes(&mut writer.local_seed_dict_mut());
     }

--- a/rust/xaynet-core/src/message/payload/update.rs
+++ b/rust/xaynet-core/src/message/payload/update.rs
@@ -281,7 +281,7 @@ pub(in crate::message) mod tests_helpers {
     use super::*;
     pub(in crate::message) use crate::mask::object::serialization::tests::{
         mask_object,
-        mask_one,
+        mask_unit,
         mask_vect,
     };
     use crate::{crypto::ByteObject, mask::seed::EncryptedMaskSeed, SumParticipantPublicKey};
@@ -358,7 +358,7 @@ pub(in crate::message) mod tests {
         );
         let mut expected = helpers::mask_vect().1;
         assert_eq!(&buffer.masked_model()[..expected.len()], &expected[..]);
-        expected = helpers::mask_one().1;
+        expected = helpers::mask_unit().1;
         assert_eq!(&buffer.masked_scalar()[..expected.len()], &expected[..]);
         assert_eq!(buffer.local_seed_dict(), &helpers::local_seed_dict().1[..]);
     }

--- a/rust/xaynet-core/src/message/payload/update.rs
+++ b/rust/xaynet-core/src/message/payload/update.rs
@@ -279,10 +279,9 @@ pub(in crate::message) mod tests_helpers {
     use std::convert::TryFrom;
 
     use super::*;
-    pub(in crate::message) use crate::mask::object::serialization::tests::{
-        mask_object,
-        mask_unit,
-        mask_vect,
+    pub(in crate::message) use crate::mask::object::serialization::{
+        tests::mask_object,
+        vect::tests::{mask_unit, mask_vect},
     };
     use crate::{crypto::ByteObject, mask::seed::EncryptedMaskSeed, SumParticipantPublicKey};
 

--- a/rust/xaynet-core/src/message/payload/update.rs
+++ b/rust/xaynet-core/src/message/payload/update.rs
@@ -11,7 +11,7 @@ use anyhow::{anyhow, Context};
 use crate::{
     crypto::ByteObject,
     mask::object::{
-        serialization::{MaskObjectBuffer, MaskVectBuffer},
+        serialization::{vect::MaskVectBuffer, MaskObjectBuffer},
         MaskObject,
     },
     message::{

--- a/rust/xaynet-core/src/message/payload/update.rs
+++ b/rust/xaynet-core/src/message/payload/update.rs
@@ -11,7 +11,7 @@ use anyhow::{anyhow, Context};
 use crate::{
     crypto::ByteObject,
     mask::object::{
-        serialization::{MaskManyBuffer, MaskObjectBuffer},
+        serialization::{MaskObjectBuffer, MaskVectBuffer},
         MaskObject,
     },
     message::{
@@ -70,11 +70,11 @@ impl<T: AsRef<[u8]>> UpdateBuffer<T> {
         }
 
         // Check the length of the masked model field
-        let _ = MaskManyBuffer::new(&self.inner.as_ref()[self.masked_model_offset()..])
+        let _ = MaskVectBuffer::new(&self.inner.as_ref()[self.masked_model_offset()..])
             .context("invalid masked model field")?;
 
         // Check the length of the masked scalar field
-        let _ = MaskManyBuffer::new(&self.inner.as_ref()[self.masked_scalar_offset()..])
+        let _ = MaskVectBuffer::new(&self.inner.as_ref()[self.masked_scalar_offset()..])
             .context("invalid masked scalar field")?;
 
         // Check the length of the local seed dictionary field
@@ -92,7 +92,7 @@ impl<T: AsRef<[u8]>> UpdateBuffer<T> {
     /// Gets the offset of the masked scalar field.
     fn masked_scalar_offset(&self) -> usize {
         let masked_model =
-            MaskManyBuffer::new_unchecked(&self.inner.as_ref()[self.masked_model_offset()..]);
+            MaskVectBuffer::new_unchecked(&self.inner.as_ref()[self.masked_model_offset()..]);
         self.masked_model_offset() + masked_model.len()
     }
 

--- a/rust/xaynet-core/src/message/payload/update.rs
+++ b/rust/xaynet-core/src/message/payload/update.rs
@@ -280,9 +280,9 @@ pub(in crate::message) mod tests_helpers {
 
     use super::*;
     pub(in crate::message) use crate::mask::object::serialization::tests::{
-        mask_many,
         mask_object,
         mask_one,
+        mask_vect,
     };
     use crate::{crypto::ByteObject, mask::seed::EncryptedMaskSeed, SumParticipantPublicKey};
 
@@ -356,7 +356,7 @@ pub(in crate::message) mod tests {
             buffer.update_signature(),
             helpers::update_signature().1.as_slice()
         );
-        let mut expected = helpers::mask_many().1;
+        let mut expected = helpers::mask_vect().1;
         assert_eq!(&buffer.masked_model()[..expected.len()], &expected[..]);
         expected = helpers::mask_one().1;
         assert_eq!(&buffer.masked_scalar()[..expected.len()], &expected[..]);

--- a/rust/xaynet-server/src/state_machine/phases/sum2.rs
+++ b/rust/xaynet-server/src/state_machine/phases/sum2.rs
@@ -222,7 +222,7 @@ mod test {
             .compose_sum2_message(
                 coord_keys.public,
                 &local_seed_dict,
-                masked_model.vector.data.len(),
+                masked_model.vect.data.len(),
             )
             .unwrap();
 

--- a/rust/xaynet-server/src/storage/tests/mod.rs
+++ b/rust/xaynet-server/src/storage/tests/mod.rs
@@ -49,7 +49,7 @@ pub fn create_mask_zeroed(byte_size: usize) -> MaskObject {
         model_type: ModelType::M3,
     };
 
-    MaskObject::new_checked(
+    MaskObject::new(
         config.clone(),
         vec![BigUint::zero(); byte_size],
         config,
@@ -66,7 +66,7 @@ pub fn create_mask(byte_size: usize, number: u32) -> MaskObject {
         model_type: ModelType::M3,
     };
 
-    MaskObject::new_checked(
+    MaskObject::new(
         config.clone(),
         vec![BigUint::from(number); byte_size],
         config,


### PR DESCRIPTION
This merge request implements some minor refactoring for further improvements to the mask object.

- Renames throughout for more consistency. In particular, `MaskMany` and `MaskOne` are renamed `MaskVect` and `MaskUnit`, respectively, as are the accessor fields
```rust
pub struct MaskObject {
    pub vect: MaskVect,
    pub unit: MaskUnit,
}
```
- Reorganised `mask/object/serialization.rs` into
```
- mask
    - object
        - serialization
            - mod.rs
            - vect.rs
            - unit.rs // in a separate PR
```
for a cleaner separation of the serialization code for mask object and its constituents. Also acts as a precursor to more improvements to mask unit serialization, which will be in `unit.rs` in another PR.

- Removed unnecessary "scalar accessor" code in the `Sum2Buffer` and `UpdateBuffer`. The sum2 and update payloads themselves also (de)serialize more directly by working with mask objects rather than the constituent parts.

- (somewhat separate from the above) Reordered the steps of the unmasking for more memory efficiency.

TODO
- [ ] tidy up commits