### PR TITLE
XN-1209 Add context parameter into docker/build-push-action to fix bu…

### DIFF
--- a/.github/workflows/dockerhub-pr-with-parameters.yml
+++ b/.github/workflows/dockerhub-pr-with-parameters.yml
@@ -57,6 +57,7 @@ jobs:
         uses: docker/build-push-action@v2
         id: docker
         with:
+          context: .
           file: docker/Dockerfile
           tags: xaynetwork/xaynet:${{ steps.comment-branch.outputs.head_ref }}
           push: true


### PR DESCRIPTION
Added  the parameter `context: .` 

The build was occurring on the master branch instead of the changes in the PR.
