### PR TITLE
XN-1178 doc forbid warnings

### DIFF
--- a/rust/xaynet-client/src/lib.rs
+++ b/rust/xaynet-client/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(doc, forbid(warnings))]
 //! Provides client-side functionality to connect to a XayNet service.
 //!
 //! This functionality includes:

--- a/rust/xaynet-core/src/lib.rs
+++ b/rust/xaynet-core/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(doc, forbid(warnings))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/xaynetwork/xaynet/master/assets/logo.png",
     issue_tracker_base_url = "https://github.com/xaynetwork/xaynet/issues",

--- a/rust/xaynet-core/src/message/utils/chunkable_iterator.rs
+++ b/rust/xaynet-core/src/message/utils/chunkable_iterator.rs
@@ -1,6 +1,6 @@
 //! This module provides an extension to the [`::std::iter::Iterator`] trait that allows iterating
 //! by chunks. One important property of our chunks, is that they implement
-//! [`std::iter::ExactSizeIterator`], which is required by the [`crate::messages::FromBytes`]
+//! [`std::iter::ExactSizeIterator`], which is required by the [`crate::message::FromBytes`]
 //! trait.
 use std::{
     cell::RefCell,

--- a/rust/xaynet-ffi/src/lib.rs
+++ b/rust/xaynet-ffi/src/lib.rs
@@ -35,7 +35,8 @@ use std::{
     convert::TryFrom,
     iter::Iterator,
     os::raw::{c_double, c_int, c_uchar, c_uint, c_void},
-    ptr, slice,
+    ptr,
+    slice,
 };
 
 use ffi_support::FfiStr;
@@ -47,7 +48,13 @@ use xaynet_client::mobile_client::{
 use xaynet_core::{
     crypto::ByteObject,
     mask::{
-        BoundType, DataType, FromPrimitives, GroupType, IntoPrimitives, MaskConfig, Model,
+        BoundType,
+        DataType,
+        FromPrimitives,
+        GroupType,
+        IntoPrimitives,
+        MaskConfig,
+        Model,
         ModelType,
     },
     ParticipantSecretKey,

--- a/rust/xaynet-ffi/src/lib.rs
+++ b/rust/xaynet-ffi/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(doc, forbid(warnings))]
 //! A C-API of the Xaynet mobile client.
 //!
 //! # Safety
@@ -34,8 +35,7 @@ use std::{
     convert::TryFrom,
     iter::Iterator,
     os::raw::{c_double, c_int, c_uchar, c_uint, c_void},
-    ptr,
-    slice,
+    ptr, slice,
 };
 
 use ffi_support::FfiStr;
@@ -47,13 +47,7 @@ use xaynet_client::mobile_client::{
 use xaynet_core::{
     crypto::ByteObject,
     mask::{
-        BoundType,
-        DataType,
-        FromPrimitives,
-        GroupType,
-        IntoPrimitives,
-        MaskConfig,
-        Model,
+        BoundType, DataType, FromPrimitives, GroupType, IntoPrimitives, MaskConfig, Model,
         ModelType,
     },
     ParticipantSecretKey,

--- a/rust/xaynet-macros/src/lib.rs
+++ b/rust/xaynet-macros/src/lib.rs
@@ -6,7 +6,9 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{
     parse::{Parse, ParseStream, Result},
-    parse_macro_input, Expr, Token,
+    parse_macro_input,
+    Expr,
+    Token,
 };
 struct Send {
     sender: Expr,

--- a/rust/xaynet-macros/src/lib.rs
+++ b/rust/xaynet-macros/src/lib.rs
@@ -1,12 +1,12 @@
+#![cfg_attr(doc, forbid(warnings))]
+
 extern crate proc_macro;
 
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{
     parse::{Parse, ParseStream, Result},
-    parse_macro_input,
-    Expr,
-    Token,
+    parse_macro_input, Expr, Token,
 };
 struct Send {
     sender: Expr,

--- a/rust/xaynet-server/src/lib.rs
+++ b/rust/xaynet-server/src/lib.rs
@@ -1,10 +1,10 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(doc, forbid(warnings))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/xaynetwork/xaynet/master/assets/logo.png",
     issue_tracker_base_url = "https://github.com/xaynetwork/xaynet/issues",
     html_favicon_url = "https://raw.githubusercontent.com/xaynetwork/xaynet/master/assets/favicon.png"
 )]
-
 //! `xaynet_server` is a backend for federated machile learning. It
 //! ensures the users privacy using the _Privacy-Enhancing Technology_
 //! (PET). Download the [whitepaper] for an introduction to the

--- a/rust/xaynet-server/src/state_machine/mod.rs
+++ b/rust/xaynet-server/src/state_machine/mod.rs
@@ -46,9 +46,9 @@
 //!
 //! **Error**
 //!
-//! Publishes [`PhaseName::Error`] and handles [`StateError`]s that can occur during the
+//! Publishes [`PhaseName::Error`] and handles [`PhaseStateError`]s that can occur during the
 //! execution of the [`StateMachine`]. In most cases, the error is handled by restarting the round.
-//! However, if a [`StateError::ChannelError`] occurs, the [`StateMachine`] will shut down.
+//! However, if a [`PhaseStateError::Channel`] occurs, the [`StateMachine`] will shut down.
 //!
 //! **Shutdown**
 //!

--- a/rust/xaynet/src/lib.rs
+++ b/rust/xaynet/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(doc, forbid(warnings))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/xaynetwork/xaynet/master/assets/logo.png",
     html_favicon_url = "https://raw.githubusercontent.com/xaynetwork/xaynet/master/assets/favicon.png",


### PR DESCRIPTION
**References**
- [XN-1178](https://xainag.atlassian.net/browse/XN-1178)

**Summary**
The `cargo doc` respectively `rustdoc` seems not to provide an option like `--deny warnings` as for example in `clippy`. Therefore we can't simply attach this to the CI command, but have to specify it in code. `forbid` was chosen over `deny` to avoid `allow`ing locally by accident. The dead documentations links have been fixed as well.
