### PR TITLE
more compact serialized mask unit

### DIFF
--- a/rust/xaynet-client/src/utils/multipart/encoder.rs
+++ b/rust/xaynet-client/src/utils/multipart/encoder.rs
@@ -243,10 +243,10 @@ mod tests {
 
     fn small_message() -> Message {
         let dict_len = 80 + 32 + 4; // 116 => dict with a single entry
-        let model_len = 6 + 22; // 28 => masked model with single weight
+        let model_len = 6 + 18; // 24 => masked model with single weight
         let message = message(dict_len, model_len);
-        let payload_len = 116 + 28 + 64 * 2; // 272
-        let message_len = payload_len + 136; // 408
+        let payload_len = dict_len + model_len + 64 * 2; // 268
+        let message_len = payload_len + 136; // 404
         assert_eq!(message.payload.buffer_length(), payload_len);
         assert_eq!(message.buffer_length(), message_len);
         message
@@ -283,7 +283,7 @@ mod tests {
         //
         // 8 of these 200 payload bytes are for the Chunk payload
         // header. So this chunk actually only contains 192 bytes (out
-        // of 272) from the Update payload. So 80 bytes remain.
+        // of 268) from the Update payload. So 76 bytes remain.
         assert_eq!(data.len(), 200 + 136);
         let parsed = Message::from_byte_slice(&data.as_slice()).unwrap();
         assert_eq!(parsed.is_multipart, true);
@@ -293,15 +293,15 @@ mod tests {
         assert_eq!(chunk1.data.len(), 192);
 
         let data = enc.next().unwrap();
-        // The payload should be 80 bytes + 8 bytes of CHUNK_OVERHEAD,
+        // The payload should be 76 bytes + 8 bytes of CHUNK_OVERHEAD,
         // plus 136 byte for the message header
-        assert_eq!(data.len(), 88 + 136);
+        assert_eq!(data.len(), 84 + 136);
         let parsed = Message::from_byte_slice(&data.as_slice()).unwrap();
         assert_eq!(parsed.is_multipart, true);
         let chunk2 = extract_chunk(parsed);
         assert!(chunk2.last);
         assert_eq!(chunk2.id, 1);
-        assert_eq!(chunk2.data.len(), 80);
+        assert_eq!(chunk2.data.len(), 76);
 
         let payload_data: Vec<u8> = [chunk1.data, chunk2.data].concat();
         let update = Update::from_byte_slice(&payload_data).unwrap();

--- a/rust/xaynet-core/src/mask/object/serialization/mod.rs
+++ b/rust/xaynet-core/src/mask/object/serialization/mod.rs
@@ -4,6 +4,7 @@
 //!
 //! [mask module]: ../index.html
 
+pub(crate) mod unit;
 pub(crate) mod vect;
 
 use anyhow::Context;
@@ -145,7 +146,7 @@ pub(crate) mod tests {
     use super::*;
     use crate::mask::{
         config::{BoundType, DataType, GroupType, MaskConfig, ModelType},
-        object::serialization::vect::tests::{mask_unit, mask_vect},
+        object::serialization::{unit::tests::mask_unit, vect::tests::mask_vect},
         MaskObject,
     };
 

--- a/rust/xaynet-core/src/mask/object/serialization/mod.rs
+++ b/rust/xaynet-core/src/mask/object/serialization/mod.rs
@@ -40,7 +40,7 @@ impl<T: AsRef<[u8]>> MaskObjectBuffer<T> {
         let buffer = Self { inner: bytes };
         buffer
             .check_buffer_length()
-            .context("not a valid MaskObject")?;
+            .context("not a valid mask object")?;
         Ok(buffer)
     }
 
@@ -56,7 +56,7 @@ impl<T: AsRef<[u8]>> MaskObjectBuffer<T> {
     pub fn check_buffer_length(&self) -> Result<(), DecodeError> {
         let inner = self.inner.as_ref();
         // check length of vect field
-        MaskVectBuffer::new(&inner[0..]).context("invalid vector field")?;
+        MaskVectBuffer::new(inner).context("invalid vector field")?;
         // check length of unit field
         MaskUnitBuffer::new(&inner[self.unit_offset()..]).context("invalid unit field")?;
         Ok(())
@@ -73,7 +73,7 @@ impl<T: AsRef<[u8]>> MaskObjectBuffer<T> {
 
     /// Gets the offset of the unit field.
     pub fn unit_offset(&self) -> usize {
-        let vect_buf = MaskVectBuffer::new_unchecked(&self.inner.as_ref()[0..]);
+        let vect_buf = MaskVectBuffer::new_unchecked(self.inner.as_ref());
         vect_buf.len()
     }
 
@@ -103,7 +103,7 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> MaskObjectBuffer<T> {
     /// # Panics
     /// May panic if this buffer is unchecked.
     pub fn vect_mut(&mut self) -> &mut [u8] {
-        &mut self.inner.as_mut()[0..]
+        self.inner.as_mut()
     }
 
     /// Gets the unit part.

--- a/rust/xaynet-core/src/mask/object/serialization/unit.rs
+++ b/rust/xaynet-core/src/mask/object/serialization/unit.rs
@@ -76,7 +76,7 @@ impl<T: AsRef<[u8]>> MaskUnitBuffer<T> {
     /// similar to [`len`] but cannot panic.
     pub fn try_len(&self) -> Result<usize, DecodeError> {
         let config =
-            MaskConfig::from_byte_slice(&self.config()).context("invalid MaskUnit buffer")?;
+            MaskConfig::from_byte_slice(&self.config()).context("invalid mask unit buffer")?;
         let data_length = config.bytes_per_number();
         Ok(MASK_CONFIG_FIELD.end + data_length)
     }

--- a/rust/xaynet-core/src/mask/object/serialization/unit.rs
+++ b/rust/xaynet-core/src/mask/object/serialization/unit.rs
@@ -1,0 +1,195 @@
+//! Serialization of masked units.
+//!
+//! See the [mask module] documentation since this is a private module anyways.
+//!
+//! [mask module]: ../index.html
+
+use std::ops::Range;
+
+use anyhow::{anyhow, Context};
+use num::bigint::BigUint;
+
+use crate::{
+    mask::{
+        config::{serialization::MASK_CONFIG_BUFFER_LEN, MaskConfig},
+        object::MaskUnit,
+    },
+    message::{
+        traits::{FromBytes, ToBytes},
+        utils::range,
+        DecodeError,
+    },
+};
+
+const MASK_CONFIG_FIELD: Range<usize> = range(0, MASK_CONFIG_BUFFER_LEN);
+
+/// A buffer for serialized mask units.
+pub struct MaskUnitBuffer<T> {
+    inner: T,
+}
+
+impl<T: AsRef<[u8]>> MaskUnitBuffer<T> {
+    pub fn new(bytes: T) -> Result<Self, DecodeError> {
+        let buffer = Self { inner: bytes };
+        buffer
+            .check_buffer_length()
+            .context("not a valid mask unit")?;
+        Ok(buffer)
+    }
+
+    pub fn new_unchecked(bytes: T) -> Self {
+        Self { inner: bytes }
+    }
+
+    pub fn check_buffer_length(&self) -> Result<(), DecodeError> {
+        let len = self.inner.as_ref().len();
+        if len < MASK_CONFIG_FIELD.end {
+            return Err(anyhow!(
+                "invalid buffer length: {} < {}",
+                len,
+                MASK_CONFIG_FIELD.end
+            ));
+        }
+
+        let total_expected_length = self.try_len()?;
+        if len < total_expected_length {
+            return Err(anyhow!(
+                "invalid buffer length: expected {} bytes but buffer has only {} bytes",
+                total_expected_length,
+                len
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn try_len(&self) -> Result<usize, DecodeError> {
+        let config =
+            MaskConfig::from_byte_slice(&self.config()).context("invalid MaskUnit buffer")?;
+        let data_length = config.bytes_per_number();
+        Ok(MASK_CONFIG_FIELD.end + data_length)
+    }
+
+    pub fn len(&self) -> usize {
+        let config = MaskConfig::from_byte_slice(&self.config()).unwrap();
+        let data_length = config.bytes_per_number();
+        MASK_CONFIG_FIELD.end + data_length
+    }
+
+    pub fn config(&self) -> &[u8] {
+        &self.inner.as_ref()[MASK_CONFIG_FIELD]
+    }
+
+    pub fn data(&self) -> &[u8] {
+        &self.inner.as_ref()[MASK_CONFIG_FIELD.end..self.len()]
+    }
+}
+
+impl<T: AsRef<[u8]> + AsMut<[u8]>> MaskUnitBuffer<T> {
+    pub fn config_mut(&mut self) -> &mut [u8] {
+        &mut self.inner.as_mut()[MASK_CONFIG_FIELD]
+    }
+
+    pub fn data_mut(&mut self) -> &mut [u8] {
+        let end = self.len();
+        &mut self.inner.as_mut()[MASK_CONFIG_FIELD.end..end]
+    }
+}
+
+impl ToBytes for MaskUnit {
+    fn buffer_length(&self) -> usize {
+        MASK_CONFIG_FIELD.end + self.config.bytes_per_number()
+    }
+
+    fn to_bytes<T: AsMut<[u8]> + AsRef<[u8]>>(&self, buffer: &mut T) {
+        let mut writer = MaskUnitBuffer::new_unchecked(buffer.as_mut());
+        self.config.to_bytes(&mut writer.config_mut());
+
+        let data = writer.data_mut();
+        let bytes = self.data.to_bytes_le();
+        data[..bytes.len()].copy_from_slice(&bytes[..]);
+        // padding
+        for b in data
+            .iter_mut()
+            .take(self.config.bytes_per_number())
+            .skip(bytes.len())
+        {
+            *b = 0;
+        }
+    }
+}
+
+impl FromBytes for MaskUnit {
+    fn from_byte_slice<T: AsRef<[u8]>>(buffer: &T) -> Result<Self, DecodeError> {
+        let reader = MaskUnitBuffer::new(buffer.as_ref())?;
+        let config = MaskConfig::from_byte_slice(&reader.config())?;
+        let data = BigUint::from_bytes_le(reader.data());
+
+        Ok(MaskUnit { data, config })
+    }
+
+    fn from_byte_stream<I: Iterator<Item = u8> + ExactSizeIterator>(
+        iter: &mut I,
+    ) -> Result<Self, DecodeError> {
+        let config = MaskConfig::from_byte_stream(iter)?;
+        if iter.len() < 4 {
+            return Err(anyhow!("byte stream exhausted"));
+        }
+        let data_len = config.bytes_per_number();
+        if iter.len() < data_len {
+            return Err(anyhow!(
+                "mask unit is {} bytes long but byte stream only has {} bytes",
+                data_len,
+                iter.len()
+            ));
+        }
+
+        let mut buf = vec![0; data_len];
+        for (i, b) in iter.take(data_len).enumerate() {
+            buf[i] = b;
+        }
+        let data = BigUint::from_bytes_le(buf.as_slice());
+
+        Ok(MaskUnit { data, config })
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use crate::mask::object::serialization::tests::mask_config;
+
+    pub fn mask_unit() -> (MaskUnit, Vec<u8>) {
+        let (config, mut bytes) = mask_config();
+        let data = BigUint::from(1_u8);
+        let mask_unit = MaskUnit::new_unchecked(config, data);
+
+        bytes.extend(vec![
+            // data (6 bytes with this config)
+            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, // 1
+        ]);
+        (mask_unit, bytes)
+    }
+
+    #[test]
+    fn serialize_mask_unit() {
+        let (mask_unit, expected) = mask_unit();
+        let mut buf = vec![0xff; expected.len()];
+        mask_unit.to_bytes(&mut buf);
+        assert_eq!(buf, expected);
+    }
+
+    #[test]
+    fn deserialize_mask_unit() {
+        let (expected, bytes) = mask_unit();
+        assert_eq!(MaskUnit::from_byte_slice(&&bytes[..]).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_mask_unit_from_stream() {
+        let (expected, bytes) = mask_unit();
+        assert_eq!(
+            MaskUnit::from_byte_stream(&mut bytes.into_iter()).unwrap(),
+            expected
+        );
+    }
+}

--- a/rust/xaynet-core/src/mask/object/serialization/vect.rs
+++ b/rust/xaynet-core/src/mask/object/serialization/vect.rs
@@ -38,7 +38,7 @@ impl<T: AsRef<[u8]>> MaskVectBuffer<T> {
     /// Creates a new buffer from `bytes`.
     ///
     /// # Errors
-    /// Fails if the `bytes` don't conform to the required buffer length for mask objects.
+    /// Fails if the `bytes` don't conform to the required buffer length for mask vectors.
     pub fn new(bytes: T) -> Result<Self, DecodeError> {
         let buffer = Self { inner: bytes };
         buffer
@@ -52,7 +52,7 @@ impl<T: AsRef<[u8]>> MaskVectBuffer<T> {
         Self { inner: bytes }
     }
 
-    /// Checks if this buffer conforms to the required buffer length for mask objects.
+    /// Checks if this buffer conforms to the required buffer length for mask vectors.
     ///
     /// # Errors
     /// Fails if the buffer is too small.
@@ -131,7 +131,7 @@ impl<T: AsRef<[u8]>> MaskVectBuffer<T> {
         &self.inner.as_ref()[MASK_CONFIG_FIELD]
     }
 
-    /// Gets the serialized mask object elements.
+    /// Gets the serialized mask vector elements.
     ///
     /// # Panics
     /// May panic if this buffer is unchecked.
@@ -141,7 +141,7 @@ impl<T: AsRef<[u8]>> MaskVectBuffer<T> {
 }
 
 impl<T: AsRef<[u8]> + AsMut<[u8]>> MaskVectBuffer<T> {
-    /// Sets the number of serialized mask object elements.
+    /// Sets the number of serialized mask vector elements.
     ///
     /// # Panics
     /// May panic if this buffer is unchecked.
@@ -157,7 +157,7 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> MaskVectBuffer<T> {
         &mut self.inner.as_mut()[MASK_CONFIG_FIELD]
     }
 
-    /// Gets the serialized mask object elements.
+    /// Gets the serialized mask vector elements.
     ///
     /// # Panics
     /// May panic if this buffer is unchecked.

--- a/rust/xaynet-core/src/mask/object/serialization/vect.rs
+++ b/rust/xaynet-core/src/mask/object/serialization/vect.rs
@@ -244,53 +244,6 @@ impl FromBytes for MaskVect {
     }
 }
 
-// impl ToBytes for MaskUnit {
-//     fn buffer_length(&self) -> usize {
-//         MaskVect::from(self).buffer_length()
-//     }
-
-//     fn to_bytes<T: AsMut<[u8]> + AsRef<[u8]>>(&self, buffer: &mut T) {
-//         MaskVect::from(self).to_bytes(buffer)
-//     }
-// }
-
-// impl FromBytes for MaskUnit {
-//     fn from_byte_slice<T: AsRef<[u8]>>(buffer: &T) -> Result<Self, DecodeError> {
-//         // TODO more direct implementation in later refactoring
-//         let mut mask_vect = MaskVect::from_byte_slice(buffer)?;
-//         let vec_len = mask_vect.data.len();
-//         if vec_len == 1 {
-//             Ok(MaskUnit::new_unchecked(
-//                 mask_vect.config,
-//                 mask_vect.data.remove(0),
-//             ))
-//         } else {
-//             Err(anyhow!(
-//                 "invalid data length: expected 1 but got {}",
-//                 vec_len
-//             ))
-//         }
-//     }
-
-//     fn from_byte_stream<I: Iterator<Item = u8> + ExactSizeIterator>(
-//         iter: &mut I,
-//     ) -> Result<Self, DecodeError> {
-//         let mut mask_vect = MaskVect::from_byte_stream(iter)?;
-//         let vec_len = mask_vect.data.len();
-//         if vec_len == 1 {
-//             Ok(MaskUnit::new_unchecked(
-//                 mask_vect.config,
-//                 mask_vect.data.remove(0),
-//             ))
-//         } else {
-//             Err(anyhow!(
-//                 "invalid data length: expected 1 but got {}",
-//                 vec_len
-//             ))
-//         }
-//     }
-// }
-
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
@@ -318,19 +271,6 @@ pub(crate) mod tests {
 
         (mask_vect, bytes)
     }
-
-    // pub fn mask_unit() -> (MaskUnit, Vec<u8>) {
-    //     let (config, mut bytes) = mask_config();
-    //     let data = BigUint::from(1_u8);
-    //     let mask_unit = MaskUnit::new_unchecked(config, data);
-
-    //     bytes.extend(vec![
-    //         // number of elements
-    //         0x00, 0x00, 0x00, 0x01, // data
-    //         0x01, 0x00, 0x00, 0x00, 0x00, 0x00, // 1
-    //     ]);
-    //     (mask_unit, bytes)
-    // }
 
     #[test]
     fn serialize_mask_vect() {

--- a/rust/xaynet-core/src/mask/object/serialization/vect.rs
+++ b/rust/xaynet-core/src/mask/object/serialization/vect.rs
@@ -82,7 +82,7 @@ impl<T: AsRef<[u8]>> MaskVectBuffer<T> {
     /// similar to [`len`] but cannot panic.
     fn try_len(&self) -> Result<usize, DecodeError> {
         let config =
-            MaskConfig::from_byte_slice(&self.config()).context("invalid MaskVect buffer")?;
+            MaskConfig::from_byte_slice(&self.config()).context("invalid mask vector buffer")?;
         let bytes_per_number = config.bytes_per_number();
         let (data_length, overflows) = self.numbers().overflowing_mul(bytes_per_number);
         if overflows {
@@ -219,7 +219,7 @@ impl FromBytes for MaskVect {
             return Err(anyhow!("byte stream exhausted"));
         }
         let numbers = u32::from_byte_stream(iter)
-            .context("failed to parse the number of items in mask object")?;
+            .context("failed to parse the number of items in mask vector")?;
         let bytes_per_number = config.bytes_per_number();
 
         let data_len = numbers as usize * bytes_per_number;

--- a/rust/xaynet-core/src/message/payload/sum2.rs
+++ b/rust/xaynet-core/src/message/payload/sum2.rs
@@ -10,7 +10,7 @@ use anyhow::{anyhow, Context};
 
 use crate::{
     crypto::ByteObject,
-    mask::object::{serialization::vect::MaskVectBuffer, MaskObject},
+    mask::object::{serialization::MaskObjectBuffer, MaskObject},
     message::{
         traits::{FromBytes, ToBytes},
         utils::range,
@@ -61,13 +61,9 @@ impl<T: AsRef<[u8]>> Sum2Buffer<T> {
             ));
         }
 
-        // Check the length of the model mask field
-        let _ = MaskVectBuffer::new(&self.inner.as_ref()[self.model_mask_offset()..])
-            .context("invalid model mask field")?;
-
-        // Check the length of the scalar mask field (TODO MaskUnitBuffer)
-        let _ = MaskVectBuffer::new(&self.inner.as_ref()[self.scalar_mask_offset()..])
-            .context("invalid scalar mask field")?;
+        // check the length of the mask field
+        MaskObjectBuffer::new(&self.inner.as_ref()[self.model_mask_offset()..])
+            .context("invalid mask field")?;
 
         Ok(())
     }
@@ -75,13 +71,6 @@ impl<T: AsRef<[u8]>> Sum2Buffer<T> {
     /// Gets the offset of the model mask field.
     fn model_mask_offset(&self) -> usize {
         SUM_SIGNATURE_RANGE.end
-    }
-
-    /// Gets the offset of the scalar mask field.
-    fn scalar_mask_offset(&self) -> usize {
-        let model_mask =
-            MaskVectBuffer::new_unchecked(&self.inner.as_ref()[self.model_mask_offset()..]);
-        self.model_mask_offset() + model_mask.len()
     }
 }
 

--- a/rust/xaynet-core/src/message/payload/sum2.rs
+++ b/rust/xaynet-core/src/message/payload/sum2.rs
@@ -191,7 +191,8 @@ pub mod tests {
 
     #[test]
     fn buffer_write() {
-        let mut bytes = vec![0xff; 110];
+        // length = 64 (signature) + 42 (mask) = 106
+        let mut bytes = vec![0xff; 106];
         {
             let mut buffer = Sum2Buffer::new_unchecked(&mut bytes);
             buffer

--- a/rust/xaynet-core/src/message/payload/update.rs
+++ b/rust/xaynet-core/src/message/payload/update.rs
@@ -10,10 +10,7 @@ use anyhow::{anyhow, Context};
 
 use crate::{
     crypto::ByteObject,
-    mask::object::{
-        serialization::{vect::MaskVectBuffer, MaskObjectBuffer},
-        MaskObject,
-    },
+    mask::object::{serialization::MaskObjectBuffer, MaskObject},
     message::{
         traits::{FromBytes, LengthValueBuffer, ToBytes},
         utils::range,
@@ -69,13 +66,9 @@ impl<T: AsRef<[u8]>> UpdateBuffer<T> {
             ));
         }
 
-        // Check the length of the masked model field
-        let _ = MaskVectBuffer::new(&self.inner.as_ref()[self.masked_model_offset()..])
-            .context("invalid masked model field")?;
-
-        // Check the length of the masked scalar field (TODO MaskUnitBuffer)
-        let _ = MaskVectBuffer::new(&self.inner.as_ref()[self.masked_scalar_offset()..])
-            .context("invalid masked scalar field")?;
+        // Check length of the masked object field
+        MaskObjectBuffer::new(&self.inner.as_ref()[self.masked_model_offset()..])
+            .context("invalid masked object field")?;
 
         // Check the length of the local seed dictionary field
         let _ = LengthValueBuffer::new(&self.inner.as_ref()[self.local_seed_dict_offset()..])
@@ -87,13 +80,6 @@ impl<T: AsRef<[u8]>> UpdateBuffer<T> {
     /// Gets the offset of the masked model field.
     fn masked_model_offset(&self) -> usize {
         UPDATE_SIGNATURE_RANGE.end
-    }
-
-    /// Gets the offset of the masked scalar field.
-    fn masked_scalar_offset(&self) -> usize {
-        let masked_model =
-            MaskVectBuffer::new_unchecked(&self.inner.as_ref()[self.masked_model_offset()..]);
-        self.masked_model_offset() + masked_model.len()
     }
 
     /// Gets the offset of the local seed dictionary field.

--- a/rust/xaynet-core/src/message/payload/update.rs
+++ b/rust/xaynet-core/src/message/payload/update.rs
@@ -317,8 +317,8 @@ pub mod tests {
         //
         // First compute the offset at which the local seed dict value
         // starts: two signature (64 bytes), the masked model (32
-        // bytes), the length field (4 bytes), the masked scalar (14 bytes)
-        let offset = 64 * 2 + 32 + 4 + 14;
+        // bytes), the length field (4 bytes), the masked scalar (10 bytes)
+        let offset = 64 * 2 + 32 + 4 + 10;
         // Sort the end of the buffer
         (&mut buf[offset..]).sort();
         assert_eq!(buf, bytes);

--- a/rust/xaynet-core/src/testutils/messages.rs
+++ b/rust/xaynet-core/src/testutils/messages.rs
@@ -244,9 +244,7 @@ pub mod mask {
         let mask_unit = MaskUnit::new(config, data).unwrap();
 
         bytes.extend(vec![
-            // number of elements
-            0x00, 0x00, 0x00, 0x01, // data
-            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, // 1
+            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, // data: 1
         ]);
         (mask_unit, bytes)
     }

--- a/rust/xaynet-core/src/testutils/multipart.rs
+++ b/rust/xaynet-core/src/testutils/multipart.rs
@@ -51,20 +51,18 @@ pub fn mask_object(len: usize) -> MaskObject {
     //         - 6 bytes (with our config) for each weight
     //    - the masked scalar:
     //         - 4 bytes for the config
-    //         - 4 bytes for the number of weights (actually
-    //           always equal to 1)
     //         - 6 bytes (with our config) for the scalar
     //
     // The only parameter we control to make the length vary is
     // the number of weights. The lengths is then:
     //
-    // len = (4 + 4 + n_weights * 6) + (4 + 4 + 6) = 22 + 6 * n_weights
+    // len = (4 + 4 + n_weights * 6) + (4 + 6) = 18 + 6 * n_weights
     //
-    // So we must have: (len - 22) % 6 = 0
-    if (len - 22) % 6 != 0 {
+    // So we must have: (len - 18) % 6 = 0
+    if (len - 18) % 6 != 0 {
         panic!("invalid masked model length")
     }
-    let n_weights = (len - 22) / 6;
+    let n_weights = (len - 18) / 6;
     // Let's not be too crazy, it makes no sense to test with too
     // many weights
     assert!(n_weights < u32::MAX as usize);


### PR DESCRIPTION
Currently, `MaskUnit`s are serialized by first converting to a `MaskVect`. This merge request allows mask units to be serialized _directly_. In line with other unit/scalar types, a `MaskUnitBuffer` is introduced serving the usual purpose as a helper for (de)serializing the corresponding `MaskUnit`. As a result of a more specialised serialization, mask units can be encoded more compactly by excluding the `LENGTH` field, as the data is always a single value.

TODO.
- [x] document `MaskUnitBuffer`