### PR TITLE
XN-1209 Add action docker/setup-buildx-action@v1 to fix: buildx call

### DIFF
--- a/.github/workflows/dockerhub-pr-with-parameters.yml
+++ b/.github/workflows/dockerhub-pr-with-parameters.yml
@@ -36,9 +36,6 @@ jobs:
         with:
           ref: ${{ steps.comment-branch.outputs.head_ref }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
       - name: Find and Replace
         uses: jacobtomlinson/gha-find-replace@master
         with:
@@ -52,6 +49,9 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
 
       - name: build-tag-push
         uses: docker/build-push-action@v2

--- a/.github/workflows/dockerhub-pr-with-parameters.yml
+++ b/.github/workflows/dockerhub-pr-with-parameters.yml
@@ -36,6 +36,9 @@ jobs:
         with:
           ref: ${{ steps.comment-branch.outputs.head_ref }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Find and Replace
         uses: jacobtomlinson/gha-find-replace@master
         with:


### PR DESCRIPTION
Add action: `docker/setup-buildx-action@v1` 
 
To fix: 
```
auto-push is currently not implemented for docker driver
Error: buildx call failed with: auto-push is currently not implemented for docker driver
```