### PR TITLE
randomized scalar tests

### DIFF
--- a/rust/xaynet-core/src/mask/masking.rs
+++ b/rust/xaynet-core/src/mask/masking.rs
@@ -588,6 +588,20 @@ mod tests {
     test_masking!(pow_i64_b6, Power2, i64, 1_000_000, 10);
     test_masking!(pow_i64_bmax, Power2, i64, 10);
 
+    /// Generate tests for masking and unmasking of a single model:
+    /// - generate random scalar from a uniform distribution with a seeded PRNG
+    /// - scale a model of unit weights and mask it
+    /// - check that all masked weights belong to the chosen finite group
+    /// - unmask the masked model
+    /// - check that all unmasked weights are equal to the original weights (up to a tolerance
+    ///   determined by the masking configuration)
+    ///
+    /// The arguments to the macro are:
+    /// - a suffix for the test name
+    /// - the group type of the model (variants of `GroupType`)
+    /// - the data type of the model (either primitives or variants of `DataType`)
+    /// - an absolute bound for the weights (optional, choices: 1, 100, 10_000, 1_000_000)
+    /// - the number of weights
     macro_rules! test_masking_scalar {
         ($suffix:ident, $group:ty, $data:ty, $bound:expr, $len:expr $(,)?) => {
             paste::item! {
@@ -1036,6 +1050,21 @@ mod tests {
     test_masking_and_aggregation!(pow_i64_b6, Power2, i64, 1_000_000, 10, 5);
     test_masking_and_aggregation!(pow_i64_bmax, Power2, i64, 10, 5);
 
+    /// Generate tests for masking, aggregation and unmasking of multiple models:
+    /// - generate random scalars from a uniform distribution with a seeded PRNG
+    /// - scale a model of unit weights, mask and aggregate it to the aggregated masked models
+    /// - derive a mask from the mask seed and aggregate it to the aggregated masks
+    /// - unmask the aggregated masked model
+    /// - check that all aggregated unmasked weights are equal to the original unit weights (up
+    ///   to a tolerance determined by the masking configuration)
+    ///
+    /// The arguments to the macro are:
+    /// - a suffix for the test name
+    /// - the group type of the model (variants of `GroupType`)
+    /// - the data type of the model (either primitives or variants of `DataType`)
+    /// - an absolute bound for the weights (optional, choices: 1, 100, 10_000, 1_000_000)
+    /// - the number of weights per model
+    /// - the number of models
     macro_rules! test_masking_and_aggregation_scalar {
         ($suffix:ident, $group:ty, $data:ty, $bound:expr, $len:expr, $count:expr $(,)?) => {
             paste::item! {

--- a/rust/xaynet-core/src/mask/masking.rs
+++ b/rust/xaynet-core/src/mask/masking.rs
@@ -750,12 +750,11 @@ mod tests {
                     let mut prng = ChaCha20Rng::from_seed(MaskSeed::generate().as_array());
                     let mut masked_models = iter::repeat_with(move || {
                         let order = config.order();
+                        let integer = generate_integer(&mut prng, &order);
                         let integers = iter::repeat_with(|| generate_integer(&mut prng, &order))
                             .take($len as usize)
                             .collect::<Vec<_>>();
-                        let model = MaskVect::new_unchecked(config, integers);
-                        let scalar = MaskUnit::default(config);
-                        MaskObject::new_unchecked(model, scalar)
+                        MaskObject::new(config.into(), integers, integer).unwrap()
                     });
 
                     // Step 3 (actual test):

--- a/rust/xaynet-core/src/mask/masking.rs
+++ b/rust/xaynet-core/src/mask/masking.rs
@@ -598,9 +598,10 @@ mod tests {
     ///
     /// The arguments to the macro are:
     /// - a suffix for the test name
-    /// - the group type of the model (variants of `GroupType`)
-    /// - the data type of the model (either primitives or variants of `DataType`)
-    /// - an absolute bound for the weights (optional, choices: 1, 100, 10_000, 1_000_000)
+    /// - the group type of the model and scalar (variants of `GroupType`)
+    /// - the data type of the model and scalar (either float primitives or float variants of
+    ///   `DataType`)
+    /// - an absolute bound for the scalar (optional, choices: 1, 100, 10_000, 1_000_000)
     /// - the number of weights
     macro_rules! test_masking_scalar {
         ($suffix:ident, $group:ty, $data:ty, $bound:expr, $len:expr $(,)?) => {
@@ -629,10 +630,9 @@ mod tests {
                     } else {
                         paste::expr! { $bound as [<$data:lower>] }
                     };
-                    let zero = 0 as [<$data:lower>];
+                    let eps = [<$data:lower>]::EPSILON;
                     let mut prng = ChaCha20Rng::from_seed(MaskSeed::generate().as_array());
-                    let rand_neg = Uniform::new(-bound, zero).sample(&mut prng);
-                    let scalar = rand_neg.abs() as f64;
+                    let scalar = Uniform::new_inclusive(eps, bound).sample(&mut prng) as f64;
                     let model = Model::from_primitives(iter::repeat(1).take(vect_len)).unwrap();
                     assert_eq!(model.len(), vect_len);
 
@@ -700,42 +700,6 @@ mod tests {
     test_masking_scalar!(pow_f64_b4, Power2, f64, 10_000, 10);
     test_masking_scalar!(pow_f64_b6, Power2, f64, 1_000_000, 10);
     test_masking_scalar!(pow_f64_bmax, Power2, f64, 10);
-
-    test_masking_scalar!(int_i32_b0, Integer, i32, 1, 10);
-    test_masking_scalar!(int_i32_b2, Integer, i32, 100, 10);
-    test_masking_scalar!(int_i32_b4, Integer, i32, 10_000, 10);
-    test_masking_scalar!(int_i32_b6, Integer, i32, 1_000_000, 10);
-    test_masking_scalar!(int_i32_bmax, Integer, i32, 10);
-
-    test_masking_scalar!(prime_i32_b0, Prime, i32, 1, 10);
-    test_masking_scalar!(prime_i32_b2, Prime, i32, 100, 10);
-    test_masking_scalar!(prime_i32_b4, Prime, i32, 10_000, 10);
-    test_masking_scalar!(prime_i32_b6, Prime, i32, 1_000_000, 10);
-    test_masking_scalar!(prime_i32_bmax, Prime, i32, 10);
-
-    test_masking_scalar!(pow_i32_b0, Power2, i32, 1, 10);
-    test_masking_scalar!(pow_i32_b2, Power2, i32, 100, 10);
-    test_masking_scalar!(pow_i32_b4, Power2, i32, 10_000, 10);
-    test_masking_scalar!(pow_i32_b6, Power2, i32, 1_000_000, 10);
-    test_masking_scalar!(pow_i32_bmax, Power2, i32, 10);
-
-    test_masking_scalar!(int_i64_b0, Integer, i64, 1, 10);
-    test_masking_scalar!(int_i64_b2, Integer, i64, 100, 10);
-    test_masking_scalar!(int_i64_b4, Integer, i64, 10_000, 10);
-    test_masking_scalar!(int_i64_b6, Integer, i64, 1_000_000, 10);
-    test_masking_scalar!(int_i64_bmax, Integer, i64, 10);
-
-    test_masking_scalar!(prime_i64_b0, Prime, i64, 1, 10);
-    test_masking_scalar!(prime_i64_b2, Prime, i64, 100, 10);
-    test_masking_scalar!(prime_i64_b4, Prime, i64, 10_000, 10);
-    test_masking_scalar!(prime_i64_b6, Prime, i64, 1_000_000, 10);
-    test_masking_scalar!(prime_i64_bmax, Prime, i64, 10);
-
-    test_masking_scalar!(pow_i64_b0, Power2, i64, 1, 10);
-    test_masking_scalar!(pow_i64_b2, Power2, i64, 100, 10);
-    test_masking_scalar!(pow_i64_b4, Power2, i64, 10_000, 10);
-    test_masking_scalar!(pow_i64_b6, Power2, i64, 1_000_000, 10);
-    test_masking_scalar!(pow_i64_bmax, Power2, i64, 10);
 
     /// Generate tests for aggregation of multiple masked models:
     /// - generate random integers from a uniform distribution with a seeded PRNG
@@ -1060,9 +1024,10 @@ mod tests {
     ///
     /// The arguments to the macro are:
     /// - a suffix for the test name
-    /// - the group type of the model (variants of `GroupType`)
-    /// - the data type of the model (either primitives or variants of `DataType`)
-    /// - an absolute bound for the weights (optional, choices: 1, 100, 10_000, 1_000_000)
+    /// - the group type of the model and scalar (variants of `GroupType`)
+    /// - the data type of the model and scalar (either float primitives or float variants of
+    ///   `DataType`)
+    /// - an absolute bound for the scalar (optional, choices: 1, 100, 10_000, 1_000_000)
     /// - the number of weights per model
     /// - the number of models
     macro_rules! test_masking_and_aggregation_scalar {
@@ -1092,11 +1057,10 @@ mod tests {
                     } else {
                         paste::expr! { $bound as [<$data:lower>] }
                     };
-                    let zero = 0 as [<$data:lower>];
+                    let eps = [<$data:lower>]::EPSILON;
                     let mut prng = ChaCha20Rng::from_seed(MaskSeed::generate().as_array());
                     let mut scalars = iter::repeat_with(move || {
-                        let rand_neg = Uniform::new(-bound, zero).sample(&mut prng);
-                        rand_neg.abs() as f64
+                        Uniform::new_inclusive(eps, bound).sample(&mut prng) as f64
                     });
                     let mut models =
                         iter::repeat(Model::from_primitives(iter::repeat(1).take(vect_len)).unwrap());
@@ -1180,40 +1144,4 @@ mod tests {
     test_masking_and_aggregation_scalar!(pow_f64_b4, Power2, f64, 10_000, 10, 2);
     test_masking_and_aggregation_scalar!(pow_f64_b6, Power2, f64, 1_000_000, 10, 2);
     test_masking_and_aggregation_scalar!(pow_f64_bmax, Power2, f64, 10, 2);
-
-    test_masking_and_aggregation_scalar!(int_i32_b0, Integer, i32, 1, 10, 5);
-    test_masking_and_aggregation_scalar!(int_i32_b2, Integer, i32, 100, 10, 5);
-    test_masking_and_aggregation_scalar!(int_i32_b4, Integer, i32, 10_000, 10, 5);
-    test_masking_and_aggregation_scalar!(int_i32_b6, Integer, i32, 1_000_000, 10, 5);
-    test_masking_and_aggregation_scalar!(int_i32_bmax, Integer, i32, 10, 5);
-
-    test_masking_and_aggregation_scalar!(prime_i32_b0, Prime, i32, 1, 10, 5);
-    test_masking_and_aggregation_scalar!(prime_i32_b2, Prime, i32, 100, 10, 5);
-    test_masking_and_aggregation_scalar!(prime_i32_b4, Prime, i32, 10_000, 10, 5);
-    test_masking_and_aggregation_scalar!(prime_i32_b6, Prime, i32, 1_000_000, 10, 5);
-    test_masking_and_aggregation_scalar!(prime_i32_bmax, Prime, i32, 10, 5);
-
-    test_masking_and_aggregation_scalar!(pow_i32_b0, Power2, i32, 1, 10, 5);
-    test_masking_and_aggregation_scalar!(pow_i32_b2, Power2, i32, 100, 10, 5);
-    test_masking_and_aggregation_scalar!(pow_i32_b4, Power2, i32, 10_000, 10, 5);
-    test_masking_and_aggregation_scalar!(pow_i32_b6, Power2, i32, 1_000_000, 10, 5);
-    test_masking_and_aggregation_scalar!(pow_i32_bmax, Power2, i32, 10, 5);
-
-    test_masking_and_aggregation_scalar!(int_i64_b0, Integer, i64, 1, 10, 5);
-    test_masking_and_aggregation_scalar!(int_i64_b2, Integer, i64, 100, 10, 5);
-    test_masking_and_aggregation_scalar!(int_i64_b4, Integer, i64, 10_000, 10, 5);
-    test_masking_and_aggregation_scalar!(int_i64_b6, Integer, i64, 1_000_000, 10, 5);
-    test_masking_and_aggregation_scalar!(int_i64_bmax, Integer, i64, 10, 5);
-
-    test_masking_and_aggregation_scalar!(prime_i64_b0, Prime, i64, 1, 10, 5);
-    test_masking_and_aggregation_scalar!(prime_i64_b2, Prime, i64, 100, 10, 5);
-    test_masking_and_aggregation_scalar!(prime_i64_b4, Prime, i64, 10_000, 10, 5);
-    test_masking_and_aggregation_scalar!(prime_i64_b6, Prime, i64, 1_000_000, 10, 5);
-    test_masking_and_aggregation_scalar!(prime_i64_bmax, Prime, i64, 10, 5);
-
-    test_masking_and_aggregation_scalar!(pow_i64_b0, Power2, i64, 1, 10, 5);
-    test_masking_and_aggregation_scalar!(pow_i64_b2, Power2, i64, 100, 10, 5);
-    test_masking_and_aggregation_scalar!(pow_i64_b4, Power2, i64, 10_000, 10, 5);
-    test_masking_and_aggregation_scalar!(pow_i64_b6, Power2, i64, 1_000_000, 10, 5);
-    test_masking_and_aggregation_scalar!(pow_i64_bmax, Power2, i64, 10, 5);
 }


### PR DESCRIPTION
**Summary.**

This PR adds to the existing suite of masking / aggregation tests, to more thoroughly test the generalised scalar (e.g. there had been no test for scalars taking arbitrary values > 1).

More specifically,

- a new suite of tests `test_masking_scalar!` (to complement `test_masking!`) which samples a random scalar. 
- a new suite of tests `test_masking_and_aggregation_scalar!` (to complement `test_masking_and_aggregation!`) which samples random scalars.
- `test_aggregation!` is extended slightly, to additionally sample a random mask unit. `test_masking!` and `test_masking_and_aggregation!` are largely unchanged.

**Explanation of the sense in which the new tests _complement_ the existing.** 

The structure of `test_masking_scalar!` largely follows the existing `test_masking!`. The main difference is that while the latter generates a random model with a fixed scalar, `test_masking_scalar!` generates a _random scalar_ with a _fixed model_.

Similar story with `test_masking_and_aggregation_scalar!`. Rather than generating `n` random models each with a fixed scalar `1/n` (a canonical choice under the older, more restrictive requirements on scalars), instead it generates `n` random scalars (of arbitrary positive value, under the more relaxed requirements of generalised scalars) each with the same fixed model.

While it would be possible to randomize both scalars and models within a single combined test, this would complicate the test, in part due to current limitations with our masking configurations:

- assuming scalars and scaled models follow the _same_ masking config, we need to be careful that the sampled weights, after scaling, don't blow the bounds of the masking config.
- the same applies when the masking configs for both are distinct, except more complicated: some pairs of masking configs likely won't make sense.

For these reasons, it is simpler to randomize _either_ one of scalars or models, so that we are free to fix a safe choice of value for the other.  

