### PR TITLE
XN-1163 replace macro use

### DIFF
--- a/rust/examples/Cargo.toml
+++ b/rust/examples/Cargo.toml
@@ -25,7 +25,7 @@ tracing = "0.1.19"
 tracing-futures = "0.2.4"
 tracing-subscriber = "0.2.12"
 xaynet-core = { path = "../xaynet-core" }
-xaynet-sdk = { path = "../xaynet-sdk", features = ["reqwest_client"] }
+xaynet-sdk = { path = "../xaynet-sdk", features = ["reqwest-client"] }
 
 [[example]]
 name = "test-drive"

--- a/rust/examples/test-drive/main.rs
+++ b/rust/examples/test-drive/main.rs
@@ -1,15 +1,10 @@
-#[macro_use]
-extern crate tracing;
-
-#[macro_use]
-extern crate async_trait;
-
 use std::{path::PathBuf, sync::Arc, time::Duration};
 
 use reqwest::Certificate;
 use structopt::StructOpt;
+use tracing::error_span;
 use tracing_futures::Instrument;
-use tracing_subscriber::*;
+use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
 use xaynet_core::{
     crypto::SigningKeyPair,

--- a/rust/examples/test-drive/participant.rs
+++ b/rust/examples/test-drive/participant.rs
@@ -1,6 +1,9 @@
 use std::{sync::Arc, time::Duration};
 
+use async_trait::async_trait;
 use tokio::{sync::mpsc, time::delay_for};
+use tracing::{info, warn};
+
 use xaynet_core::mask::Model;
 use xaynet_sdk::{
     client::Client,

--- a/rust/xaynet-core/src/common.rs
+++ b/rust/xaynet-core/src/common.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use sodiumoxide::{self, crypto::box_};
 
 use crate::{crypto::ByteObject, CoordinatorPublicKey};

--- a/rust/xaynet-core/src/crypto/encrypt.rs
+++ b/rust/xaynet-core/src/crypto/encrypt.rs
@@ -6,6 +6,7 @@
 //! [crypto module]: ../index.html
 
 use derive_more::{AsMut, AsRef, From};
+use serde::{Deserialize, Serialize};
 use sodiumoxide::crypto::{box_, sealedbox};
 
 use super::ByteObject;

--- a/rust/xaynet-core/src/crypto/hash.rs
+++ b/rust/xaynet-core/src/crypto/hash.rs
@@ -5,11 +5,11 @@
 //! [sodiumoxide]: https://docs.rs/sodiumoxide/
 //! [crypto module]: ../index.html
 
-use super::ByteObject;
-
+use derive_more::{AsMut, AsRef, From};
+use serde::{Deserialize, Serialize};
 use sodiumoxide::crypto::hash::sha256;
 
-use derive_more::{AsMut, AsRef, From};
+use super::ByteObject;
 
 #[derive(
     AsRef,

--- a/rust/xaynet-core/src/crypto/sign.rs
+++ b/rust/xaynet-core/src/crypto/sign.rs
@@ -10,6 +10,7 @@ use num::{
     bigint::{BigUint, ToBigInt},
     rational::Ratio,
 };
+use serde::{Deserialize, Serialize};
 use sodiumoxide::crypto::{hash::sha256, sign};
 
 use super::ByteObject;

--- a/rust/xaynet-core/src/lib.rs
+++ b/rust/xaynet-core/src/lib.rs
@@ -11,8 +11,6 @@
 //! for an introduction.
 //!
 //! [whitepaper]: https://uploads-ssl.webflow.com/5f0c5c0bb18a279f0a62919e/5f157004da6585f299fa542b_XayNet%20Whitepaper%202.1.pdf
-#[macro_use]
-extern crate serde;
 
 pub mod common;
 pub mod crypto;

--- a/rust/xaynet-core/src/mask/config/mod.rs
+++ b/rust/xaynet-core/src/mask/config/mod.rs
@@ -13,6 +13,7 @@ use num::{
     rational::Ratio,
     traits::{pow::Pow, Num},
 };
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 // target dependent maximum bytes per mask object element

--- a/rust/xaynet-core/src/mask/masking.rs
+++ b/rust/xaynet-core/src/mask/masking.rs
@@ -11,7 +11,6 @@ use num::{
     clamp,
     rational::Ratio,
 };
-
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
 use thiserror::Error;

--- a/rust/xaynet-core/src/mask/model.rs
+++ b/rust/xaynet-core/src/mask/model.rs
@@ -17,6 +17,7 @@ use num::{
     rational::Ratio,
     traits::{float::FloatCore, identities::Zero, ToPrimitive},
 };
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Hash, From, Index, IndexMut, Into, Serialize, Deserialize)]

--- a/rust/xaynet-core/src/mask/object/mod.rs
+++ b/rust/xaynet-core/src/mask/object/mod.rs
@@ -9,6 +9,7 @@ pub mod serialization;
 use std::iter::Iterator;
 
 use num::bigint::BigUint;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::mask::config::{MaskConfig, MaskConfigPair};

--- a/rust/xaynet-core/src/mask/seed.rs
+++ b/rust/xaynet-core/src/mask/seed.rs
@@ -9,6 +9,7 @@ use std::iter;
 use derive_more::{AsMut, AsRef};
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
+use serde::{Deserialize, Serialize};
 use sodiumoxide::crypto::box_;
 use thiserror::Error;
 

--- a/rust/xaynet-core/src/message/message.rs
+++ b/rust/xaynet-core/src/message/message.rs
@@ -7,6 +7,7 @@
 use std::convert::{TryFrom, TryInto};
 
 use anyhow::{anyhow, Context};
+use serde::{Deserialize, Serialize};
 
 use crate::{
     crypto::{ByteObject, PublicEncryptKey, PublicSigningKey, SecretSigningKey, Signature},

--- a/rust/xaynet-core/src/message/utils/chunkable_iterator.rs
+++ b/rust/xaynet-core/src/message/utils/chunkable_iterator.rs
@@ -2,6 +2,7 @@
 //! by chunks. One important property of our chunks, is that they implement
 //! [`std::iter::ExactSizeIterator`], which is required by the [`crate::message::FromBytes`]
 //! trait.
+
 use std::{
     cell::RefCell,
     cmp,

--- a/rust/xaynet-core/src/testutils/messages.rs
+++ b/rust/xaynet-core/src/testutils/messages.rs
@@ -1,5 +1,6 @@
 //! This module provides helpers for generating messages or messages
 //! parts such as signatures, cryptographic keys, or mask objects.
+
 use std::convert::TryFrom;
 
 use num::BigUint;

--- a/rust/xaynet-ffi/src/lib.rs
+++ b/rust/xaynet-ffi/src/lib.rs
@@ -26,9 +26,6 @@
 //!
 //! [#71668]: https://github.com/rust-lang/rust/issues/71668
 
-#[macro_use]
-extern crate ffi_support;
-
 #[cfg(feature = "tls")]
 use std::path::PathBuf;
 use std::{
@@ -39,7 +36,7 @@ use std::{
     slice,
 };
 
-use ffi_support::FfiStr;
+use ffi_support::{define_box_destructor, FfiStr};
 
 use xaynet_client::mobile_client::{
     participant::{AggregationConfig, MaxMessageSize, ParticipantSettings},

--- a/rust/xaynet-sdk/Cargo.toml
+++ b/rust/xaynet-sdk/Cargo.toml
@@ -40,4 +40,4 @@ xaynet-core = { path = "../xaynet-core", version = "0.1.0", features = ["testuti
 
 [features]
 default = []
-reqwest_client = ["bincode", "reqwest/rustls-tls"]
+reqwest-client = ["bincode", "reqwest/rustls-tls"]

--- a/rust/xaynet-sdk/src/client/mod.rs
+++ b/rust/xaynet-sdk/src/client/mod.rs
@@ -1,2 +1,3 @@
 mod reqwest;
+
 pub use self::reqwest::{Client, ClientError};

--- a/rust/xaynet-sdk/src/client/reqwest.rs
+++ b/rust/xaynet-sdk/src/client/reqwest.rs
@@ -1,5 +1,6 @@
 use std::{fs, path::Path, sync::Arc};
 
+use async_trait::async_trait;
 use reqwest::{self, Certificate, ClientBuilder, Identity, Response, StatusCode};
 use thiserror::Error;
 

--- a/rust/xaynet-sdk/src/lib.rs
+++ b/rust/xaynet-sdk/src/lib.rs
@@ -80,7 +80,7 @@
 //! - a client to talk with the Xaynet coordinator. This can be any
 //!   type that implements the [`XaynetClient`] trait. For this we're
 //!   going to use the [`Client`] that is available when compiling
-//!   with `--features reqwest_client`.
+//!   with `--features reqwest-client`.
 //! - a notifier that the state machine can use to send
 //!   notifications. This can be any type that implements the
 //!   [`Notify`] trait. We'll use channels for this.
@@ -91,14 +91,12 @@
 //! is the full code:
 //!
 //! ```rust,ignore
-//! #[macro_use]
-//! extern crate async_trait;
-//!
 //! use std::{
 //!     sync::{mpsc, Arc},
 //!     time::Duration,
 //! };
 //!
+//! use async_trait::async_trait;
 //! use tokio::time::delay_for;
 //! use xaynet_core::{
 //!     crypto::SigningKeyPair,
@@ -201,24 +199,17 @@
 //!     }
 //! }
 //! ```
-#[macro_use]
-extern crate async_trait;
-#[macro_use]
-extern crate serde;
-#[macro_use]
-extern crate tracing;
 
-mod message_encoder;
-pub(crate) use message_encoder::MessageEncoder;
-
-mod settings;
-pub use settings::PetSettings;
-
-mod state_machine;
-pub use state_machine::{PassiveNotifier, StateMachine, TransitionOutcome};
-
-mod traits;
-pub use traits::{ModelStore, Notify, XaynetClient};
-
-#[cfg(feature = "reqwest_client")]
+#[cfg(feature = "reqwest-client")]
 pub mod client;
+mod message_encoder;
+mod settings;
+mod state_machine;
+mod traits;
+
+pub(crate) use crate::message_encoder::MessageEncoder;
+pub use crate::{
+    settings::PetSettings,
+    state_machine::{PassiveNotifier, StateMachine, TransitionOutcome},
+    traits::{ModelStore, Notify, XaynetClient},
+};

--- a/rust/xaynet-sdk/src/message_encoder/encoder.rs
+++ b/rust/xaynet-sdk/src/message_encoder/encoder.rs
@@ -1,12 +1,11 @@
-#![allow(dead_code)]
-
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
+
+use super::Chunker;
 use xaynet_core::{
     crypto::{PublicEncryptKey, SecretSigningKey, SigningKeyPair},
     message::{Chunk, Message, Payload, Tag, ToBytes},
 };
-
-use super::Chunker;
 
 /// An encoder for multipart messages. It implements
 /// `Iterator<Item=Vec<u8>>`, which yields message parts ready to be

--- a/rust/xaynet-sdk/src/message_encoder/mod.rs
+++ b/rust/xaynet-sdk/src/message_encoder/mod.rs
@@ -1,5 +1,5 @@
 mod chunker;
-pub(self) use chunker::Chunker;
-
 mod encoder;
+
+use chunker::Chunker;
 pub use encoder::MessageEncoder;

--- a/rust/xaynet-sdk/src/settings/max_message_size.rs
+++ b/rust/xaynet-sdk/src/settings/max_message_size.rs
@@ -1,5 +1,6 @@
-use serde::{de::Error as SerdeError, Deserialize, Deserializer};
+use serde::{de::Error as SerdeError, Deserialize, Deserializer, Serialize};
 use thiserror::Error;
+
 pub use xaynet_core::message::MESSAGE_HEADER_LENGTH;
 
 /// The minimum message payload size

--- a/rust/xaynet-sdk/src/settings/mod.rs
+++ b/rust/xaynet-sdk/src/settings/mod.rs
@@ -1,10 +1,12 @@
+mod max_message_size;
+
+use serde::{Deserialize, Serialize};
+
+pub use max_message_size::MaxMessageSize;
 use xaynet_core::{
     crypto::SigningKeyPair,
     mask::{MaskConfig, MaskConfigPair},
 };
-
-mod max_message_size;
-pub use max_message_size::MaxMessageSize;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct PetSettings {

--- a/rust/xaynet-sdk/src/state_machine/io.rs
+++ b/rust/xaynet-sdk/src/state_machine/io.rs
@@ -1,5 +1,7 @@
 use std::error::Error;
 
+use async_trait::async_trait;
+
 use xaynet_core::{
     common::RoundParameters,
     mask::Model,

--- a/rust/xaynet-sdk/src/state_machine/mod.rs
+++ b/rust/xaynet-sdk/src/state_machine/mod.rs
@@ -1,5 +1,5 @@
 // Important the macro_use modules must be declared first for the
-// macro to be used in the other modules
+// macro to be used in the other modules (until declarative macros are stable)
 #[macro_use]
 mod phase;
 mod io;
@@ -9,11 +9,12 @@ mod state_machine;
 
 // It is useful to re-export everything within this module because
 // there are lot of interdependencies between all the sub-modules
+pub use self::{
+    io::PassiveNotifier,
+    state_machine::{StateMachine, TransitionOutcome},
+};
 use self::{
     io::{boxed_io, IO},
     phase::{Phase, Progress, SerializableState, SharedState, State, Step},
     phases::{Awaiting, NewRound, Sum, Sum2, Update},
 };
-
-pub use io::PassiveNotifier;
-pub use state_machine::{StateMachine, TransitionOutcome};

--- a/rust/xaynet-sdk/src/state_machine/phase.rs
+++ b/rust/xaynet-sdk/src/state_machine/phase.rs
@@ -1,18 +1,20 @@
+use async_trait::async_trait;
 use derive_more::From;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
-
-use xaynet_core::{
-    common::RoundParameters,
-    crypto::SigningKeyPair,
-    mask::{MaskConfigPair, Model},
-    message::Payload,
-};
+use tracing::{debug, error, info, warn};
 
 use super::{Awaiting, NewRound, Sum, Sum2, Update, IO};
 use crate::{
     settings::{MaxMessageSize, PetSettings},
     state_machine::{StateMachine, TransitionOutcome},
     MessageEncoder,
+};
+use xaynet_core::{
+    common::RoundParameters,
+    crypto::SigningKeyPair,
+    mask::{MaskConfigPair, Model},
+    message::Payload,
 };
 
 /// State of the state machine

--- a/rust/xaynet-sdk/src/state_machine/phases/awaiting.rs
+++ b/rust/xaynet-sdk/src/state_machine/phases/awaiting.rs
@@ -1,3 +1,7 @@
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use tracing::info;
+
 use crate::state_machine::{Phase, Step, TransitionOutcome};
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/rust/xaynet-sdk/src/state_machine/phases/mod.rs
+++ b/rust/xaynet-sdk/src/state_machine/phases/mod.rs
@@ -4,8 +4,4 @@ mod sum;
 mod sum2;
 mod update;
 
-pub use awaiting::Awaiting;
-pub use new_round::NewRound;
-pub use sum::Sum;
-pub use sum2::Sum2;
-pub use update::Update;
+pub use self::{awaiting::Awaiting, new_round::NewRound, sum::Sum, sum2::Sum2, update::Update};

--- a/rust/xaynet-sdk/src/state_machine/phases/new_round.rs
+++ b/rust/xaynet-sdk/src/state_machine/phases/new_round.rs
@@ -1,6 +1,9 @@
-use xaynet_core::crypto::{ByteObject, Signature};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use tracing::info;
 
 use crate::state_machine::{Phase, State, Step, Sum, TransitionOutcome, Update};
+use xaynet_core::crypto::{ByteObject, Signature};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct NewRound;

--- a/rust/xaynet-sdk/src/state_machine/phases/sum.rs
+++ b/rust/xaynet-sdk/src/state_machine/phases/sum.rs
@@ -1,11 +1,14 @@
-use xaynet_core::{
-    crypto::{EncryptKeyPair, Signature},
-    message::Sum as SumMessage,
-};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use tracing::{info, warn};
 
 use crate::{
     state_machine::{Phase, Progress, State, Step, Sum2, TransitionOutcome},
     MessageEncoder,
+};
+use xaynet_core::{
+    crypto::{EncryptKeyPair, Signature},
+    message::Sum as SumMessage,
 };
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/rust/xaynet-sdk/src/state_machine/phases/sum2.rs
+++ b/rust/xaynet-sdk/src/state_machine/phases/sum2.rs
@@ -1,13 +1,16 @@
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, error, info, warn};
+
+use crate::{
+    state_machine::{Phase, Progress, Step, TransitionOutcome, IO},
+    MessageEncoder,
+};
 use xaynet_core::{
     crypto::{EncryptKeyPair, Signature},
     mask::{Aggregation, MaskObject, MaskSeed},
     message::Sum2 as Sum2Message,
     UpdateSeedDict,
-};
-
-use crate::{
-    state_machine::{Phase, Progress, Step, TransitionOutcome, IO},
-    MessageEncoder,
 };
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/rust/xaynet-sdk/src/state_machine/phases/update.rs
+++ b/rust/xaynet-sdk/src/state_machine/phases/update.rs
@@ -1,6 +1,14 @@
 use std::ops::Deref;
 
+use async_trait::async_trait;
 use derive_more::From;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, info, warn};
+
+use crate::{
+    state_machine::{Phase, Progress, Step, TransitionOutcome, IO},
+    MessageEncoder,
+};
 use xaynet_core::{
     crypto::Signature,
     mask::{MaskObject, MaskSeed, Masker, Model},
@@ -8,11 +16,6 @@ use xaynet_core::{
     LocalSeedDict,
     ParticipantTaskSignature,
     SumDict,
-};
-
-use crate::{
-    state_machine::{Phase, Progress, Step, TransitionOutcome, IO},
-    MessageEncoder,
 };
 
 #[derive(From)]

--- a/rust/xaynet-sdk/src/state_machine/state_machine.rs
+++ b/rust/xaynet-sdk/src/state_machine/state_machine.rs
@@ -1,7 +1,5 @@
 use derive_more::From;
 
-use crate::{settings::PetSettings, ModelStore, Notify, XaynetClient};
-
 use super::{
     boxed_io,
     Awaiting,
@@ -14,6 +12,7 @@ use super::{
     Sum2,
     Update,
 };
+use crate::{settings::PetSettings, ModelStore, Notify, XaynetClient};
 
 /// Outcome of a state machine transition attempt.
 pub enum TransitionOutcome {

--- a/rust/xaynet-sdk/src/traits.rs
+++ b/rust/xaynet-sdk/src/traits.rs
@@ -1,3 +1,5 @@
+use async_trait::async_trait;
+
 use xaynet_core::{
     common::RoundParameters,
     mask::Model,

--- a/rust/xaynet-server/Cargo.toml
+++ b/rust/xaynet-server/Cargo.toml
@@ -93,7 +93,7 @@ path = "src/bin/main.rs"
 
 [features]
 default = []
-full = ["metrics", "tls"]
+full = ["metrics", "model-persistence", "tls"]
 metrics = ["chrono", "influxdb"]
 model-persistence = ["fancy-regex", "hex", "rusoto_core", "rusoto_s3"]
 tls = ["warp/tls"]

--- a/rust/xaynet-server/src/bin/main.rs
+++ b/rust/xaynet-server/src/bin/main.rs
@@ -2,7 +2,13 @@ use std::{path::PathBuf, process};
 
 use structopt::StructOpt;
 use tokio::signal;
+use tracing::warn;
 use tracing_subscriber::*;
+
+#[cfg(feature = "metrics")]
+use xaynet_server::metrics::{run_metric_service, MetricsService};
+#[cfg(feature = "model-persistence")]
+use xaynet_server::storage::s3;
 use xaynet_server::{
     rest::{serve, RestError},
     services,
@@ -10,15 +16,6 @@ use xaynet_server::{
     state_machine::StateMachineInitializer,
     storage::redis,
 };
-
-#[cfg(feature = "metrics")]
-use xaynet_server::metrics::{run_metric_service, MetricsService};
-
-#[cfg(feature = "model-persistence")]
-use xaynet_server::storage::s3;
-
-#[macro_use]
-extern crate tracing;
 
 #[derive(Debug, StructOpt)]
 #[structopt(name = "Coordinator")]

--- a/rust/xaynet-server/src/lib.rs
+++ b/rust/xaynet-server/src/lib.rs
@@ -12,24 +12,12 @@
 //!
 //! [whitepaper]: https://uploads-ssl.webflow.com/5f0c5c0bb18a279f0a62919e/5f157004da6585f299fa542b_XayNet%20Whitepaper%202.1.pdf
 
-#[macro_use]
-extern crate async_trait;
-#[macro_use]
-extern crate serde;
-
-#[macro_use]
-extern crate tracing;
-
-#[macro_use]
-extern crate xaynet_macros;
-
 pub mod examples;
+#[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
+#[cfg(feature = "metrics")]
+pub mod metrics;
 pub mod rest;
 pub mod services;
 pub mod settings;
 pub mod state_machine;
 pub mod storage;
-
-#[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
-#[cfg(feature = "metrics")]
-pub mod metrics;

--- a/rust/xaynet-server/src/metrics/service.rs
+++ b/rust/xaynet-server/src/metrics/service.rs
@@ -1,5 +1,6 @@
 use influxdb::{Client, WriteQuery};
 use tokio::sync::mpsc::{channel, Receiver, Sender};
+use tracing::{error, warn};
 
 /// Runs the metrics service.
 ///

--- a/rust/xaynet-server/src/rest.rs
+++ b/rust/xaynet-server/src/rest.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 
 use bytes::{Buf, Bytes};
 use thiserror::Error;
+use tracing::{error, warn};
 use warp::{
     http::{Response, StatusCode},
     reply::Reply,

--- a/rust/xaynet-server/src/services/fetchers/mask_length.rs
+++ b/rust/xaynet-server/src/services/fetchers/mask_length.rs
@@ -2,6 +2,7 @@ use std::task::{Context, Poll};
 
 use futures::future::{self, Ready};
 use tower::Service;
+use tracing::error_span;
 use tracing_futures::{Instrument, Instrumented};
 
 use crate::state_machine::events::{EventListener, EventSubscriber, MaskLengthUpdate};

--- a/rust/xaynet-server/src/services/fetchers/mod.rs
+++ b/rust/xaynet-server/src/services/fetchers/mod.rs
@@ -2,11 +2,18 @@
 //!
 //! There are multiple such services and the [`Fetcher`] trait
 //! provides a single unifying interface for all of these.
+
 mod mask_length;
 mod model;
 mod round_parameters;
 mod seed_dict;
 mod sum_dict;
+
+use std::task::{Context, Poll};
+
+use async_trait::async_trait;
+use futures::future::poll_fn;
+use tower::{layer::Layer, Service, ServiceBuilder};
 
 pub use self::{
     mask_length::{MaskLengthRequest, MaskLengthResponse, MaskLengthService},
@@ -15,12 +22,6 @@ pub use self::{
     seed_dict::{SeedDictRequest, SeedDictResponse, SeedDictService},
     sum_dict::{SumDictRequest, SumDictResponse, SumDictService},
 };
-
-use std::task::{Context, Poll};
-
-use futures::future::poll_fn;
-use tower::{layer::Layer, Service, ServiceBuilder};
-
 use crate::state_machine::events::EventSubscriber;
 
 /// A single interface for retrieving data from the coordinator.

--- a/rust/xaynet-server/src/services/fetchers/model.rs
+++ b/rust/xaynet-server/src/services/fetchers/model.rs
@@ -5,10 +5,11 @@ use std::{
 
 use futures::future::{self, Ready};
 use tower::Service;
+use tracing::error_span;
 use tracing_futures::{Instrument, Instrumented};
-use xaynet_core::mask::Model;
 
 use crate::state_machine::events::{EventListener, EventSubscriber, ModelUpdate};
+use xaynet_core::mask::Model;
 
 /// [`ModelService`]'s request type
 #[derive(Default, Clone, Eq, PartialEq, Debug)]

--- a/rust/xaynet-server/src/services/fetchers/round_parameters.rs
+++ b/rust/xaynet-server/src/services/fetchers/round_parameters.rs
@@ -2,10 +2,11 @@ use std::task::{Context, Poll};
 
 use futures::future::{self, Ready};
 use tower::Service;
+use tracing::error_span;
 use tracing_futures::{Instrument, Instrumented};
-use xaynet_core::common::RoundParameters;
 
 use crate::state_machine::events::{EventListener, EventSubscriber};
+use xaynet_core::common::RoundParameters;
 
 /// [`RoundParamsService`]'s request type
 #[derive(Default, Clone, Eq, PartialEq, Debug)]

--- a/rust/xaynet-server/src/services/fetchers/seed_dict.rs
+++ b/rust/xaynet-server/src/services/fetchers/seed_dict.rs
@@ -5,10 +5,11 @@ use std::{
 
 use futures::future::{self, Ready};
 use tower::Service;
+use tracing::error_span;
 use tracing_futures::{Instrument, Instrumented};
-use xaynet_core::SeedDict;
 
 use crate::state_machine::events::{DictionaryUpdate, EventListener, EventSubscriber};
+use xaynet_core::SeedDict;
 
 /// A service that serves the seed dictionary for the current round.
 pub struct SeedDictService(EventListener<DictionaryUpdate<SeedDict>>);

--- a/rust/xaynet-server/src/services/fetchers/sum_dict.rs
+++ b/rust/xaynet-server/src/services/fetchers/sum_dict.rs
@@ -5,10 +5,11 @@ use std::{
 
 use futures::future::{self, Ready};
 use tower::Service;
+use tracing::error_span;
 use tracing_futures::{Instrument, Instrumented};
-use xaynet_core::SumDict;
 
 use crate::state_machine::events::{DictionaryUpdate, EventListener, EventSubscriber};
+use xaynet_core::SumDict;
 
 /// A service that returns the sum dictionary for the current round.
 pub struct SumDictService(EventListener<DictionaryUpdate<SumDict>>);

--- a/rust/xaynet-server/src/services/messages/decryptor.rs
+++ b/rust/xaynet-server/src/services/messages/decryptor.rs
@@ -7,12 +7,13 @@ use tower::{
     limit::concurrency::{future::ResponseFuture, ConcurrencyLimit},
     Service,
 };
-use xaynet_core::crypto::EncryptKeyPair;
+use tracing::{debug, info, trace};
 
 use crate::{
     services::messages::{BoxedServiceFuture, ServiceError},
     state_machine::events::{EventListener, EventSubscriber},
 };
+use xaynet_core::crypto::EncryptKeyPair;
 
 /// A service for decrypting PET messages.
 ///

--- a/rust/xaynet-server/src/services/messages/error.rs
+++ b/rust/xaynet-server/src/services/messages/error.rs
@@ -1,7 +1,7 @@
 use thiserror::Error;
-use xaynet_core::message::DecodeError;
 
 use crate::state_machine::RequestError;
+use xaynet_core::message::DecodeError;
 
 /// Error type for the message parsing service
 #[derive(Debug, Error)]

--- a/rust/xaynet-server/src/services/messages/message_parser.rs
+++ b/rust/xaynet-server/src/services/messages/message_parser.rs
@@ -4,10 +4,7 @@ use futures::{future, task::Context};
 use rayon::ThreadPool;
 use tokio::sync::oneshot;
 use tower::{layer::Layer, limit::concurrency::ConcurrencyLimit, Service, ServiceBuilder};
-use xaynet_core::{
-    crypto::{EncryptKeyPair, PublicEncryptKey},
-    message::{FromBytes, Message, MessageBuffer, Tag},
-};
+use tracing::{debug, info, trace, warn};
 
 use crate::{
     services::messages::{BoxedServiceFuture, ServiceError},
@@ -15,6 +12,10 @@ use crate::{
         events::{EventListener, EventSubscriber},
         phases::PhaseName,
     },
+};
+use xaynet_core::{
+    crypto::{EncryptKeyPair, PublicEncryptKey},
+    message::{FromBytes, Message, MessageBuffer, Tag},
 };
 
 /// A type that hold a un-parsed message

--- a/rust/xaynet-server/src/services/messages/mod.rs
+++ b/rust/xaynet-server/src/services/messages/mod.rs
@@ -2,20 +2,13 @@
 //!
 //! There are multiple such services and [`PetMessageHandler`]
 //! provides a single unifying interface for all of these.
+
 mod decryptor;
 mod error;
 mod message_parser;
 mod multipart;
 mod state_machine;
 mod task_validator;
-pub use self::error::ServiceError;
-use self::{
-    decryptor::Decryptor,
-    message_parser::MessageParser,
-    multipart::MultipartHandler,
-    state_machine::StateMachine,
-    task_validator::TaskValidator,
-};
 
 use std::sync::Arc;
 
@@ -24,6 +17,14 @@ use rayon::ThreadPoolBuilder;
 use tower::Service;
 use xaynet_core::message::Message;
 
+pub use self::error::ServiceError;
+use self::{
+    decryptor::Decryptor,
+    message_parser::MessageParser,
+    multipart::MultipartHandler,
+    state_machine::StateMachine,
+    task_validator::TaskValidator,
+};
 use crate::state_machine::{events::EventSubscriber, requests::RequestSender};
 
 impl PetMessageHandler {

--- a/rust/xaynet-server/src/services/messages/multipart/mod.rs
+++ b/rust/xaynet-server/src/services/messages/multipart/mod.rs
@@ -1,4 +1,3 @@
-use crate::services::messages::ServiceError;
 mod buffer;
 mod service;
 
@@ -6,6 +5,8 @@ use std::task::{Context, Poll};
 
 use futures::future::TryFutureExt;
 use tower::{buffer::Buffer, Service, ServiceBuilder};
+
+use crate::services::messages::ServiceError;
 use xaynet_core::message::Message;
 
 type Inner = Buffer<service::MultipartHandler, Message>;

--- a/rust/xaynet-server/src/services/messages/multipart/service.rs
+++ b/rust/xaynet-server/src/services/messages/multipart/service.rs
@@ -8,12 +8,12 @@ use futures::{
     task::Context,
 };
 use tower::Service;
+
+use crate::services::messages::{multipart::buffer::MultipartMessageBuffer, ServiceError};
 use xaynet_core::{
     crypto::{PublicEncryptKey, PublicSigningKey},
     message::{Chunk, DecodeError, FromBytes, Message, Payload, Sum, Sum2, Tag, Update},
 };
-
-use crate::services::messages::{multipart::buffer::MultipartMessageBuffer, ServiceError};
 
 /// A `MessageBuilder` stores chunks of a multipart message. Once it
 /// has all the chunks, it can be consumed and turned into a

--- a/rust/xaynet-server/src/services/messages/state_machine.rs
+++ b/rust/xaynet-server/src/services/messages/state_machine.rs
@@ -4,12 +4,11 @@ use futures::task::Context;
 use tower::Service;
 use xaynet_core::message::Message;
 
+pub use crate::state_machine::RequestError;
 use crate::{
     services::messages::{BoxedServiceFuture, ServiceError},
     state_machine::requests::RequestSender,
 };
-
-pub use crate::state_machine::RequestError;
 
 /// A service that hands the requests to the state machine
 /// ([`StateMachine`]) that runs in the

--- a/rust/xaynet-server/src/services/messages/task_validator.rs
+++ b/rust/xaynet-server/src/services/messages/task_validator.rs
@@ -2,15 +2,15 @@ use std::task::Poll;
 
 use futures::{future, task::Context};
 use tower::Service;
-use xaynet_core::{
-    common::RoundParameters,
-    crypto::ByteObject,
-    message::{Message, Payload},
-};
 
 use crate::{
     services::messages::ServiceError,
     state_machine::events::{EventListener, EventSubscriber},
+};
+use xaynet_core::{
+    common::RoundParameters,
+    crypto::ByteObject,
+    message::{Message, Payload},
 };
 
 /// A service for performing sanity checks and preparing incoming

--- a/rust/xaynet-server/src/services/mod.rs
+++ b/rust/xaynet-server/src/services/mod.rs
@@ -7,6 +7,7 @@
 //!   module
 //! - the services for processing PET message are provided by the
 //!   [`messages`] module.
+
 pub mod fetchers;
 pub mod messages;
 

--- a/rust/xaynet-server/src/services/tests/fetchers.rs
+++ b/rust/xaynet-server/src/services/tests/fetchers.rs
@@ -2,14 +2,6 @@ use std::{collections::HashMap, sync::Arc};
 
 use tokio_test::assert_ready;
 use tower_test::mock::Spawn;
-use xaynet_core::{
-    common::{RoundParameters, RoundSeed},
-    crypto::{ByteObject, PublicEncryptKey, PublicSigningKey},
-    mask::{EncryptedMaskSeed, Model},
-    SeedDict,
-    SumDict,
-    UpdateSeedDict,
-};
 
 use crate::{
     services::{
@@ -28,6 +20,14 @@ use crate::{
         tests::utils::new_event_channels,
     },
     state_machine::events::{DictionaryUpdate, MaskLengthUpdate, ModelUpdate},
+};
+use xaynet_core::{
+    common::{RoundParameters, RoundSeed},
+    crypto::{ByteObject, PublicEncryptKey, PublicSigningKey},
+    mask::{EncryptedMaskSeed, Model},
+    SeedDict,
+    SumDict,
+    UpdateSeedDict,
 };
 
 #[tokio::test]

--- a/rust/xaynet-server/src/services/tests/utils.rs
+++ b/rust/xaynet-server/src/services/tests/utils.rs
@@ -1,12 +1,11 @@
+use crate::state_machine::{
+    events::{EventPublisher, EventSubscriber, ModelUpdate},
+    phases::PhaseName,
+};
 use xaynet_core::{
     common::{RoundParameters, RoundSeed},
     crypto::{ByteObject, EncryptKeyPair, PublicEncryptKey, SigningKeyPair},
     message::{Message, Sum},
-};
-
-use crate::state_machine::{
-    events::{EventPublisher, EventSubscriber, ModelUpdate},
-    phases::PhaseName,
 };
 
 /// Create an [`EventPublisher`]/[`EventSubscriber`] pair with default

--- a/rust/xaynet-server/src/settings/mod.rs
+++ b/rust/xaynet-server/src/settings/mod.rs
@@ -3,13 +3,14 @@
 //! Values defined in the configuration file can be overridden by environment variables. Examples of
 //! configuration files can be found in the `configs/` directory located in the repository root.
 
+use std::{fmt, path::PathBuf};
+
 use config::{Config, ConfigError, Environment};
 use redis::{ConnectionInfo, IntoConnectionInfo};
 use serde::{
     de::{self, Deserializer, Visitor},
     Deserialize,
 };
-use std::{fmt, path::PathBuf};
 use thiserror::Error;
 use tracing_subscriber::filter::EnvFilter;
 use validator::{Validate, ValidationError, ValidationErrors};

--- a/rust/xaynet-server/src/settings/s3.rs
+++ b/rust/xaynet-server/src/settings/s3.rs
@@ -1,10 +1,11 @@
+use std::fmt;
+
 use fancy_regex::Regex;
 use rusoto_core::Region;
 use serde::{
     de::{self, value, Deserializer, Visitor},
     Deserialize,
 };
-use std::fmt;
 use validator::{Validate, ValidationError};
 
 #[derive(Debug, Validate, Deserialize)]

--- a/rust/xaynet-server/src/state_machine/coordinator.rs
+++ b/rust/xaynet-server/src/state_machine/coordinator.rs
@@ -1,11 +1,13 @@
 //! Coordinator state and round parameter types.
+
+use serde::{Deserialize, Serialize};
+
+use crate::settings::{MaskSettings, ModelSettings, PetSettings};
 use xaynet_core::{
     common::{RoundParameters, RoundSeed},
     crypto::{ByteObject, EncryptKeyPair},
     mask::MaskConfig,
 };
-
-use crate::settings::{MaskSettings, ModelSettings, PetSettings};
 
 /// The coordinator state.
 #[derive(Debug, PartialEq, Serialize, Deserialize)]

--- a/rust/xaynet-server/src/state_machine/events.rs
+++ b/rust/xaynet-server/src/state_machine/events.rs
@@ -11,6 +11,8 @@ use std::{
 
 use futures::Stream;
 use tokio::sync::watch;
+
+use crate::state_machine::phases::PhaseName;
 use xaynet_core::{
     common::RoundParameters,
     crypto::EncryptKeyPair,
@@ -18,8 +20,6 @@ use xaynet_core::{
     SeedDict,
     SumDict,
 };
-
-use crate::state_machine::phases::PhaseName;
 
 /// An event emitted by the coordinator.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/rust/xaynet-server/src/state_machine/mod.rs
+++ b/rust/xaynet-server/src/state_machine/mod.rs
@@ -97,6 +97,11 @@ pub mod events;
 pub mod phases;
 pub mod requests;
 
+use derive_more::From;
+use thiserror::Error;
+#[cfg(feature = "model-persistence")]
+use tracing::{debug, info, warn};
+
 use self::{
     coordinator::CoordinatorState,
     events::{EventPublisher, EventSubscriber, ModelUpdate},
@@ -115,22 +120,17 @@ use self::{
     },
     requests::{RequestReceiver, RequestSender},
 };
+#[cfg(feature = "metrics")]
+use crate::metrics::MetricsSender;
+#[cfg(feature = "model-persistence")]
+use crate::{settings::RestoreSettings, storage::s3};
 use crate::{
     settings::{MaskSettings, ModelSettings, PetSettings},
     storage::{redis, MaskDictIncrError, RedisError, SeedDictUpdateError, SumDictAddError},
 };
-use derive_more::From;
-use thiserror::Error;
-use xaynet_core::mask::UnmaskingError;
-
-#[cfg(feature = "metrics")]
-use crate::metrics::MetricsSender;
-
 #[cfg(feature = "model-persistence")]
 use xaynet_core::mask::Model;
-
-#[cfg(feature = "model-persistence")]
-use crate::{settings::RestoreSettings, storage::s3};
+use xaynet_core::mask::UnmaskingError;
 
 /// Error returned when the state machine fails to handle a request
 #[derive(Debug, Error)]

--- a/rust/xaynet-server/src/state_machine/phases/error.rs
+++ b/rust/xaynet-server/src/state_machine/phases/error.rs
@@ -1,3 +1,12 @@
+use std::time::Duration;
+
+use async_trait::async_trait;
+use thiserror::Error;
+use tokio::time::delay_for;
+use tracing::{error, info};
+
+#[cfg(feature = "metrics")]
+use crate::metrics;
 use crate::{
     state_machine::{
         phases::{Idle, Phase, PhaseName, PhaseState, Shared, Shutdown},
@@ -6,13 +15,7 @@ use crate::{
     },
     storage::redis::RedisError,
 };
-use std::time::Duration;
-use tokio::time::delay_for;
-
-#[cfg(feature = "metrics")]
-use crate::metrics;
-
-use thiserror::Error;
+use xaynet_macros::metrics;
 
 /// Error that can occur during the execution of the [`StateMachine`].
 #[derive(Error, Debug)]

--- a/rust/xaynet-server/src/state_machine/phases/idle.rs
+++ b/rust/xaynet-server/src/state_machine/phases/idle.rs
@@ -1,19 +1,20 @@
-use xaynet_core::{
-    common::RoundSeed,
-    crypto::{ByteObject, EncryptKeyPair, SigningKeySeed},
-};
+use async_trait::async_trait;
+use sodiumoxide::crypto::hash::sha256;
+use tracing::{debug, info};
 
+#[cfg(feature = "metrics")]
+use crate::metrics;
 use crate::state_machine::{
     events::{DictionaryUpdate, MaskLengthUpdate},
     phases::{Phase, PhaseName, PhaseState, Shared, Sum},
     PhaseStateError,
     StateMachine,
 };
-
-#[cfg(feature = "metrics")]
-use crate::metrics;
-
-use sodiumoxide::crypto::hash::sha256;
+use xaynet_core::{
+    common::RoundSeed,
+    crypto::{ByteObject, EncryptKeyPair, SigningKeySeed},
+};
+use xaynet_macros::metrics;
 
 /// Idle state
 #[derive(Debug)]

--- a/rust/xaynet-server/src/state_machine/phases/mod.rs
+++ b/rust/xaynet-server/src/state_machine/phases/mod.rs
@@ -8,6 +8,11 @@ mod sum2;
 mod unmask;
 mod update;
 
+use async_trait::async_trait;
+use futures::StreamExt;
+use tracing::{debug, error, error_span, info, warn, Span};
+use tracing_futures::Instrument;
+
 pub use self::{
     error::PhaseStateError,
     idle::Idle,
@@ -17,7 +22,10 @@ pub use self::{
     unmask::Unmask,
     update::Update,
 };
-
+#[cfg(feature = "model-persistence")]
+use crate::storage::s3;
+#[cfg(feature = "metrics")]
+use crate::{metrics, metrics::MetricsSender};
 use crate::{
     state_machine::{
         coordinator::CoordinatorState,
@@ -28,16 +36,7 @@ use crate::{
     },
     storage::redis,
 };
-
-#[cfg(feature = "metrics")]
-use crate::{metrics, metrics::MetricsSender};
-
-#[cfg(feature = "model-persistence")]
-use crate::storage::s3;
-
-use futures::StreamExt;
-use tracing::Span;
-use tracing_futures::Instrument;
+use xaynet_macros::metrics;
 
 /// Name of the current phase
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/rust/xaynet-server/src/state_machine/phases/shutdown.rs
+++ b/rust/xaynet-server/src/state_machine/phases/shutdown.rs
@@ -1,3 +1,5 @@
+use async_trait::async_trait;
+
 use crate::state_machine::{
     phases::{Phase, PhaseName, PhaseState, Shared},
     PhaseStateError,

--- a/rust/xaynet-server/src/state_machine/phases/sum.rs
+++ b/rust/xaynet-server/src/state_machine/phases/sum.rs
@@ -1,5 +1,11 @@
 use std::sync::Arc;
 
+use async_trait::async_trait;
+use tokio::time::{timeout, Duration};
+use tracing::{debug, info};
+
+#[cfg(feature = "metrics")]
+use crate::metrics;
 use crate::state_machine::{
     events::DictionaryUpdate,
     phases::{Handler, Phase, PhaseName, PhaseState, PhaseStateError, Shared, Update},
@@ -7,11 +13,7 @@ use crate::state_machine::{
     RequestError,
     StateMachine,
 };
-
-#[cfg(feature = "metrics")]
-use crate::metrics;
-
-use tokio::time::{timeout, Duration};
+use xaynet_macros::metrics;
 
 /// Sum state
 #[derive(Debug)]

--- a/rust/xaynet-server/src/state_machine/phases/sum2.rs
+++ b/rust/xaynet-server/src/state_machine/phases/sum2.rs
@@ -1,16 +1,17 @@
-use xaynet_core::mask::Aggregation;
+use async_trait::async_trait;
+use tokio::time::{timeout, Duration};
+use tracing::{debug, info};
 
+#[cfg(feature = "metrics")]
+use crate::metrics;
 use crate::state_machine::{
     phases::{Handler, Phase, PhaseName, PhaseState, PhaseStateError, Shared, Unmask},
     requests::{StateMachineRequest, Sum2Request},
     RequestError,
     StateMachine,
 };
-
-#[cfg(feature = "metrics")]
-use crate::metrics;
-
-use tokio::time::{timeout, Duration};
+use xaynet_core::mask::Aggregation;
+use xaynet_macros::metrics;
 
 /// Sum2 state
 #[derive(Debug)]

--- a/rust/xaynet-server/src/state_machine/phases/unmask.rs
+++ b/rust/xaynet-server/src/state_machine/phases/unmask.rs
@@ -1,16 +1,21 @@
 use std::{cmp::Ordering, sync::Arc};
 
-use xaynet_core::mask::{Aggregation, MaskObject, Model};
+use async_trait::async_trait;
+#[cfg(feature = "metrics")]
+use tracing::error;
+use tracing::info;
+#[cfg(feature = "model-persistence")]
+use tracing::warn;
 
+#[cfg(feature = "metrics")]
+use crate::metrics;
 use crate::state_machine::{
     events::ModelUpdate,
     phases::{Idle, Phase, PhaseName, PhaseState, PhaseStateError, Shared},
     StateMachine,
     UnmaskGlobalModelError,
 };
-
-#[cfg(feature = "metrics")]
-use crate::metrics;
+use xaynet_core::mask::{Aggregation, MaskObject, Model};
 
 /// Unmask state
 #[derive(Debug)]

--- a/rust/xaynet-server/src/state_machine/phases/update.rs
+++ b/rust/xaynet-server/src/state_machine/phases/update.rs
@@ -1,11 +1,11 @@
 use std::sync::Arc;
 
-use xaynet_core::{
-    mask::{Aggregation, MaskObject},
-    LocalSeedDict,
-    UpdateParticipantPublicKey,
-};
+use async_trait::async_trait;
+use tokio::time::{timeout, Duration};
+use tracing::{debug, info, warn};
 
+#[cfg(feature = "metrics")]
+use crate::metrics;
 use crate::state_machine::{
     events::{DictionaryUpdate, MaskLengthUpdate},
     phases::{Handler, Phase, PhaseName, PhaseState, PhaseStateError, Shared, Sum2},
@@ -13,11 +13,12 @@ use crate::state_machine::{
     RequestError,
     StateMachine,
 };
-
-#[cfg(feature = "metrics")]
-use crate::metrics;
-
-use tokio::time::{timeout, Duration};
+use xaynet_core::{
+    mask::{Aggregation, MaskObject},
+    LocalSeedDict,
+    UpdateParticipantPublicKey,
+};
+use xaynet_macros::metrics;
 
 /// Update state
 #[derive(Debug)]

--- a/rust/xaynet-server/src/state_machine/requests.rs
+++ b/rust/xaynet-server/src/state_machine/requests.rs
@@ -2,6 +2,7 @@
 //! types.
 //!
 //! [`StateMachine`]: crate::state_machine::StateMachine
+
 use std::{
     pin::Pin,
     task::{Context, Poll},
@@ -11,7 +12,9 @@ use derive_more::From;
 use futures::Stream;
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot};
-use tracing::Span;
+use tracing::{trace, Span};
+
+use crate::state_machine::{RequestError, StateMachineResult};
 use xaynet_core::{
     mask::MaskObject,
     message::{Message, Payload, Update},
@@ -26,8 +29,6 @@ use xaynet_core::{
 #[derive(Debug, Error)]
 #[error("the RequestSender cannot be used because the state machine shut down")]
 pub struct StateMachineShutdown;
-
-use crate::state_machine::{RequestError, StateMachineResult};
 
 /// A sum request.
 #[derive(Debug)]

--- a/rust/xaynet-server/src/state_machine/tests/builder.rs
+++ b/rust/xaynet-server/src/state_machine/tests/builder.rs
@@ -1,5 +1,5 @@
-use xaynet_core::{common::RoundSeed, crypto::EncryptKeyPair, mask::MaskConfig};
-
+#[cfg(feature = "model-persistence")]
+use crate::storage::s3;
 use crate::{
     state_machine::{
         events::EventSubscriber,
@@ -10,9 +10,7 @@ use crate::{
     },
     storage::redis,
 };
-
-#[cfg(feature = "model-persistence")]
-use crate::storage::s3;
+use xaynet_core::{common::RoundSeed, crypto::EncryptKeyPair, mask::MaskConfig};
 
 #[derive(Debug)]
 pub struct StateMachineBuilder<P> {

--- a/rust/xaynet-server/src/state_machine/tests/impls.rs
+++ b/rust/xaynet-server/src/state_machine/tests/impls.rs
@@ -1,5 +1,4 @@
 use tracing::Span;
-use xaynet_core::message::Message;
 
 use crate::state_machine::{
     events::{DictionaryUpdate, MaskLengthUpdate},
@@ -8,6 +7,7 @@ use crate::state_machine::{
     StateMachine,
     StateMachineResult,
 };
+use xaynet_core::message::Message;
 
 impl RequestSender {
     pub async fn msg(&self, msg: &Message) -> StateMachineResult {

--- a/rust/xaynet-server/src/state_machine/tests/initializer.rs
+++ b/rust/xaynet-server/src/state_machine/tests/initializer.rs
@@ -1,12 +1,8 @@
+use serial_test::serial;
+
 use super::utils::{mask_settings, model_settings, pet_settings};
 #[cfg(feature = "metrics")]
 use crate::metrics::MetricsSender;
-use crate::{
-    state_machine::{CoordinatorState, StateMachineInitializer},
-    storage::redis,
-};
-use serial_test::serial;
-
 #[cfg(feature = "model-persistence")]
 use crate::{
     settings::RestoreSettings,
@@ -16,6 +12,10 @@ use crate::{
         StateMachineInitializationError,
     },
     storage::{s3, tests::create_global_model},
+};
+use crate::{
+    state_machine::{CoordinatorState, StateMachineInitializer},
+    storage::redis,
 };
 
 #[cfg(feature = "model-persistence")]

--- a/rust/xaynet-server/src/state_machine/tests/mod.rs
+++ b/rust/xaynet-server/src/state_machine/tests/mod.rs
@@ -3,11 +3,7 @@ pub mod impls;
 pub mod initializer;
 pub mod utils;
 
-use xaynet_core::{
-    common::{RoundParameters, RoundSeed},
-    crypto::{ByteObject, EncryptKeyPair},
-    mask::{FromPrimitives, Model},
-};
+use serial_test::serial;
 
 use crate::state_machine::{
     events::Event,
@@ -17,7 +13,11 @@ use crate::state_machine::{
         utils::{enable_logging, generate_summer, generate_updater, Participant},
     },
 };
-use serial_test::serial;
+use xaynet_core::{
+    common::{RoundParameters, RoundSeed},
+    crypto::{ByteObject, EncryptKeyPair},
+    mask::{FromPrimitives, Model},
+};
 
 #[tokio::test]
 #[serial]

--- a/rust/xaynet-server/src/state_machine/tests/utils.rs
+++ b/rust/xaynet-server/src/state_machine/tests/utils.rs
@@ -1,3 +1,19 @@
+use tracing_subscriber::{EnvFilter, FmtSubscriber};
+
+#[cfg(feature = "metrics")]
+use crate::metrics::MetricsSender;
+#[cfg(feature = "model-persistence")]
+use crate::storage::s3;
+use crate::{
+    settings::{MaskSettings, ModelSettings, PetSettings},
+    state_machine::{
+        coordinator::CoordinatorState,
+        events::{EventPublisher, EventSubscriber, ModelUpdate},
+        phases::{PhaseName, Shared},
+        requests::{RequestReceiver, RequestSender},
+    },
+    storage::redis,
+};
 use xaynet_core::{
     common::RoundParameters,
     crypto::{ByteObject, EncryptKeyPair, Signature, SigningKeyPair},
@@ -20,25 +36,6 @@ use xaynet_core::{
     SumParticipantEphemeralPublicKey,
     UpdateSeedDict,
 };
-
-use crate::{
-    settings::{MaskSettings, ModelSettings, PetSettings},
-    state_machine::{
-        coordinator::CoordinatorState,
-        events::{EventPublisher, EventSubscriber, ModelUpdate},
-        phases::{PhaseName, Shared},
-        requests::{RequestReceiver, RequestSender},
-    },
-    storage::redis,
-};
-
-#[cfg(feature = "metrics")]
-use crate::metrics::MetricsSender;
-
-#[cfg(feature = "model-persistence")]
-use crate::storage::s3;
-
-use tracing_subscriber::*;
 
 pub fn enable_logging() {
     let _fmt_subscriber = FmtSubscriber::builder()

--- a/rust/xaynet-server/src/storage/impls.rs
+++ b/rust/xaynet-server/src/storage/impls.rs
@@ -1,10 +1,13 @@
-use crate::state_machine::coordinator::CoordinatorState;
+use std::convert::TryFrom;
+
 use derive_more::{Deref, From, Into};
 use num_enum::TryFromPrimitive;
 use paste::paste;
 use redis::{ErrorKind, FromRedisValue, RedisError, RedisResult, RedisWrite, ToRedisArgs, Value};
-use std::convert::TryFrom;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
+
+use crate::state_machine::coordinator::CoordinatorState;
 use xaynet_core::{
     crypto::{ByteObject, PublicEncryptKey, PublicSigningKey},
     mask::{EncryptedMaskSeed, MaskObject},

--- a/rust/xaynet-server/src/storage/mod.rs
+++ b/rust/xaynet-server/src/storage/mod.rs
@@ -2,6 +2,8 @@ pub(crate) mod impls;
 pub mod redis;
 #[cfg(feature = "model-persistence")]
 pub mod s3;
+#[cfg(test)]
+pub(crate) mod tests;
 
 pub use self::{
     impls::{
@@ -14,6 +16,3 @@ pub use self::{
     },
     redis::{RedisError, RedisResult},
 };
-
-#[cfg(test)]
-pub(crate) mod tests;

--- a/rust/xaynet-server/src/storage/redis.rs
+++ b/rust/xaynet-server/src/storage/redis.rs
@@ -34,6 +34,14 @@
 //!     "latest_global_model_id": global_model_id
 //! }
 //! ```
+
+use std::{collections::HashMap, sync::Arc};
+
+use redis::{aio::ConnectionManager, AsyncCommands, IntoConnectionInfo, Pipeline, Script};
+pub use redis::{RedisError, RedisResult};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tracing::debug;
+
 use crate::{
     state_machine::coordinator::CoordinatorState,
     storage::impls::{
@@ -50,10 +58,6 @@ use crate::{
         SumDictAdd,
     },
 };
-use redis::{aio::ConnectionManager, AsyncCommands, IntoConnectionInfo, Pipeline, Script};
-use std::{collections::HashMap, sync::Arc};
-use tokio::sync::{OwnedSemaphorePermit, Semaphore};
-
 use xaynet_core::{
     mask::{EncryptedMaskSeed, MaskObject},
     LocalSeedDict,
@@ -63,8 +67,6 @@ use xaynet_core::{
     SumParticipantPublicKey,
     UpdateParticipantPublicKey,
 };
-
-pub use redis::{RedisError, RedisResult};
 
 #[derive(Clone)]
 pub struct Client {

--- a/rust/xaynet-server/src/storage/s3.rs
+++ b/rust/xaynet-server/src/storage/s3.rs
@@ -1,4 +1,5 @@
-use crate::settings::{S3BucketsSettings, S3Settings};
+use std::sync::Arc;
+
 use rusoto_core::{credential::StaticProvider, request::TlsError, HttpClient, RusotoError};
 use rusoto_s3::{
     CreateBucketError,
@@ -16,10 +17,11 @@ use rusoto_s3::{
     StreamingBody,
     S3,
 };
-use std::sync::Arc;
 use thiserror::Error;
 use tokio::io::AsyncReadExt;
+use tracing::debug;
 
+use crate::settings::{S3BucketsSettings, S3Settings};
 use xaynet_core::mask::Model;
 
 type S3Result<T> = Result<T, S3Error>;

--- a/rust/xaynet-server/src/storage/tests/mod.rs
+++ b/rust/xaynet-server/src/storage/tests/mod.rs
@@ -1,5 +1,6 @@
-use crate::storage::{impls::SeedDictUpdate, redis::Client};
 use num::{bigint::BigUint, traits::identities::Zero};
+
+use crate::storage::{impls::SeedDictUpdate, redis::Client};
 use xaynet_core::{
     crypto::{ByteObject, EncryptKeyPair, SigningKeyPair},
     mask::{BoundType, DataType, EncryptedMaskSeed, GroupType, MaskConfig, MaskObject, ModelType},


### PR DESCRIPTION
**References**
- [XN-1163](https://xainag.atlassian.net/browse/XN-1163)

**Summary**
- replaces the 2015 edition's `#[macro_use]` imports with the 2018 edition's `use` import, see the [rust edition guide](https://doc.rust-lang.org/edition-guide/rust-2018/macros/macro-changes.html)
- commits are grouped by workspace to help readability
- cleans up some imports

one thing i noted while working on this is that the `metrics!` proc macro has the `#[cfg(feature = "metrics")]` flag hidden inside of its definition in the `xaynet_macros` crate. this has some implications:
- `metrics!` will do nothing when the flag is not enabled, which is not clear from the calling site
- `metrics!` must be imported when called whether or not the flag is enabled

i'd suggest to remove the flag from within the proc macro and put it at the caller site like usual.
```rust
#[cfg(feature = "metrics")]
use xaynet_macros::metrics;

// function body
    #[cfg(feature = "metrics")]
    metrics!(...);
```
should we do this in a separate pr or should we include it in this one since the changes are quickly done, wdyt?

**Todo**
- [x] rebase on client refactoring
- [x] decided on metrics proc macro: no change for now
