### PR TITLE
Use docker-dev.toml instead of config.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,19 +136,19 @@ environment on your system, as everything is done inside the container.
 Docker images of the latest releases are provided on
 [Docker Hub](https://hub.docker.com/r/xaynetwork/xaynet).
 
-You can try them out with the default `configs/config.toml` by running:
+You can try them out with the default `configs/docker-dev.toml` by running:
 
 **Xaynet below v0.11**
 
 ```bash
-docker run -v ${PWD}/configs/config.toml:/app/config.toml -p 8081:8081 xaynetwork/xaynet:v0.10.0 /app/coordinator -c /app/config.toml
+docker run -v ${PWD}/configs/docker-dev.toml:/app/config.toml -p 8081:8081 xaynetwork/xaynet:v0.10.0 /app/coordinator -c /app/config.toml
 ```
 
 **Xaynet v0.11+**
 
 ```bash
-# don't forget to adjust the Redis url in configs/config.toml
-docker run -v ${PWD}/configs/config.toml:/app/config.toml -p 8081:8081 xaynetwork/xaynet:v0.11.0
+# don't forget to adjust the Redis url in configs/docker-dev.toml
+docker run -v ${PWD}/configs/docker-dev.toml:/app/config.toml -p 8081:8081 xaynetwork/xaynet:v0.11.0
 ```
 
 The docker image contains a release build of the coordinator without optional features.


### PR DESCRIPTION
The command shown in the README file does not work because the wrong configuration is used.
`config.toml` uses uses `localhost` as `bind_address` and therefore the coordinator can be reached within the container itself, but not from the host system.