### PR TITLE
XN-1132 enable clippy everywhere

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: cargo clippy
         working-directory: ./rust
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
 
   test:
     name: cargo-test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -95,7 +95,9 @@ jobs:
 
       - name: cargo clippy
         working-directory: ./rust
-        run: cargo clippy --all-targets -- -D warnings
+        run: |
+          cargo clippy --all-targets -- --deny warnings
+          cargo clippy --all-targets --all-features -- --deny warnings
 
   test:
     name: cargo-test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -96,8 +96,8 @@ jobs:
       - name: cargo clippy
         working-directory: ./rust
         run: |
-          cargo clippy --all-targets -- --deny warnings
-          cargo clippy --all-targets --all-features -- --deny warnings
+          cargo clippy --all-targets -- --deny warnings --deny clippy::cargo
+          cargo clippy --all-targets --all-features -- --deny warnings --deny clippy::cargo
 
   test:
     name: cargo-test

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,13 +1,13 @@
 [workspace]
-
 members = [
     "xaynet",
-    "xaynet-server",
     "xaynet-client",
     "xaynet-core",
-    "xaynet-macros",
     "xaynet-ffi",
-    # Internal
-    "examples",
+    "xaynet-macros",
+    "xaynet-server",
+
+    # internals
     "benches",
+    "examples",
 ]

--- a/rust/benches/Cargo.toml
+++ b/rust/benches/Cargo.toml
@@ -3,11 +3,18 @@ name = "benches"
 version = "0.0.0"
 authors = ["Xayn Engineering <engineering@xaynet.dev>"]
 edition = "2018"
+description = "The Xayn Network project is building a privacy layer for machine learning so that AI projects can meet compliance such as GDPR and CCPA. The approach relies on Federated Learning as enabling technology that allows production AI applications to be fully privacy compliant."
+readme = "../../README.md"
+homepage = "https://xaynet.dev/"
+repository = "https://github.com/xaynetwork/xaynet/"
+license-file = "../../LICENSE"
+keywords = ["federated-learning", "fl", "ai", "machine-learning"]
+categories = ["science", "cryptography"]
 publish = false
 
 [dev-dependencies]
 criterion = "0.3.3"
-xaynet-core = { version = "0.1.0", path = "../xaynet-core", features = ["testutils"] }
+xaynet-core = { path = "../xaynet-core", features = ["testutils"] }
 
 [[bench]]
 name = "messages"

--- a/rust/examples/Cargo.toml
+++ b/rust/examples/Cargo.toml
@@ -1,17 +1,25 @@
 [package]
 name = "examples"
 version = "0.0.0"
+authors = ["Xayn Engineering <engineering@xaynet.dev>"]
 publish = false
 edition = "2018"
+description = "The Xayn Network project is building a privacy layer for machine learning so that AI projects can meet compliance such as GDPR and CCPA. The approach relies on Federated Learning as enabling technology that allows production AI applications to be fully privacy compliant."
+readme = "../../README.md"
+homepage = "https://xaynet.dev/"
+repository = "https://github.com/xaynetwork/xaynet/"
+license-file = "../../LICENSE"
+keywords = ["federated-learning", "fl", "ai", "machine-learning"]
+categories = ["science", "cryptography"]
 
 [dev-dependencies]
+sodiumoxide = "0.2.6"
+structopt = "0.3.17"
+tokio = { version = "0.2.22", features = ["full"] }
+tracing = "0.1.19"
+tracing-subscriber = "0.2.12"
 xaynet-client = { path = "../xaynet-client" }
 xaynet-core = { path = "../xaynet-core" }
-tracing = "0.1.19"
-structopt = "0.3.17"
-tracing-subscriber = "0.2.12"
-sodiumoxide = "0.2.6"
-tokio = { version = "0.2.22", features = ["full"] }
 
 [features]
 default = []

--- a/rust/examples/mobile-client.rs
+++ b/rust/examples/mobile-client.rs
@@ -181,12 +181,11 @@ fn perform_task(
         Err((client, _)) => client,
     };
 
-    match client.get_global_model().unwrap() {
-        Some(model) => println!(
+    if let Some(model) = client.get_global_model().unwrap() {
+        println!(
             "global model: {:?}",
             model.into_primitives_unchecked().collect::<Vec<f32>>()
-        ),
-        _ => (),
+        );
     };
 
     let new_bytes = client.serialize();

--- a/rust/xaynet-client/Cargo.toml
+++ b/rust/xaynet-client/Cargo.toml
@@ -3,31 +3,33 @@ name = "xaynet-client"
 version = "0.1.0"
 authors = ["Xayn Engineering <engineering@xaynet.dev>"]
 edition = "2018"
-description = "`xaynet_client` provides an implementation of a Xayn Network client"
+description = "The Xayn Network project is building a privacy layer for machine learning so that AI projects can meet compliance such as GDPR and CCPA. The approach relies on Federated Learning as enabling technology that allows production AI applications to be fully privacy compliant."
+readme = "../../README.md"
+homepage = "https://xaynet.dev/"
+repository = "https://github.com/xaynetwork/xaynet/"
 license-file = "../../LICENSE"
 keywords = ["federated-learning", "fl", "ai", "machine-learning"]
-repository = "https://github.com/xaynetwork/xaynet/"
-homepage = "https://xaynet.dev/"
+categories = ["science", "cryptography"]
 
 [dependencies]
-tokio = "0.2.22"
-derive_more = { version = "0.99.10", default-features = false, features = ["from"] }
-serde = { version = "1.0.116", features = ["derive"] }
-bytes = "0.5.6"
-sodiumoxide = "0.2.6"
-bincode = "1.3.1"
-thiserror = "1.0.20"
-tracing = "0.1.19"
 async-trait = "0.1.40"
-xaynet-core = { path = "../xaynet-core", version = "0.1.0" }
+bincode = "1.3.1"
+bytes = "0.5.6"
+derive_more = { version = "0.99.10", default-features = false, features = ["from"] }
 reqwest = { version = "0.10.8", default-features = false }
+serde = { version = "1.0.116", features = ["derive"] }
+sodiumoxide = "0.2.6"
+thiserror = "1.0.20"
+tokio = "0.2.22"
+tracing = "0.1.19"
+xaynet-core = { path = "../xaynet-core", version = "0.1.0" }
 
 [dev-dependencies]
-tower-test = "0.3.0"
-tokio-test = "0.2.1"
 num = { version = "0.3.0", features = ["serde"] }
-xaynet-core = { path = "../xaynet-core", version = "0.1.0", features = ["testutils"] }
 serde_json = "1.0.58"
+tokio-test = "0.2.1"
+tower-test = "0.3.0"
+xaynet-core = { path = "../xaynet-core", version = "0.1.0", features = ["testutils"] }
 
 [features]
 default = []

--- a/rust/xaynet-client/src/mobile_client/participant/awaiting.rs
+++ b/rust/xaynet-client/src/mobile_client/participant/awaiting.rs
@@ -113,10 +113,10 @@ mod tests {
             193, 111, 216, 217, 127, 168, 104, 99, 42, 55, 201, 207, 226, 237,
         ];
 
-        match part.determine_role(eligible_sum_seed, 0.5_f64, 0.5_f64) {
-            Role::Summer(_) => (),
-            _ => panic!(),
-        }
+        assert!(matches!(
+            part.determine_role(eligible_sum_seed, 0.5_f64, 0.5_f64),
+            Role::Summer(_)
+        ));
     }
 
     #[test]
@@ -139,10 +139,10 @@ mod tests {
             170, 245, 38, 85, 161, 86, 143, 96, 18, 89, 161, 186, 172, 199,
         ];
 
-        match part.determine_role(eligible_sum_update_seed, 0.5_f64, 0.5_f64) {
-            Role::Summer(_) => (),
-            _ => panic!(),
-        }
+        assert!(matches!(
+            part.determine_role(eligible_sum_update_seed, 0.5_f64, 0.5_f64),
+            Role::Summer(_)
+        ));
     }
 
     #[test]
@@ -165,10 +165,10 @@ mod tests {
             80, 43, 96, 255, 29, 236, 183, 96, 245, 36, 182, 239, 179,
         ];
 
-        match part.determine_role(eligible_update_seed, 0.5_f64, 0.5_f64) {
-            Role::Updater(_) => (),
-            _ => panic!(),
-        }
+        assert!(matches!(
+            part.determine_role(eligible_update_seed, 0.5_f64, 0.5_f64),
+            Role::Updater(_)
+        ));
     }
 
     #[test]
@@ -191,9 +191,9 @@ mod tests {
             187, 119, 128, 151, 223, 57, 144, 229, 66, 150, 100, 75, 62, 62,
         ];
 
-        match part.determine_role(ineligible_sum_update_seed, 0.5_f64, 0.5_f64) {
-            Role::Unselected(_) => (),
-            _ => panic!(),
-        }
+        assert!(matches!(
+            part.determine_role(ineligible_sum_update_seed, 0.5_f64, 0.5_f64),
+            Role::Unselected(_)
+        ));
     }
 }

--- a/rust/xaynet-client/src/mobile_client/participant/awaiting.rs
+++ b/rust/xaynet-client/src/mobile_client/participant/awaiting.rs
@@ -115,7 +115,7 @@ mod tests {
 
         match part.determine_role(eligible_sum_seed, 0.5_f64, 0.5_f64) {
             Role::Summer(_) => (),
-            _ => assert!(false),
+            _ => panic!(),
         }
     }
 
@@ -141,7 +141,7 @@ mod tests {
 
         match part.determine_role(eligible_sum_update_seed, 0.5_f64, 0.5_f64) {
             Role::Summer(_) => (),
-            _ => assert!(false),
+            _ => panic!(),
         }
     }
 
@@ -167,7 +167,7 @@ mod tests {
 
         match part.determine_role(eligible_update_seed, 0.5_f64, 0.5_f64) {
             Role::Updater(_) => (),
-            _ => assert!(false),
+            _ => panic!(),
         }
     }
 
@@ -193,7 +193,7 @@ mod tests {
 
         match part.determine_role(ineligible_sum_update_seed, 0.5_f64, 0.5_f64) {
             Role::Unselected(_) => (),
-            _ => assert!(false),
+            _ => panic!(),
         }
     }
 }

--- a/rust/xaynet-core/Cargo.toml
+++ b/rust/xaynet-core/Cargo.toml
@@ -3,31 +3,33 @@ name = "xaynet-core"
 version = "0.1.0"
 authors = ["Xayn Engineering <engineering@xaynet.dev>"]
 edition = "2018"
-description = "`xaynet_core` provides building blocks that are common to the Xayn Network backend and client."
+description = "The Xayn Network project is building a privacy layer for machine learning so that AI projects can meet compliance such as GDPR and CCPA. The approach relies on Federated Learning as enabling technology that allows production AI applications to be fully privacy compliant."
+readme = "../../README.md"
+homepage = "https://xaynet.dev/"
+repository = "https://github.com/xaynetwork/xaynet/"
 license-file = "../../LICENSE"
 keywords = ["federated-learning", "fl", "ai", "machine-learning"]
-repository = "https://github.com/xaynetwork/xaynet/"
-homepage = "https://xaynet.dev/"
+categories = ["science", "cryptography"]
 
 [dependencies]
+anyhow = "1.0.32"
+bitflags = "1.2.1"
 derive_more = { version = "0.99.10", default-features = false, features = [
-    "display",
-    "from",
     "as_ref",
     "as_mut",
-    "into",
+    "display",
+    "from",
     "index",
     "index_mut",
+    "into",
 ] }
+num = { version = "0.3.0", features = ["serde"] }
+paste = "1.0.1"
 rand = "0.7.3"
 rand_chacha = "0.2.2"
 serde = { version = "1.0.116", features = ["derive"] }
 sodiumoxide = "0.2.6"
-num = { version = "0.3.0", features = ["serde"] }
 thiserror = "1.0.20"
-anyhow = "1.0.32"
-bitflags = "1.2.1"
-paste = "1.0.1"
 
 [features]
 testutils = []

--- a/rust/xaynet-core/src/mask/model.rs
+++ b/rust/xaynet-core/src/mask/model.rs
@@ -435,11 +435,12 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::float_cmp)]
     fn test_ratio_to_float() {
         let ratio = R::from_float(0_f32).unwrap();
-        assert_eq!(ratio_to_float::<f32>(&ratio).unwrap(), 0.0);
+        assert_eq!(ratio_to_float::<f32>(&ratio).unwrap(), 0_f32);
         let ratio = R::from_float(0_f64).unwrap();
-        assert_eq!(ratio_to_float::<f64>(&ratio).unwrap(), 0.0);
+        assert_eq!(ratio_to_float::<f64>(&ratio).unwrap(), 0_f64);
 
         let ratio = R::from_float(0.1_f32).unwrap();
         assert_eq!(ratio_to_float::<f32>(&ratio).unwrap(), 0.1_f32);

--- a/rust/xaynet-core/src/message/payload/update.rs
+++ b/rust/xaynet-core/src/message/payload/update.rs
@@ -306,7 +306,7 @@ pub mod tests {
         // bytes), the length field (4 bytes), the masked scalar (10 bytes)
         let offset = 64 * 2 + 32 + 4 + 10;
         // Sort the end of the buffer
-        (&mut buf[offset..]).sort();
+        (&mut buf[offset..]).sort_unstable();
         assert_eq!(buf, bytes);
     }
 }

--- a/rust/xaynet-ffi/Cargo.toml
+++ b/rust/xaynet-ffi/Cargo.toml
@@ -3,11 +3,13 @@ name = "xaynet-ffi"
 version = "0.0.0"
 authors = ["Xayn Engineering <engineering@xaynet.dev>"]
 edition = "2018"
-description = "`xaynet_ffi` provides an implementation of a Xayn Network client with C bindings."
+description = "The Xayn Network project is building a privacy layer for machine learning so that AI projects can meet compliance such as GDPR and CCPA. The approach relies on Federated Learning as enabling technology that allows production AI applications to be fully privacy compliant."
+readme = "README.md"
+homepage = "https://xaynet.dev/"
+repository = "https://github.com/xaynetwork/xaynet/"
 license-file = "../../LICENSE"
 keywords = ["federated-learning", "fl", "ai", "machine-learning"]
-repository = "https://github.com/xaynetwork/xaynet/"
-homepage = "https://xaynet.dev/"
+categories = ["science", "cryptography"]
 
 [dependencies]
 ffi-support = "0.4.2"

--- a/rust/xaynet-macros/Cargo.toml
+++ b/rust/xaynet-macros/Cargo.toml
@@ -3,14 +3,17 @@ name = "xaynet-macros"
 version = "0.1.0"
 authors = ["Xayn Engineering <engineering@xaynet.dev>"]
 edition = "2018"
-license-file = "../../LICENSE"
-repository = "https://github.com/xaynetwork/xaynet/"
+description = "The Xayn Network project is building a privacy layer for machine learning so that AI projects can meet compliance such as GDPR and CCPA. The approach relies on Federated Learning as enabling technology that allows production AI applications to be fully privacy compliant."
+readme = "../../README.md"
 homepage = "https://xaynet.dev/"
-description = "Macros for internal use in `xaynet-server`"
+repository = "https://github.com/xaynetwork/xaynet/"
+license-file = "../../LICENSE"
+keywords = ["federated-learning", "fl", "ai", "machine-learning"]
+categories = ["science", "cryptography"]
 
 [dependencies]
-syn = "1.0.41"
 quote = "1.0.7"
+syn = "1.0.41"
 
 [lib]
 proc-macro = true

--- a/rust/xaynet-server/Cargo.toml
+++ b/rust/xaynet-server/Cargo.toml
@@ -4,78 +4,83 @@ version = "0.1.0"
 authors = ["Xayn Engineering <engineering@xaynet.dev>"]
 edition = "2018"
 description = "The Xayn Network project is building a privacy layer for machine learning so that AI projects can meet compliance such as GDPR and CCPA. The approach relies on Federated Learning as enabling technology that allows production AI applications to be fully privacy compliant."
+readme = "../../README.md"
+homepage = "https://xaynet.dev/"
+repository = "https://github.com/xaynetwork/xaynet/"
 license-file = "../../LICENSE"
 keywords = ["federated-learning", "fl", "ai", "machine-learning"]
-repository = "https://github.com/xaynetwork/xaynet/"
-homepage = "https://xaynet.dev/"
+categories = ["science", "cryptography"]
 
 [dependencies]
-futures = "0.3.5"
-tokio = { version = "0.2.22", features = [
-    "rt-core",
-    "rt-threaded",
-    "tcp",
-    "time",
-    "macros",
-    "signal",
-    "sync",
-    "stream",
-] }
+anyhow = "1.0.32"
+async-trait = "0.1.40"
+bincode = "1.3.1"
+bitflags = "1.2.1"
+bytes = "0.5.6"
+config = "0.10.1"
 derive_more = { version = "0.99.10", default-features = false, features = [
+    "as_mut",
+    "as_ref",
+    "deref",
     "display",
     "from",
-    "as_ref",
-    "as_mut",
-    "into",
     "index",
     "index_mut",
-    "deref",
+    "into",
 ] }
+futures = "0.3.5"
+num = { version = "0.3.0", features = ["serde"] }
+num_enum = "0.5.1"
+paste = "1.0.1"
 rand = "0.7.3"
 rand_chacha = "0.2.2"
 serde = { version = "1.0.116", features = ["derive"] }
-bytes = "0.5.6"
+rayon = "1.4.0"
+redis = { version = "0.17.0", default-features = false, features = [
+    "aio",
+    "connection-manager",
+    "script",
+    "tokio-rt-core",
+] }
 sodiumoxide = "0.2.6"
-num = { version = "0.3.0", features = ["serde"] }
-bincode = "1.3.1"
-thiserror = "1.0.20"
-anyhow = "1.0.32"
-bitflags = "1.2.1"
-warp = "0.2.5"
-config = "0.10.1"
-validator = { version = "0.11.0", features = ["derive"] }
 structopt = "0.3.17"
-paste = "1.0.1"
+thiserror = "1.0.20"
+tokio = { version = "0.2.22", features = [
+    "macros",
+    "rt-core",
+    "rt-threaded",
+    "signal",
+    "stream",
+    "sync",
+    "tcp",
+    "time",
+] }
 tower = "0.3.1"
 tracing = "0.1.19"
 tracing-futures = "0.2.4"
 tracing-subscriber = "0.2.12"
 uuid = { version = "0.8.1", features = ["v4"] }
-rayon = "1.4.0"
-async-trait = "0.1.40"
-xaynet-macros = { path = "../xaynet-macros", version = "0.1.0" }
+validator = { version = "0.11.0", features = ["derive"] }
+warp = "0.2.5"
 xaynet-core = { path = "../xaynet-core", version = "0.1.0" }
-redis = { version = "0.17.0", default-features = false, features = ["connection-manager", "aio", "tokio-rt-core", "script"] }
-num_enum = "0.5.1"
+xaynet-macros = { path = "../xaynet-macros", version = "0.1.0" }
 
-# optional dependencies
-# metrics feature
+# feature: metrics
 influxdb = { version = "0.1.0", features = ["derive"], optional = true }
 chrono = { version = "0.4.15", optional = true }
-# model-persistence feature
+
+# feature: model-persistence
+fancy-regex = { version = "0.4.0", optional = true }
+hex = { version = "0.4.2", optional = true }
 rusoto_core = { version = "0.45.0", optional = true }
 rusoto_s3 = { version = "0.45.0", optional = true }
-hex = { version = "0.4.2", optional = true }
-fancy-regex = { version = "0.4.0", optional = true }
 
 [dev-dependencies]
-tower-test = "0.3.0"
-tokio-test = "0.2.1"
-# We can't run tarpaulin with the flag `--test-threads=1` because it can
-# trigger a segfault
-# https://github.com/xd009642/tarpaulin/issues/317
-# A workaround is to use `serial_test`
+# We can't run tarpaulin with the flag `--test-threads=1` because it can trigger a segfault:
+# https://github.com/xd009642/tarpaulin/issues/317. A workaround is to use `serial_test`.
 serial_test = "0.5.0"
+tokio-test = "0.2.1"
+tower-test = "0.3.0"
 xaynet-client = { path = "../xaynet-client", version = "0.1.0" }
 
 [[bin]]
@@ -84,7 +89,7 @@ path = "src/bin/main.rs"
 
 [features]
 default = []
+full = ["metrics", "tls"]
+metrics = ["chrono", "influxdb"]
+model-persistence = ["fancy-regex", "hex", "rusoto_core", "rusoto_s3"]
 tls = ["warp/tls"]
-metrics = ["influxdb", "chrono"]
-model-persistence = ["rusoto_core", "rusoto_s3", "hex", "fancy-regex"]
-full = ["tls", "metrics", "model-persistence"]

--- a/rust/xaynet-server/src/services/messages/multipart/service.rs
+++ b/rust/xaynet-server/src/services/messages/multipart/service.rs
@@ -243,7 +243,7 @@ mod tests {
             id: 1,
             message_id: 1234,
             last: false,
-            data: data,
+            data,
         };
         let chunk2 = Chunk {
             id: 2,
@@ -276,7 +276,7 @@ mod tests {
     fn test_message_builder_in_order() {
         let mut msg = message_builder();
         let (data, sum) = sum();
-        let (c1, c2, c3, c4, c5) = chunks(data.clone());
+        let (c1, c2, c3, c4, c5) = chunks(data);
 
         assert!(msg.data.is_empty());
         assert!(msg.last_chunk_id.is_none());
@@ -317,7 +317,7 @@ mod tests {
     fn test_message_builder_out_of_order() {
         let mut msg = message_builder();
         let (data, sum) = sum();
-        let (c1, c2, c3, c4, c5) = chunks(data.clone());
+        let (c1, c2, c3, c4, c5) = chunks(data);
 
         assert!(msg.data.is_empty());
         assert!(msg.last_chunk_id.is_none());
@@ -360,7 +360,7 @@ mod tests {
         assert_ready!(task.poll_ready()).unwrap();
 
         let coordinator_pk =
-            PublicEncryptKey::from_slice(&vec![0x00; PublicSigningKey::LENGTH]).unwrap();
+            PublicEncryptKey::from_slice(&[0x00; PublicSigningKey::LENGTH]).unwrap();
 
         // The payload of the message (and therefore the chunks) will
         // be the same for the two participants. What must differ is
@@ -369,7 +369,7 @@ mod tests {
         let (c1, c2, c3, c4, c5) = chunks(data.clone());
 
         // A signing key that identifies a first faked participant.
-        let pk1 = PublicSigningKey::from_slice(&vec![0x11; PublicSigningKey::LENGTH]).unwrap();
+        let pk1 = PublicSigningKey::from_slice(&[0x11; PublicSigningKey::LENGTH]).unwrap();
         // message ID for the message from our fake participant identified by `pk1`
         let message_id1 = MessageId {
             message_id: 1234,
@@ -383,7 +383,7 @@ mod tests {
         // Do the same thing to fake a second participant: generate a
         // public key, a message ID, and a function to create messages
         // originating from that participant
-        let pk2 = PublicSigningKey::from_slice(&vec![0x22; PublicSigningKey::LENGTH]).unwrap();
+        let pk2 = PublicSigningKey::from_slice(&[0x22; PublicSigningKey::LENGTH]).unwrap();
         let message_id2 = MessageId {
             message_id: 1234,
             participant_pk: pk2,

--- a/rust/xaynet-server/src/services/tests/utils.rs
+++ b/rust/xaynet-server/src/services/tests/utils.rs
@@ -15,7 +15,7 @@ use crate::state_machine::{
 pub fn new_event_channels() -> (EventPublisher, EventSubscriber) {
     let keys = EncryptKeyPair::generate();
     let params = RoundParameters {
-        pk: keys.public.clone(),
+        pk: keys.public,
         sum: 0.0,
         update: 0.0,
         seed: RoundSeed::generate(),
@@ -36,7 +36,7 @@ pub fn new_sum_message(round_params: &RoundParameters) -> (Message, SigningKeyPa
             .sign_detached(&[round_params.seed.as_slice(), b"sum"].concat()),
         ephm_pk: PublicEncryptKey::generate(),
     };
-    let message = Message::new_sum(signing_keys.public.clone(), round_params.pk, sum);
+    let message = Message::new_sum(signing_keys.public, round_params.pk, sum);
     (message, signing_keys)
 }
 

--- a/rust/xaynet-server/src/state_machine/phases/idle.rs
+++ b/rust/xaynet-server/src/state_machine/phases/idle.rs
@@ -183,7 +183,7 @@ mod test {
         let new_keys = shared.state.keys.clone();
 
         // Make sure the seed and keys have updated
-        assert_ne!(initial_seed, new_round_params.seed.clone());
+        assert_ne!(initial_seed, new_round_params.seed);
         assert_ne!(initial_keys, new_keys);
 
         fn expected_event<T>(event: T) -> Event<T> {

--- a/rust/xaynet-server/src/state_machine/phases/sum2.rs
+++ b/rust/xaynet-server/src/state_machine/phases/sum2.rs
@@ -244,11 +244,7 @@ mod test {
         let (mask, count) = best_masks.pop().unwrap();
         assert_eq!(count, 1);
 
-        let unmasked_model = unmask_state
-            .aggregation()
-            .unwrap()
-            .clone()
-            .unmask(mask.clone());
+        let unmasked_model = unmask_state.aggregation().unwrap().clone().unmask(mask);
         assert_eq!(unmasked_model, model);
 
         assert_eq!(

--- a/rust/xaynet-server/src/state_machine/phases/unmask.rs
+++ b/rust/xaynet-server/src/state_machine/phases/unmask.rs
@@ -65,7 +65,6 @@ impl Phase for PhaseState<Unmask> {
         {
             // As key for the global model we use the round_id and the seed
             // (format: `roundid_roundseed`) of the round in which the global model was created.
-            use hex;
             use xaynet_core::crypto::ByteObject;
             let round_seed = hex::encode(self.shared.state.round_params.seed.as_slice());
             let key = format!("{}_{}", self.shared.state.round_id, round_seed);
@@ -74,7 +73,7 @@ impl Phase for PhaseState<Unmask> {
                 .s3
                 .upload_global_model(&key, &global_model)
                 .await
-                .map_err(|err| PhaseStateError::SaveGlobalModel(err))?;
+                .map_err(PhaseStateError::SaveGlobalModel)?;
         }
 
         info!("broadcasting the new global model");

--- a/rust/xaynet-server/src/state_machine/phases/update.rs
+++ b/rust/xaynet-server/src/state_machine/phases/update.rs
@@ -322,7 +322,7 @@ mod test {
         // We have only one updater, so the aggregation should contain
         // the masked model from that updater
         assert_eq!(
-            <Aggregation as Into<MaskObject>>::into(sum2_state.aggregation().clone().into()),
+            <Aggregation as Into<MaskObject>>::into(sum2_state.aggregation().clone()),
             masked_model
         );
         let best_masks = eio.redis.connection().await.get_best_masks().await.unwrap();

--- a/rust/xaynet-server/src/state_machine/tests/builder.rs
+++ b/rust/xaynet-server/src/state_machine/tests/builder.rs
@@ -87,8 +87,8 @@ where
 
     #[allow(dead_code)]
     pub fn with_keys(mut self, keys: EncryptKeyPair) -> Self {
-        self.shared.state.round_params.pk = keys.public.clone();
-        self.shared.state.keys = keys.clone();
+        self.shared.state.round_params.pk = keys.public;
+        self.shared.state.keys = keys;
         self
     }
 

--- a/rust/xaynet-server/src/state_machine/tests/impls.rs
+++ b/rust/xaynet-server/src/state_machine/tests/impls.rs
@@ -17,10 +17,7 @@ impl RequestSender {
 
 impl StateMachine {
     pub fn is_update(&self) -> bool {
-        match self {
-            StateMachine::Update(_) => true,
-            _ => false,
-        }
+        matches!(self, StateMachine::Update(_))
     }
 
     pub fn into_update_phase_state(self) -> PhaseState<phases::Update> {
@@ -31,10 +28,7 @@ impl StateMachine {
     }
 
     pub fn is_sum(&self) -> bool {
-        match self {
-            StateMachine::Sum(_) => true,
-            _ => false,
-        }
+        matches!(self, StateMachine::Sum(_))
     }
 
     pub fn into_sum_phase_state(self) -> PhaseState<phases::Sum> {
@@ -45,10 +39,7 @@ impl StateMachine {
     }
 
     pub fn is_sum2(&self) -> bool {
-        match self {
-            StateMachine::Sum2(_) => true,
-            _ => false,
-        }
+        matches!(self, StateMachine::Sum2(_))
     }
 
     pub fn into_sum2_phase_state(self) -> PhaseState<phases::Sum2> {
@@ -59,10 +50,7 @@ impl StateMachine {
     }
 
     pub fn is_idle(&self) -> bool {
-        match self {
-            StateMachine::Idle(_) => true,
-            _ => false,
-        }
+        matches!(self, StateMachine::Idle(_))
     }
 
     pub fn into_idle_phase_state(self) -> PhaseState<phases::Idle> {
@@ -73,10 +61,7 @@ impl StateMachine {
     }
 
     pub fn is_unmask(&self) -> bool {
-        match self {
-            StateMachine::Unmask(_) => true,
-            _ => false,
-        }
+        matches!(self, StateMachine::Unmask(_))
     }
 
     pub fn into_unmask_phase_state(self) -> PhaseState<phases::Unmask> {
@@ -87,10 +72,7 @@ impl StateMachine {
     }
 
     pub fn is_error(&self) -> bool {
-        match self {
-            StateMachine::Error(_) => true,
-            _ => false,
-        }
+        matches!(self, StateMachine::Error(_))
     }
 
     pub fn into_error_phase_state(self) -> PhaseState<phases::PhaseStateError> {
@@ -101,10 +83,7 @@ impl StateMachine {
     }
 
     pub fn is_shutdown(&self) -> bool {
-        match self {
-            StateMachine::Shutdown(_) => true,
-            _ => false,
-        }
+        matches!(self, StateMachine::Shutdown(_))
     }
 
     pub fn into_shutdown_phase_state(self) -> PhaseState<phases::Shutdown> {

--- a/rust/xaynet-server/src/state_machine/tests/mod.rs
+++ b/rust/xaynet-server/src/state_machine/tests/mod.rs
@@ -97,7 +97,6 @@ async fn integration_full_round() {
     // check if a global model exist
     #[cfg(feature = "model-persistence")]
     {
-        use hex;
         use xaynet_core::crypto::ByteObject;
         let round_id = events.params_listener().get_latest().round_id;
         let round_seed = events.params_listener().get_latest().event.seed;

--- a/rust/xaynet-server/src/state_machine/tests/utils.rs
+++ b/rust/xaynet-server/src/state_machine/tests/utils.rs
@@ -38,10 +38,9 @@ pub fn generate_summer(seed: &RoundSeed, sum_ratio: f64, update_ratio: f64) -> P
     loop {
         let mut participant = Participant::new().unwrap();
         participant.compute_signatures(seed.as_slice());
-        match participant.check_task(sum_ratio, update_ratio) {
-            Task::Sum => return participant,
-            _ => {}
-        }
+        if participant.check_task(sum_ratio, update_ratio) == Task::Sum {
+            return participant;
+        };
     }
 }
 
@@ -49,10 +48,9 @@ pub fn generate_updater(seed: &RoundSeed, sum_ratio: f64, update_ratio: f64) -> 
     loop {
         let mut participant = Participant::new().unwrap();
         participant.compute_signatures(seed.as_slice());
-        match participant.check_task(sum_ratio, update_ratio) {
-            Task::Update => return participant,
-            _ => {}
-        }
+        if participant.check_task(sum_ratio, update_ratio) == Task::Update {
+            return participant;
+        };
     }
 }
 
@@ -75,7 +73,6 @@ pub fn pet_settings() -> PetSettings {
         max_sum_time: 2,
         min_update_time: 1,
         max_update_time: 2,
-        ..Default::default()
     }
 }
 

--- a/rust/xaynet-server/src/storage/redis.rs
+++ b/rust/xaynet-server/src/storage/redis.rs
@@ -926,7 +926,7 @@ mod tests {
         assert_eq!(remove_result, 1);
 
         let update_result =
-            write_local_seed_entries(&client, &vec![(update_participant, local_seed_dict)]).await;
+            write_local_seed_entries(&client, &[(update_participant, local_seed_dict)]).await;
         update_result.into_iter().for_each(|res| {
             assert!(matches!(
                 res.into_inner().unwrap_err(),

--- a/rust/xaynet-server/src/storage/s3.rs
+++ b/rust/xaynet-server/src/storage/s3.rs
@@ -145,7 +145,6 @@ impl Client {
 pub(in crate) mod tests {
     use super::*;
     use crate::storage::tests::create_global_model;
-    use hex;
     use rusoto_core::Region;
     use rusoto_s3::{
         Delete,

--- a/rust/xaynet-server/src/storage/tests/mod.rs
+++ b/rust/xaynet-server/src/storage/tests/mod.rs
@@ -21,7 +21,7 @@ pub fn create_sum_participant_entry() -> (SumParticipantPublicKey, SumParticipan
 }
 
 pub fn create_local_seed_entries(
-    sum_pks: &Vec<SumParticipantPublicKey>,
+    sum_pks: &[SumParticipantPublicKey],
 ) -> Vec<(UpdateParticipantPublicKey, LocalSeedDict)> {
     let mut entries = Vec::new();
 
@@ -33,7 +33,7 @@ pub fn create_local_seed_entries(
         let mut local_seed_dict = LocalSeedDict::new();
         for sum_pk in sum_pks {
             let seed = EncryptedMaskSeed::zeroed();
-            local_seed_dict.insert(sum_pk.clone(), seed);
+            local_seed_dict.insert(*sum_pk, seed);
         }
         entries.push((update_pk, local_seed_dict))
     }
@@ -50,7 +50,7 @@ pub fn create_mask_zeroed(byte_size: usize) -> MaskObject {
     };
 
     MaskObject::new(
-        config.clone(),
+        config,
         vec![BigUint::zero(); byte_size],
         config,
         BigUint::zero(),
@@ -67,7 +67,7 @@ pub fn create_mask(byte_size: usize, number: u32) -> MaskObject {
     };
 
     MaskObject::new(
-        config.clone(),
+        config,
         vec![BigUint::from(number); byte_size],
         config,
         BigUint::zero(),
@@ -77,7 +77,7 @@ pub fn create_mask(byte_size: usize, number: u32) -> MaskObject {
 
 pub fn create_seed_dict(
     sum_dict: SumDict,
-    seed_updates: &Vec<(UpdateParticipantPublicKey, LocalSeedDict)>,
+    seed_updates: &[(UpdateParticipantPublicKey, LocalSeedDict)],
 ) -> SeedDict {
     let mut seed_dict: SeedDict = sum_dict
         .keys()
@@ -116,7 +116,7 @@ pub async fn create_and_write_sum_participant_entries(
 
 pub async fn write_local_seed_entries(
     client: &Client,
-    local_seed_entries: &Vec<(UpdateParticipantPublicKey, LocalSeedDict)>,
+    local_seed_entries: &[(UpdateParticipantPublicKey, LocalSeedDict)],
 ) -> Vec<SeedDictUpdate> {
     let mut update_result = Vec::new();
 

--- a/rust/xaynet/Cargo.toml
+++ b/rust/xaynet/Cargo.toml
@@ -4,21 +4,27 @@ version = "0.10.0"
 authors = ["Xayn Engineering <engineering@xaynet.dev>"]
 edition = "2018"
 description = "The Xayn Network project is building a privacy layer for machine learning so that AI projects can meet compliance such as GDPR and CCPA. The approach relies on Federated Learning as enabling technology that allows production AI applications to be fully privacy compliant."
+readme = "../../README.md"
+homepage = "https://xaynet.dev/"
+repository = "https://github.com/xaynetwork/xaynet/"
 license-file = "../../LICENSE"
 keywords = ["federated-learning", "fl", "ai", "machine-learning"]
 categories = ["science", "cryptography"]
-repository = "https://github.com/xaynetwork/xaynet/"
-homepage = "https://xaynet.dev/"
 
 [badges]
 codecov = { repository = "xaynetwork/xaynet", branch = "master", service = "github" }
 
 [dependencies]
 xaynet-core = { path = "../xaynet-core", version = "0.1.0" }
+
+# feature: client
 xaynet-client = { path = "../xaynet-client", version = "0.1.0", optional = true }
+
+# feature: server
 xaynet-server = { path = "../xaynet-server", version = "0.1.0", optional = true }
 
 [features]
 default = []
 client = ["xaynet-client"]
+full = ["client", "server"]
 server = ["xaynet-server"]


### PR DESCRIPTION
**References**
- [XN-1132](https://xainag.atlassian.net/browse/XN-1132)

**Summary**
Enables `cargo clippy` for all targets (including tests) on the CI and fixes the newly raised issues. Also enables `clippy::cargo` lints, those are off by default and check some best practices for the `Cargo.toml` files. Fixed the issues within the `package` section and reordered them in the same way as the rust book. Also took the opportunity to sort the dependencies alphanumerically to improve findability (if the sorting is deemed too much, i can also revert this).

**Todo**
- [x] fix remaining clippy issues
- [x] check if enabling clippy for manifests is a viable option
- [x] wait for #567 to be merged to rebase
