### PR TITLE
fix dropping message in select branch

### DIFF
--- a/rust/xaynet-server/src/state_machine/phases/sum.rs
+++ b/rust/xaynet-server/src/state_machine/phases/sum.rs
@@ -97,7 +97,7 @@ where
                 "{} sum messages handled (min {} required)",
                 self.inner.sum_count, self.shared.state.min_sum_count,
             );
-            self.process_single().await?;
+            self.process_next().await?;
         }
         Ok(())
     }

--- a/rust/xaynet-server/src/state_machine/phases/sum2.rs
+++ b/rust/xaynet-server/src/state_machine/phases/sum2.rs
@@ -73,7 +73,7 @@ where
                 "{} sum2 messages handled (min {} required)",
                 self.inner.sum2_count, self.shared.state.min_sum_count
             );
-            self.process_single().await?;
+            self.process_next().await?;
         }
         Ok(())
     }

--- a/rust/xaynet-server/src/state_machine/phases/update.rs
+++ b/rust/xaynet-server/src/state_machine/phases/update.rs
@@ -99,7 +99,7 @@ where
                 "{} update messages handled (min {} required)",
                 self.inner.update_count, self.shared.state.min_update_count
             );
-            self.process_single().await?;
+            self.process_next().await?;
         }
         Ok(())
     }

--- a/rust/xaynet-server/src/state_machine/requests.rs
+++ b/rust/xaynet-server/src/state_machine/requests.rs
@@ -119,9 +119,7 @@ impl RequestSender {
             )
         })?;
         resp_rx.await.map_err(|_| {
-            RequestError::InternalError(
-                "failed to receive response from the state machine: state machine is shutting down",
-            )
+            RequestError::InternalError("failed to receive response from the state machine")
         })?
     }
 }


### PR DESCRIPTION
Addresses an issue where a message may be dropped after the delay has elapsed.

Found the solution in the [tokio::select! documentation](https://docs.rs/tokio/0.2.22/tokio/macro.select.html#avoid-racy-if-preconditions). 

We should check later if we have the same error in phase timeout.