### PR TITLE
masking configuration pair

### DIFF
--- a/rust/xaynet-client/src/mobile_client/participant/sum2.rs
+++ b/rust/xaynet-client/src/mobile_client/participant/sum2.rs
@@ -84,7 +84,7 @@ impl Participant<Sum2> {
         let config = self.state.aggregation_config.mask;
         let mut mask_agg = Aggregation::new(config.into(), mask_len);
         for seed in mask_seeds.into_iter() {
-            let mask = seed.derive_mask(mask_len, config, config);
+            let mask = seed.derive_mask(mask_len, config.into());
             mask_agg
                 .validate_aggregation(&mask)
                 .map_err(|_| PetError::InvalidMask)?;

--- a/rust/xaynet-client/src/mobile_client/participant/sum2.rs
+++ b/rust/xaynet-client/src/mobile_client/participant/sum2.rs
@@ -81,9 +81,8 @@ impl Participant<Sum2> {
             return Err(PetError::InvalidMask);
         }
 
-        // HACK reuse config for both
         let config = self.state.aggregation_config.mask;
-        let mut mask_agg = Aggregation::new(config, config, mask_len);
+        let mut mask_agg = Aggregation::new(config.into(), mask_len);
         for seed in mask_seeds.into_iter() {
             let mask = seed.derive_mask(mask_len, config, config);
             mask_agg

--- a/rust/xaynet-client/src/mobile_client/participant/update.rs
+++ b/rust/xaynet-client/src/mobile_client/participant/update.rs
@@ -43,11 +43,8 @@ impl Participant<Update> {
 
     /// Generate a mask seed and mask a local model.
     fn mask_model(&self, local_model: Model) -> (MaskSeed, MaskObject) {
-        Masker::new(
-            self.state.aggregation_config.mask,
-            self.state.aggregation_config.mask, // HACK reuse model mask config
-        )
-        .mask(self.state.aggregation_config.scalar, local_model)
+        Masker::new(self.state.aggregation_config.mask.into())
+            .mask(self.state.aggregation_config.scalar, local_model)
     }
 
     // Create a local seed dictionary from a sum dictionary.

--- a/rust/xaynet-client/src/participant.rs
+++ b/rust/xaynet-client/src/participant.rs
@@ -218,14 +218,12 @@ impl Participant {
         mask_seeds: Vec<MaskSeed>,
         mask_len: usize,
         mask_config: MaskConfig,
-        // FIXME also need scalar mask config somehow
     ) -> Result<MaskObject, PetError> {
         if mask_seeds.is_empty() {
             return Err(PetError::InvalidMask);
         }
 
-        // HACK reuse model mask config for now
-        let mut mask_agg = Aggregation::new(mask_config, mask_config, mask_len);
+        let mut mask_agg = Aggregation::new(mask_config.into(), mask_len);
         for seed in mask_seeds.into_iter() {
             let mask = seed.derive_mask(mask_len, mask_config, mask_config);
 

--- a/rust/xaynet-client/src/participant.rs
+++ b/rust/xaynet-client/src/participant.rs
@@ -225,7 +225,7 @@ impl Participant {
 
         let mut mask_agg = Aggregation::new(mask_config.into(), mask_len);
         for seed in mask_seeds.into_iter() {
-            let mask = seed.derive_mask(mask_len, mask_config, mask_config);
+            let mask = seed.derive_mask(mask_len, mask_config.into());
 
             mask_agg
                 .validate_aggregation(&mask)

--- a/rust/xaynet-client/src/participant.rs
+++ b/rust/xaynet-client/src/participant.rs
@@ -190,7 +190,7 @@ impl Participant {
     fn mask_model(scalar: f64, local_model: Model) -> (MaskSeed, MaskObject) {
         // TODO: use proper config
         let config = dummy_config();
-        Masker::new(config, config).mask(scalar, local_model) // HACK reuse model mask config
+        Masker::new(config.into()).mask(scalar, local_model)
     }
 
     // Create a local seed dictionary from a sum dictionary.

--- a/rust/xaynet-core/src/mask/config/mod.rs
+++ b/rust/xaynet-core/src/mask/config/mod.rs
@@ -632,3 +632,22 @@ impl MaskConfig {
         BigUint::from_str_radix(order_str, 10).unwrap()
     }
 }
+
+/// Convenience struct for a pair of masking configurations.
+///
+/// One configuration is intended for (un)masking a vector of values, the other
+/// for a unit value.
+pub struct MaskConfigPair {
+    pub vect: MaskConfig,
+    pub unit: MaskConfig,
+}
+
+impl MaskConfigPair {
+    /// Creates two copies of the given masking configuration as a pair.
+    pub fn new_shared(config: MaskConfig) -> Self {
+        Self {
+            vect: config,
+            unit: config,
+        }
+    }
+}

--- a/rust/xaynet-core/src/mask/config/mod.rs
+++ b/rust/xaynet-core/src/mask/config/mod.rs
@@ -633,6 +633,7 @@ impl MaskConfig {
     }
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 /// Convenience struct for a pair of masking configurations.
 ///
 /// One configuration is intended for (un)masking a vector of values, the other
@@ -642,9 +643,9 @@ pub struct MaskConfigPair {
     pub unit: MaskConfig,
 }
 
-impl MaskConfigPair {
+impl From<MaskConfig> for MaskConfigPair {
     /// Creates two copies of the given masking configuration as a pair.
-    pub fn new_shared(config: MaskConfig) -> Self {
+    fn from(config: MaskConfig) -> Self {
         Self {
             vect: config,
             unit: config,

--- a/rust/xaynet-core/src/mask/masking.rs
+++ b/rust/xaynet-core/src/mask/masking.rs
@@ -500,7 +500,7 @@ mod tests {
                     assert_eq!(masked_model.vect.data.len(), model.len());
                     assert!(masked_model.is_valid());
 
-                    let mask = mask_seed.derive_mask(model.len(), config.clone(), config.clone());
+                    let mask = mask_seed.derive_mask(model.len(), config.into());
                     let aggregation = Aggregation::from(masked_model);
                     let unmasked_model = aggregation.unmask(mask);
 
@@ -800,7 +800,7 @@ mod tests {
 
                         let (mask_seed, masked_model) =
                             Masker::new(config, config).mask(scalar, model);
-                        let mask = mask_seed.derive_mask($len as usize, config, config);
+                        let mask = mask_seed.derive_mask($len as usize, config.into());
 
                         assert!(
                             aggregated_masked_model.validate_aggregation(&masked_model).is_ok()

--- a/rust/xaynet-core/src/mask/masking.rs
+++ b/rust/xaynet-core/src/mask/masking.rs
@@ -94,12 +94,11 @@ impl Into<MaskObject> for Aggregation {
 
 #[allow(clippy::len_without_is_empty)]
 impl Aggregation {
-    // TODO refactor
     /// Creates a new, empty aggregator for masks or masked models.
-    pub fn new(config_many: MaskConfig, config_one: MaskConfig, object_size: usize) -> Self {
+    pub fn new(config: MaskConfigPair, object_size: usize) -> Self {
         Self {
             nb_models: 0,
-            object: MaskObject::empty(config_many, config_one, object_size),
+            object: MaskObject::empty(config.vect, config.unit, object_size),
             object_size,
         }
     }
@@ -107,18 +106,6 @@ impl Aggregation {
     /// Gets the length of the aggregated mask object.
     pub fn len(&self) -> usize {
         self.object_size
-    }
-
-    // TODO remove
-    /// Gets the masking configuration of the vector aggregator.
-    pub fn config_many(&self) -> MaskConfig {
-        self.object.vect.config
-    }
-
-    // TODO remove
-    /// Gets the masking configuration of the scalar aggregator.
-    pub fn config_one(&self) -> MaskConfig {
-        self.object.unit.config
     }
 
     /// Gets the masking configurations of the aggregator.
@@ -646,7 +633,7 @@ mod tests {
                     // Step 3 (actual test):
                     // a. aggregate the masked models
                     // b. check the aggregated masked model
-                    let mut aggregated_masked_model = Aggregation::new(config, config, model_size);
+                    let mut aggregated_masked_model = Aggregation::new(config.into(), model_size);
                     for nb in 1..$count as usize + 1 {
                         let masked_model = masked_models.next().unwrap();
                         assert!(
@@ -798,8 +785,8 @@ mod tests {
                         iter::repeat(paste::expr! { 0 as [<$data:lower>] }).take($len as usize)
                     )
                     .unwrap();
-                    let mut aggregated_masked_model = Aggregation::new(config, config, model_size);
-                    let mut aggregated_mask = Aggregation::new(config, config, model_size);
+                    let mut aggregated_masked_model = Aggregation::new(config.into(), model_size);
+                    let mut aggregated_mask = Aggregation::new(config.into(), model_size);
                     let scalar = 1_f64 / ($count as f64);
                     let scalar_ratio = Ratio::from_float(scalar).unwrap();
                     for _ in 0..$count as usize {

--- a/rust/xaynet-core/src/mask/masking.rs
+++ b/rust/xaynet-core/src/mask/masking.rs
@@ -356,7 +356,10 @@ impl Masker {
     pub fn mask(self, scalar: f64, model: Model) -> (MaskSeed, MaskObject) {
         let (random_int, mut random_ints) = self.random_ints();
         let Self { config, seed } = self;
-        let (config_n, config_1) = (config.vect, config.unit);
+        let MaskConfigPair {
+            vect: config_n,
+            unit: config_1,
+        } = config;
 
         // clamp the scalar
         let add_shift_1 = config_1.add_shift();

--- a/rust/xaynet-core/src/mask/masking.rs
+++ b/rust/xaynet-core/src/mask/masking.rs
@@ -98,7 +98,7 @@ impl Aggregation {
     pub fn new(config: MaskConfigPair, object_size: usize) -> Self {
         Self {
             nb_models: 0,
-            object: MaskObject::empty(config.vect, config.unit, object_size),
+            object: MaskObject::empty(config, object_size),
             object_size,
         }
     }

--- a/rust/xaynet-core/src/mask/masking.rs
+++ b/rust/xaynet-core/src/mask/masking.rs
@@ -187,8 +187,9 @@ impl Aggregation {
     /// [`validate_unmasking()`]: #method.validate_unmasking
     /// [`mask()`]: struct.Masker.html#method.mask
     pub fn unmask(self, mask_obj: MaskObject) -> Model {
-        let (masked_n, config_n) = (self.object.vect.data, self.object.vect.config);
-        let (masked_1, config_1) = (self.object.unit.data, self.object.unit.config);
+        let MaskObject { vect, unit } = self.object;
+        let (masked_n, config_n) = (vect.data, vect.config);
+        let (masked_1, config_1) = (unit.data, unit.config);
         let mask_n = mask_obj.vect.data;
         let mask_1 = mask_obj.unit.data;
 

--- a/rust/xaynet-core/src/mask/masking.rs
+++ b/rust/xaynet-core/src/mask/masking.rs
@@ -19,7 +19,7 @@ use thiserror::Error;
 use crate::{
     crypto::{prng::generate_integer, ByteObject},
     mask::{
-        config::MaskConfig,
+        config::{MaskConfig, MaskConfigPair},
         model::{float_to_ratio_bounded, Model},
         object::{MaskObject, MaskUnit, MaskVect},
         seed::MaskSeed,
@@ -94,6 +94,7 @@ impl Into<MaskObject> for Aggregation {
 
 #[allow(clippy::len_without_is_empty)]
 impl Aggregation {
+    // TODO refactor
     /// Creates a new, empty aggregator for masks or masked models.
     pub fn new(config_many: MaskConfig, config_one: MaskConfig, object_size: usize) -> Self {
         Self {
@@ -108,14 +109,24 @@ impl Aggregation {
         self.object_size
     }
 
+    // TODO remove
     /// Gets the masking configuration of the vector aggregator.
     pub fn config_many(&self) -> MaskConfig {
         self.object.vect.config
     }
 
+    // TODO remove
     /// Gets the masking configuration of the scalar aggregator.
     pub fn config_one(&self) -> MaskConfig {
         self.object.unit.config
+    }
+
+    /// Gets the masking configurations of the aggregator.
+    pub fn config(&self) -> MaskConfigPair {
+        MaskConfigPair {
+            vect: self.object.vect.config,
+            unit: self.object.unit.config,
+        }
     }
 
     /// Validates if unmasking of the aggregated masked model with the given `mask` may be
@@ -318,6 +329,7 @@ impl Aggregation {
 
 /// A masker for models.
 pub struct Masker {
+    // TODO refactor
     config_model: MaskConfig,
     config_scalar: MaskConfig,
     seed: MaskSeed,

--- a/rust/xaynet-core/src/mask/mod.rs
+++ b/rust/xaynet-core/src/mask/mod.rs
@@ -103,12 +103,12 @@
 //! };
 //!
 //! // mask the local models
-//! let (local_mask_seed_1, masked_local_model_1) = Masker::new(config, config).mask(scalar, local_model_1);
-//! let (local_mask_seed_2, masked_local_model_2) = Masker::new(config, config).mask(scalar, local_model_2);
+//! let (local_mask_seed_1, masked_local_model_1) = Masker::new(config.into()).mask(scalar, local_model_1);
+//! let (local_mask_seed_2, masked_local_model_2) = Masker::new(config.into()).mask(scalar, local_model_2);
 //!
 //! // derive the masks of the local masked models
-//! let local_mask_1 = local_mask_seed_1.derive_mask(number_weights, config, config);
-//! let local_mask_2 = local_mask_seed_2.derive_mask(number_weights, config, config);
+//! let local_mask_1 = local_mask_seed_1.derive_mask(number_weights, config.into());
+//! let local_mask_2 = local_mask_seed_2.derive_mask(number_weights, config.into());
 //! ```
 //!
 //! ## Aggregation
@@ -124,12 +124,12 @@
 //! # let local_model_1 = Model::from_primitives_bounded(vec![0_f32; number_weights].into_iter());
 //! # let local_model_2 = Model::from_primitives_bounded(vec![1_f32; number_weights].into_iter());
 //! # let config = MaskConfig { group_type: GroupType::Prime, data_type: DataType::F32, bound_type: BoundType::B0, model_type: ModelType::M3};
-//! # let (local_mask_seed_1, masked_local_model_1) = Masker::new(config, config).mask(scalar, local_model_1);
-//! # let (local_mask_seed_2, masked_local_model_2) = Masker::new(config, config).mask(scalar, local_model_2);
-//! # let local_model_mask_1 = local_mask_seed_1.derive_mask(number_weights, config, config);
-//! # let local_model_mask_2 = local_mask_seed_2.derive_mask(number_weights, config, config);
+//! # let (local_mask_seed_1, masked_local_model_1) = Masker::new(config.into()).mask(scalar, local_model_1);
+//! # let (local_mask_seed_2, masked_local_model_2) = Masker::new(config.into()).mask(scalar, local_model_2);
+//! # let local_model_mask_1 = local_mask_seed_1.derive_mask(number_weights, config.into());
+//! # let local_model_mask_2 = local_mask_seed_2.derive_mask(number_weights, config.into());
 //! // aggregate the local model masks (similarly for local scalar masks)
-//! let mut mask_aggregator = Aggregation::new(config, config, number_weights);
+//! let mut mask_aggregator = Aggregation::new(config.into(), number_weights);
 //! if let Ok(_) = mask_aggregator.validate_aggregation(&local_model_mask_1) {
 //!     mask_aggregator.aggregate(local_model_mask_1);
 //! };
@@ -139,7 +139,7 @@
 //! let global_mask: MaskObject = mask_aggregator.into();
 //!
 //! // aggregate the local masked models
-//! let mut model_aggregator = Aggregation::new(config, config, number_weights);
+//! let mut model_aggregator = Aggregation::new(config.into(), number_weights);
 //! if let Ok(_) = model_aggregator.validate_aggregation(&masked_local_model_1) {
 //!     model_aggregator.aggregate(masked_local_model_1);
 //! };
@@ -160,15 +160,15 @@
 //! # let local_model_1 = Model::from_primitives_bounded(vec![0_f32; number_weights].into_iter());
 //! # let local_model_2 = Model::from_primitives_bounded(vec![1_f32; number_weights].into_iter());
 //! # let config = MaskConfig { group_type: GroupType::Prime, data_type: DataType::F32, bound_type: BoundType::B0, model_type: ModelType::M3};
-//! # let (local_mask_seed_1, masked_local_model_1) = Masker::new(config, config).mask(scalar, local_model_1);
-//! # let (local_mask_seed_2, masked_local_model_2) = Masker::new(config, config).mask(scalar, local_model_2);
-//! # let local_model_mask_1 = local_mask_seed_1.derive_mask(number_weights, config, config);
-//! # let local_model_mask_2 = local_mask_seed_2.derive_mask(number_weights, config, config);
-//! # let mut mask_aggregator = Aggregation::new(config, config, number_weights);
+//! # let (local_mask_seed_1, masked_local_model_1) = Masker::new(config.into()).mask(scalar, local_model_1);
+//! # let (local_mask_seed_2, masked_local_model_2) = Masker::new(config.into()).mask(scalar, local_model_2);
+//! # let local_model_mask_1 = local_mask_seed_1.derive_mask(number_weights, config.into());
+//! # let local_model_mask_2 = local_mask_seed_2.derive_mask(number_weights, config.into());
+//! # let mut mask_aggregator = Aggregation::new(config.into(), number_weights);
 //! # if let Ok(_) = mask_aggregator.validate_aggregation(&local_model_mask_1) { mask_aggregator.aggregate(local_model_mask_1); };
 //! # if let Ok(_) = mask_aggregator.validate_aggregation(&local_model_mask_2) { mask_aggregator.aggregate(local_model_mask_2); };
 //! # let global_mask: MaskObject = mask_aggregator.into();
-//! # let mut model_aggregator = Aggregation::new(config, config, number_weights);
+//! # let mut model_aggregator = Aggregation::new(config.into(), number_weights);
 //! # if let Ok(_) = model_aggregator.validate_aggregation(&masked_local_model_1) { model_aggregator.aggregate(masked_local_model_1); };
 //! # if let Ok(_) = model_aggregator.validate_aggregation(&masked_local_model_2) { model_aggregator.aggregate(masked_local_model_2); };
 //! // unmask the aggregated masked model with the aggregated mask

--- a/rust/xaynet-core/src/mask/mod.rs
+++ b/rust/xaynet-core/src/mask/mod.rs
@@ -195,6 +195,7 @@ pub use self::{
         GroupType,
         InvalidMaskConfigError,
         MaskConfig,
+        MaskConfigPair,
         ModelType,
     },
     masking::{Aggregation, AggregationError, Masker, UnmaskingError},

--- a/rust/xaynet-core/src/mask/object/mod.rs
+++ b/rust/xaynet-core/src/mask/object/mod.rs
@@ -124,6 +124,7 @@ impl MaskObject {
         Self { vect, unit }
     }
 
+    // TODO refactor
     /// Creates a new mask object from the given vector, unit and masking configurations.
     pub fn new(
         config_v: MaskConfig,
@@ -136,6 +137,7 @@ impl MaskObject {
         Ok(Self { vect, unit })
     }
 
+    // TODO refactor
     /// Creates a new empty mask object of given size and masking configurations.
     pub fn empty(config_many: MaskConfig, config_one: MaskConfig, size: usize) -> Self {
         Self {

--- a/rust/xaynet-core/src/mask/object/mod.rs
+++ b/rust/xaynet-core/src/mask/object/mod.rs
@@ -11,7 +11,7 @@ use std::iter::Iterator;
 use num::bigint::BigUint;
 use thiserror::Error;
 
-use crate::mask::config::MaskConfig;
+use crate::mask::config::{MaskConfig, MaskConfigPair};
 
 #[derive(Error, Debug)]
 #[error("the mask object is invalid: data is incompatible with the masking configuration")]
@@ -124,25 +124,22 @@ impl MaskObject {
         Self { vect, unit }
     }
 
-    // TODO refactor
     /// Creates a new mask object from the given vector, unit and masking configurations.
     pub fn new(
-        config_v: MaskConfig,
-        data_v: Vec<BigUint>,
-        config_s: MaskConfig,
-        data_s: BigUint,
+        config: MaskConfigPair,
+        data_vect: Vec<BigUint>,
+        data_unit: BigUint,
     ) -> Result<Self, InvalidMaskObjectError> {
-        let vect = MaskVect::new(config_v, data_v)?;
-        let unit = MaskUnit::new(config_s, data_s)?;
+        let vect = MaskVect::new(config.vect, data_vect)?;
+        let unit = MaskUnit::new(config.unit, data_unit)?;
         Ok(Self { vect, unit })
     }
 
-    // TODO refactor
     /// Creates a new empty mask object of given size and masking configurations.
-    pub fn empty(config_many: MaskConfig, config_one: MaskConfig, size: usize) -> Self {
+    pub fn empty(config: MaskConfigPair, size: usize) -> Self {
         Self {
-            vect: MaskVect::empty(config_many, size),
-            unit: MaskUnit::default(config_one),
+            vect: MaskVect::empty(config.vect, size),
+            unit: MaskUnit::default(config.unit),
         }
     }
 

--- a/rust/xaynet-core/src/mask/seed.rs
+++ b/rust/xaynet-core/src/mask/seed.rs
@@ -60,6 +60,7 @@ impl MaskSeed {
     pub fn derive_mask(
         &self,
         len: usize,
+        // TODO refactor
         config_many: MaskConfig,
         config_one: MaskConfig,
     ) -> MaskObject {

--- a/rust/xaynet-core/src/mask/seed.rs
+++ b/rust/xaynet-core/src/mask/seed.rs
@@ -58,15 +58,20 @@ impl MaskSeed {
 
     /// Derives a mask of given length from this seed wrt the masking configurations.
     pub fn derive_mask(&self, len: usize, config: MaskConfigPair) -> MaskObject {
+        let MaskConfigPair {
+            vect: config_n,
+            unit: config_1,
+        } = config;
         let mut prng = ChaCha20Rng::from_seed(self.as_array());
 
-        let rand_int = generate_integer(&mut prng, &config.unit.order());
-        let scalar_mask = MaskUnit::new_unchecked(config.unit, rand_int);
+        let rand_int = generate_integer(&mut prng, &config_1.order());
+        let scalar_mask = MaskUnit::new_unchecked(config_1, rand_int);
 
-        let rand_ints = iter::repeat_with(|| generate_integer(&mut prng, &config.vect.order()))
+        let order_n = config_n.order();
+        let rand_ints = iter::repeat_with(|| generate_integer(&mut prng, &order_n))
             .take(len)
             .collect();
-        let model_mask = MaskVect::new_unchecked(config.vect, rand_ints);
+        let model_mask = MaskVect::new_unchecked(config_n, rand_ints);
 
         MaskObject::new_unchecked(model_mask, scalar_mask)
     }

--- a/rust/xaynet-server/src/state_machine/phases/sum2.rs
+++ b/rust/xaynet-server/src/state_machine/phases/sum2.rs
@@ -152,7 +152,7 @@ mod test {
     use xaynet_core::{
         common::RoundSeed,
         crypto::{ByteObject, EncryptKeyPair},
-        mask::{FromPrimitives, Model},
+        mask::{FromPrimitives, MaskConfig, Model},
         SumDict,
     };
 
@@ -181,11 +181,8 @@ mod test {
             updater.compose_update_message(coord_keys.public, &sum_dict, scalar, model.clone());
         let masked_model = utils::masked_model(&msg);
         let local_seed_dict = utils::local_seed_dict(&msg);
-        let mut aggregation = Aggregation::new(
-            utils::mask_settings().into(),
-            utils::mask_settings().into(),
-            model_size,
-        );
+        let config: MaskConfig = utils::mask_settings().into(); // help out the typechecker
+        let mut aggregation = Aggregation::new(config.into(), model_size);
         aggregation.aggregate(masked_model.clone());
 
         // Create the state machine

--- a/rust/xaynet-server/src/state_machine/phases/sum2.rs
+++ b/rust/xaynet-server/src/state_machine/phases/sum2.rs
@@ -181,7 +181,7 @@ mod test {
             updater.compose_update_message(coord_keys.public, &sum_dict, scalar, model.clone());
         let masked_model = utils::masked_model(&msg);
         let local_seed_dict = utils::local_seed_dict(&msg);
-        let config: MaskConfig = utils::mask_settings().into(); // help out the typechecker
+        let config: MaskConfig = utils::mask_settings().into();
         let mut aggregation = Aggregation::new(config.into(), model_size);
         aggregation.aggregate(masked_model.clone());
 

--- a/rust/xaynet-server/src/state_machine/phases/update.rs
+++ b/rust/xaynet-server/src/state_machine/phases/update.rs
@@ -256,7 +256,7 @@ mod test {
         let mut frozen_sum_dict = SumDict::new();
         frozen_sum_dict.insert(summer.pk, summer_ephm_pk);
 
-        let config: MaskConfig = utils::mask_settings().into(); // help out the typechecker
+        let config: MaskConfig = utils::mask_settings().into();
         let aggregation = Aggregation::new(config.into(), model_size);
         let update = Update {
             update_count: 0,

--- a/rust/xaynet-server/src/state_machine/phases/update.rs
+++ b/rust/xaynet-server/src/state_machine/phases/update.rs
@@ -132,10 +132,8 @@ impl PhaseState<Update> {
         Self {
             inner: Update {
                 update_count: 0,
-                // HACK reuse mask config
                 model_agg: Aggregation::new(
-                    shared.state.mask_config,
-                    shared.state.mask_config,
+                    shared.state.mask_config.into(),
                     shared.state.model_size,
                 ),
             },
@@ -228,7 +226,7 @@ mod test {
     use xaynet_core::{
         common::RoundSeed,
         crypto::{ByteObject, EncryptKeyPair},
-        mask::{FromPrimitives, Model},
+        mask::{FromPrimitives, MaskConfig, Model},
         SeedDict,
         SumDict,
         UpdateSeedDict,
@@ -258,11 +256,8 @@ mod test {
         let mut frozen_sum_dict = SumDict::new();
         frozen_sum_dict.insert(summer.pk, summer_ephm_pk);
 
-        let aggregation = Aggregation::new(
-            utils::mask_settings().into(),
-            utils::mask_settings().into(),
-            model_size,
-        );
+        let config: MaskConfig = utils::mask_settings().into(); // help out the typechecker
+        let aggregation = Aggregation::new(config.into(), model_size);
         let update = Update {
             update_count: 0,
             model_agg: aggregation.clone(),

--- a/rust/xaynet-server/src/storage/tests/mod.rs
+++ b/rust/xaynet-server/src/storage/tests/mod.rs
@@ -50,9 +50,8 @@ pub fn create_mask_zeroed(byte_size: usize) -> MaskObject {
     };
 
     MaskObject::new(
-        config,
+        config.into(),
         vec![BigUint::zero(); byte_size],
-        config,
         BigUint::zero(),
     )
     .unwrap()
@@ -67,9 +66,8 @@ pub fn create_mask(byte_size: usize, number: u32) -> MaskObject {
     };
 
     MaskObject::new(
-        config,
+        config.into(),
         vec![BigUint::from(number); byte_size],
-        config,
         BigUint::zero(),
     )
     .unwrap()


### PR DESCRIPTION
Implements an overdue suggestion https://github.com/xaynetwork/xaynet/pull/524#discussion_r490779866 to introduce a struct collecting both a vector `MaskConfig` and a unit `MaskConfig` together:
```rust
pub struct MaskConfigPair {
    pub vect: MaskConfig,
    pub unit: MaskConfig,
}
```
This helps to tidy the API in several places, namely
- `Masker`
- `Aggregation`
- `MaskSeed`
- `MaskObject`

all of which currently take two `MaskConfig`s as parameters in their methods. In addition, as most of the code currently uses the same config for both anyway, a `From` impl helps to further reduce code duplication.
 