### PR TITLE
XN-1263 add minimum supported rust version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![crates.io badge](https://img.shields.io/crates/v/xaynet.svg)](https://crates.io/crates/xaynet) [![docs.rs badge](https://docs.rs/xaynet/badge.svg)](https://docs.rs/xaynet) [![Coverage Status](https://codecov.io/gh/xaynetwork/xaynet/branch/master/graph/badge.svg)](https://codecov.io/gh/xaynetwork/xaynet)
+[![crates.io badge](https://img.shields.io/crates/v/xaynet.svg)](https://crates.io/crates/xaynet) [![docs.rs badge](https://docs.rs/xaynet/badge.svg)](https://docs.rs/xaynet) [![rustc badge](https://img.shields.io/badge/rustc-1.46+-lightgray.svg)](https://www.rust-lang.org/learn/get-started) [![Coverage Status](https://codecov.io/gh/xaynetwork/xaynet/branch/master/graph/badge.svg)](https://codecov.io/gh/xaynetwork/xaynet)
 
 ![Xaynet banner](./assets/xaynet_banner.png)
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ that meets these requirements:
 
 # Getting Started
 
+## Minimum supported rust version
+
+rustc 1.46.0
+
 ## Running the platform
 
 There are a few different ways to run the backend: via docker, or by deploying it to

--- a/README.tpl
+++ b/README.tpl
@@ -1,4 +1,4 @@
-[![crates.io badge](https://img.shields.io/crates/v/xaynet.svg)](https://crates.io/crates/xaynet) [![docs.rs badge](https://docs.rs/xaynet/badge.svg)](https://docs.rs/xaynet) {{badges}}
+[![crates.io badge](https://img.shields.io/crates/v/xaynet.svg)](https://crates.io/crates/xaynet) [![docs.rs badge](https://docs.rs/xaynet/badge.svg)](https://docs.rs/xaynet)  [![rustc badge](https://img.shields.io/badge/rustc-1.46+-lightgray.svg)](https://www.rust-lang.org/learn/get-started) {{badges}}
 
 ![Xaynet banner](./assets/xaynet_banner.png)
 

--- a/README.tpl
+++ b/README.tpl
@@ -10,6 +10,10 @@
 
 # Getting Started
 
+## Minimum supported rust version
+
+rustc 1.46.0
+
 ## Running the platform
 
 There are a few different ways to run the backend: via docker, or by deploying it to

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,3 +11,7 @@ members = [
     "benches",
     "examples",
 ]
+
+[workspace.metadata]
+# minimum supported rust version
+msrv = "1.46.0"

--- a/rust/benches/Cargo.toml
+++ b/rust/benches/Cargo.toml
@@ -12,6 +12,10 @@ keywords = ["federated-learning", "fl", "ai", "machine-learning"]
 categories = ["science", "cryptography"]
 publish = false
 
+[package.metadata]
+# minimum supported rust version
+msrv = "1.46.0"
+
 [dev-dependencies]
 criterion = "0.3.3"
 xaynet-core = { path = "../xaynet-core", features = ["testutils"] }

--- a/rust/examples/Cargo.toml
+++ b/rust/examples/Cargo.toml
@@ -12,6 +12,10 @@ license-file = "../../LICENSE"
 keywords = ["federated-learning", "fl", "ai", "machine-learning"]
 categories = ["science", "cryptography"]
 
+[package.metadata]
+# minimum supported rust version
+msrv = "1.46.0"
+
 [dev-dependencies]
 sodiumoxide = "0.2.6"
 structopt = "0.3.17"

--- a/rust/xaynet-client/Cargo.toml
+++ b/rust/xaynet-client/Cargo.toml
@@ -11,6 +11,10 @@ license-file = "../../LICENSE"
 keywords = ["federated-learning", "fl", "ai", "machine-learning"]
 categories = ["science", "cryptography"]
 
+[package.metadata]
+# minimum supported rust version
+msrv = "1.46.0"
+
 [dependencies]
 async-trait = "0.1.40"
 bincode = "1.3.1"

--- a/rust/xaynet-core/Cargo.toml
+++ b/rust/xaynet-core/Cargo.toml
@@ -11,6 +11,10 @@ license-file = "../../LICENSE"
 keywords = ["federated-learning", "fl", "ai", "machine-learning"]
 categories = ["science", "cryptography"]
 
+[package.metadata]
+# minimum supported rust version
+msrv = "1.46.0"
+
 [dependencies]
 anyhow = "1.0.32"
 bitflags = "1.2.1"

--- a/rust/xaynet-ffi/Cargo.toml
+++ b/rust/xaynet-ffi/Cargo.toml
@@ -11,6 +11,10 @@ license-file = "../../LICENSE"
 keywords = ["federated-learning", "fl", "ai", "machine-learning"]
 categories = ["science", "cryptography"]
 
+[package.metadata]
+# minimum supported rust version
+msrv = "1.46.0"
+
 [dependencies]
 ffi-support = "0.4.2"
 xaynet-client = { path = "../xaynet-client", default-features = false, version = "0.1.0" }

--- a/rust/xaynet-macros/Cargo.toml
+++ b/rust/xaynet-macros/Cargo.toml
@@ -11,6 +11,10 @@ license-file = "../../LICENSE"
 keywords = ["federated-learning", "fl", "ai", "machine-learning"]
 categories = ["science", "cryptography"]
 
+[package.metadata]
+# minimum supported rust version
+msrv = "1.46.0"
+
 [dependencies]
 quote = "1.0.7"
 syn = "1.0.41"

--- a/rust/xaynet-server/Cargo.toml
+++ b/rust/xaynet-server/Cargo.toml
@@ -11,6 +11,10 @@ license-file = "../../LICENSE"
 keywords = ["federated-learning", "fl", "ai", "machine-learning"]
 categories = ["science", "cryptography"]
 
+[package.metadata]
+# minimum supported rust version
+msrv = "1.46.0"
+
 [dependencies]
 anyhow = "1.0.32"
 async-trait = "0.1.40"

--- a/rust/xaynet/Cargo.toml
+++ b/rust/xaynet/Cargo.toml
@@ -17,6 +17,7 @@ msrv = "1.46.0"
 
 [badges]
 codecov = { repository = "xaynetwork/xaynet", branch = "master", service = "github" }
+maintenance = { status = "actively-developed" }
 
 [dependencies]
 xaynet-core = { path = "../xaynet-core", version = "0.1.0" }

--- a/rust/xaynet/Cargo.toml
+++ b/rust/xaynet/Cargo.toml
@@ -11,6 +11,10 @@ license-file = "../../LICENSE"
 keywords = ["federated-learning", "fl", "ai", "machine-learning"]
 categories = ["science", "cryptography"]
 
+[package.metadata]
+# minimum supported rust version
+msrv = "1.46.0"
+
 [badges]
 codecov = { repository = "xaynetwork/xaynet", branch = "master", service = "github" }
 


### PR DESCRIPTION
**References**
- [XN-1263](https://xainag.atlassian.net/browse/XN-1263)

**Summary**
The rfc on a minimal supported rust version is far from being stablilized, see the [tracking issue](https://github.com/rust-lang/rust/issues/65262). Therefore we at least include this as metadata information and in the readme.
