### PR TITLE
Impl storage traits

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -583,6 +583,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
+name = "displaydoc"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc2ab4d5a16117f9029e9a6b5e4e79f4c67f6519bc134210d4d4a04ba31f41b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dtoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3569,6 +3580,7 @@ dependencies = [
  "chrono",
  "config",
  "derive_more",
+ "displaydoc",
  "fancy-regex",
  "futures",
  "hex",

--- a/rust/xaynet-server/Cargo.toml
+++ b/rust/xaynet-server/Cargo.toml
@@ -32,7 +32,9 @@ derive_more = { version = "0.99.10", default-features = false, features = [
     "index_mut",
     "into",
 ] }
+displaydoc = "0.1.7"
 futures = "0.3.5"
+hex = "0.4.2"
 num = { version = "0.3.0", features = ["serde"] }
 num_enum = "0.5.1"
 paste = "1.0.1"
@@ -75,7 +77,6 @@ chrono = { version = "0.4.15", optional = true }
 
 # feature: model-persistence
 fancy-regex = { version = "0.4.0", optional = true }
-hex = { version = "0.4.2", optional = true }
 rusoto_core = { version = "0.45.0", optional = true }
 rusoto_s3 = { version = "0.45.0", optional = true }
 
@@ -95,5 +96,5 @@ path = "src/bin/main.rs"
 default = []
 full = ["metrics", "model-persistence", "tls"]
 metrics = ["chrono", "influxdb"]
-model-persistence = ["fancy-regex", "hex", "rusoto_core", "rusoto_s3"]
+model-persistence = ["fancy-regex", "rusoto_core", "rusoto_s3"]
 tls = ["warp/tls"]

--- a/rust/xaynet-server/src/state_machine/mod.rs
+++ b/rust/xaynet-server/src/state_machine/mod.rs
@@ -126,7 +126,7 @@ use crate::metrics::MetricsSender;
 use crate::{settings::RestoreSettings, storage::s3};
 use crate::{
     settings::{MaskSettings, ModelSettings, PetSettings},
-    storage::{redis, MaskDictIncrError, RedisError, SeedDictUpdateError, SumDictAddError},
+    storage::{redis, LocalSeedDictAddError, MaskScoreIncrError, RedisError, SumPartAddError},
 };
 #[cfg(feature = "model-persistence")]
 use xaynet_core::mask::Model;
@@ -135,26 +135,33 @@ use xaynet_core::mask::UnmaskingError;
 /// Error returned when the state machine fails to handle a request
 #[derive(Debug, Error)]
 pub enum RequestError {
+    /// the message was rejected
     #[error("the message was rejected")]
     MessageRejected,
 
+    /// the model or scalar sent by the participant could not be aggregated
     #[error("invalid update: the model or scalar sent by the participant could not be aggregated")]
     AggregationFailed,
 
+    /// the request could not be processed due to an internal error
     #[error("the request could not be processed due to an internal error: {0}")]
     InternalError(&'static str),
 
+    /// a redis request failed
     #[error("redis request failed: {0}")]
     Redis(#[from] RedisError),
 
+    /// adding a local seed dict to the seed dictionary failed
     #[error(transparent)]
-    SeedDictUpdate(#[from] SeedDictUpdateError),
+    LocalSeedDictAdd(#[from] LocalSeedDictAddError),
 
+    /// adding a sum participant to the sum dictionary failed
     #[error(transparent)]
-    SumDictAdd(#[from] SumDictAddError),
+    SumPartAdd(#[from] SumPartAddError),
 
+    /// incrementing a mask score failed
     #[error(transparent)]
-    MaskDictIncr(#[from] MaskDictIncrError),
+    MaskScoreIncr(#[from] MaskScoreIncrError),
 }
 
 pub type StateMachineResult = Result<(), RequestError>;

--- a/rust/xaynet-server/src/storage/api.rs
+++ b/rust/xaynet-server/src/storage/api.rs
@@ -189,3 +189,67 @@ where
     }
 }
 
+/// A wrapper that contains the result of the "add sum participant" operation.
+#[derive(Deref)]
+pub struct SumPartAdd(pub(crate) Result<(), SumPartAddError>);
+
+impl SumPartAdd {
+    /// Unwraps this wrapper, returning the underlying result.
+    pub fn into_inner(self) -> Result<(), SumPartAddError> {
+        self.0
+    }
+}
+
+/// Error that can occur when adding a sum participant to the [`SumDict`].
+#[derive(Display, Error, Debug, TryFromPrimitive)]
+#[repr(i64)]
+pub enum SumPartAddError {
+    /// sum participant already exists
+    AlreadyExists = 0,
+}
+
+/// A wrapper that contains the result of the "add local seed dict" operation.
+#[derive(Deref)]
+pub struct LocalSeedDictAdd(pub(crate) Result<(), LocalSeedDictAddError>);
+
+impl LocalSeedDictAdd {
+    /// Unwraps this wrapper, returning the underlying result.
+    pub fn into_inner(self) -> Result<(), LocalSeedDictAddError> {
+        self.0
+    }
+}
+
+/// Error that can occur when adding a local seed dict to the [`SeedDict`].
+#[derive(Display, Error, Debug, TryFromPrimitive)]
+#[repr(i64)]
+pub enum LocalSeedDictAddError {
+    /// the length of the local seed dict and the length of sum dict are not equal
+    LengthMisMatch = -1,
+    /// local dict contains an unknown sum participant
+    UnknownSumParticipant = -2,
+    /// update participant already submitted an update
+    UpdatePkAlreadySubmitted = -3,
+    /// update participant already exists in the inner update seed dict
+    UpdatePkAlreadyExistsInUpdateSeedDict = -4,
+}
+
+/// A wrapper that contains the result of the "increment mask score" operation.
+#[derive(Deref)]
+pub struct MaskScoreIncr(pub(crate) Result<(), MaskScoreIncrError>);
+
+impl MaskScoreIncr {
+    /// Unwraps this wrapper, returning the underlying result.
+    pub fn into_inner(self) -> Result<(), MaskScoreIncrError> {
+        self.0
+    }
+}
+
+/// Error that can occur when incrementing a mask score.
+#[derive(Display, Error, Debug, TryFromPrimitive)]
+#[repr(i64)]
+pub enum MaskScoreIncrError {
+    /// unknown sum participant
+    UnknownSumPk = -1,
+    /// sum participant submitted a mask already
+    MaskAlreadySubmitted = -2,
+}

--- a/rust/xaynet-server/src/storage/api.rs
+++ b/rust/xaynet-server/src/storage/api.rs
@@ -1,0 +1,191 @@
+//! Storage API.
+
+use async_trait::async_trait;
+use derive_more::Deref;
+use displaydoc::Display;
+use num_enum::TryFromPrimitive;
+use thiserror::Error;
+
+use crate::state_machine::coordinator::CoordinatorState;
+use xaynet_core::{
+    common::RoundSeed,
+    crypto::ByteObject,
+    mask::{MaskObject, Model},
+    LocalSeedDict,
+    SeedDict,
+    SumDict,
+    SumParticipantEphemeralPublicKey,
+    SumParticipantPublicKey,
+    UpdateParticipantPublicKey,
+};
+
+/// The error type for storage operations that are not directly related to application domain.
+/// These include, for example IO errors like broken pipe, file not found, out-of-memory, etc.
+pub type StorageError = anyhow::Error;
+
+/// The result of the storage operation.
+pub type StorageResult<T> = Result<T, StorageError>;
+
+#[async_trait]
+/// An abstract coordinator storage.
+pub trait CoordinatorStorage
+where
+    Self: Clone + Send + Sync + 'static,
+{
+    /// Sets a [`CoordinatorState`].
+    ///
+    /// # Behavior
+    ///
+    /// - If no state has been set yet, set the state and return `StorageResult::Ok(())`.
+    /// - If a state already exists, override the state and return `StorageResult::Ok(())`.
+    async fn set_coordinator_state(&mut self, state: &CoordinatorState) -> StorageResult<()>;
+
+    /// Returns a [`CoordinatorState`].
+    ///
+    /// # Behavior
+    ///
+    /// - If no state has been set yet, return `StorageResult::Ok(Option::None)`.
+    /// - If a state exists, return `StorageResult::Ok(Some(CoordinatorState))`.
+    async fn coordinator_state(&mut self) -> StorageResult<Option<CoordinatorState>>;
+
+    /// Adds a sum participant entry to the [`SumDict`].
+    ///
+    /// # Behavior
+    ///
+    /// - If a sum participant has been successfully added, return `StorageResult::Ok(SumPartAdd)`
+    ///   containing a `Result::Ok(())`.
+    /// - If the participant could not be added due to a PET protocol error, return
+    ///   the corresponding `StorageResult::Ok(SumPartAdd)` containing a
+    ///   `Result::Err(SumPartAddError)`.
+    async fn add_sum_participant(
+        &mut self,
+        pk: &SumParticipantPublicKey,
+        ephm_pk: &SumParticipantEphemeralPublicKey,
+    ) -> StorageResult<SumPartAdd>;
+
+    /// Returns the [`SumDict`].
+    ///
+    /// # Behavior
+    ///
+    /// - If the sum dict does not exist, return `StorageResult::Ok(Option::None)`.
+    /// - If the sum dict exists, return `StorageResult::Ok(Option::Some(SumDict))`.
+    async fn sum_dict(&mut self) -> StorageResult<Option<SumDict>>;
+
+    /// Adds a local [`LocalSeedDict`] of the given [`UpdateParticipantPublicKey`] to the [`SeedDict`].
+    ///
+    /// # Behavior
+    ///
+    /// - If the local seed dict has been successfully added, return
+    ///   `StorageResult::Ok(LocalSeedDictAdd)` containing a `Result::Ok(())`.
+    /// - If the local seed dict could not be added due to a PET protocol error, return
+    ///   the corresponding `StorageResult::Ok(LocalSeedDictAdd)` containing a
+    ///   `Result::Err(LocalSeedDictAddError)`.
+    async fn add_local_seed_dict(
+        &mut self,
+        update_pk: &UpdateParticipantPublicKey,
+        local_seed_dict: &LocalSeedDict,
+    ) -> StorageResult<LocalSeedDictAdd>;
+
+    /// Returns the [`SeedDict`].
+    ///
+    /// # Behavior
+    ///
+    /// - If the seed dict does not exist, return `StorageResult::Ok(Option::None)`.
+    /// - If the seed dict exists, return `StorageResult::Ok(Option::Some(SeedDict))`.
+    async fn seed_dict(&mut self) -> StorageResult<Option<SeedDict>>;
+
+    /// Increments the mask score with the given [`MaskObject`]b by one.
+    ///
+    /// # Behavior
+    ///
+    /// - If the mask score has been successfully incremented, return
+    ///   `StorageResult::Ok(MaskScoreIncr)` containing a `Result::Ok(())`.
+    /// - If the mask score could not be incremented due to a PET protocol error,
+    ///   return the corresponding `Result::Ok(MaskScoreIncr)` containing a
+    ///   `Result::Err(MaskScoreIncrError)`.
+    async fn incr_mask_score(
+        &mut self,
+        pk: &SumParticipantPublicKey,
+        mask: &MaskObject,
+    ) -> StorageResult<MaskScoreIncr>;
+
+    /// Returns the two masks with the highest score.
+    ///
+    /// # Behavior
+    ///
+    /// - If no masks exist, return `Result::Ok(Option::None)`.
+    /// - If only one mask exists, return this mask
+    ///   `StorageResult::Ok(Option::Some(Vec<(MaskObject, u64)>))`.
+    /// - If two masks exist with the same score, return both
+    ///   `StorageResult::Ok(Option::Some(Vec<(MaskObject, u64)>))`.
+    /// - If two masks exist with the different score, return
+    ///   both in descending order `StorageResult::Ok(Option::Some(Vec<(MaskObject, u64)>))`.
+    async fn best_masks(&mut self) -> StorageResult<Option<Vec<(MaskObject, u64)>>>;
+
+    /// Returns the number of unique masks.
+    async fn number_of_unique_masks(&mut self) -> StorageResult<u64>;
+
+    /// Deletes all coordinator data. This includes the coordinator
+    /// state as well as the [`SumDict`], [`SeedDict`] and `mask` dictionary.
+    async fn delete_coordinator_data(&mut self) -> StorageResult<()>;
+
+    /// Deletes the [`SumDict`], [`SeedDict`] and `mask` dictionary.
+    async fn delete_dicts(&mut self) -> StorageResult<()>;
+
+    /// Sets the latest global model id.
+    ///
+    /// # Behavior
+    ///
+    /// - If no global model id has been set yet, set the new id and return `StorageResult::Ok(())`.
+    /// - If the global model id already exists, override with the new id and
+    ///   return `StorageResult::Ok(())`.
+    async fn set_latest_global_model_id(&mut self, id: &str) -> StorageResult<()>;
+
+    /// Returns the latest global model id.
+    ///
+    /// # Behavior
+    ///
+    /// - If the global model id does not exist, return `StorageResult::Ok(None)`.
+    /// - If the global model id exists, return `StorageResult::Ok(Some(String)))`.
+    async fn latest_global_model_id(&mut self) -> StorageResult<Option<String>>;
+}
+
+#[async_trait]
+/// An abstract model storage.
+pub trait ModelStorage
+where
+    Self: Clone + Send + Sync + 'static,
+{
+    /// Sets a global model.
+    ///
+    /// # Behavior
+    ///
+    /// - If the global model already exists (has the same model id), return
+    ///   `StorageResult::Err(StorageError))`.
+    /// - If the global model does not exist, set the model and return `StorageResult::Ok(String)`
+    async fn set_global_model(
+        &mut self,
+        round_id: u64,
+        round_seed: &RoundSeed,
+        global_model: &Model,
+    ) -> StorageResult<String>;
+
+    /// Returns a global model.
+    ///
+    /// # Behavior
+    ///
+    /// - If the global model does not exist, return `StorageResult::Ok(Option::None)`.
+    /// - If the global model exists, return `StorageResult::Ok(Option::Some(Model))`.
+    async fn global_model(&mut self, id: &str) -> StorageResult<Option<Model>>;
+
+    /// Creates a unique global model id by using the round id and the round seed in which
+    /// the global model was created.
+    ///
+    /// The format of the default implementation is `roundid_roundseed`,
+    /// where the [`RoundSeed`] is encoded in hexadecimal.
+    fn create_global_model_id(round_id: u64, round_seed: &RoundSeed) -> String {
+        let round_seed = hex::encode(round_seed.as_slice());
+        format!("{}_{}", round_id, round_seed)
+    }
+}
+

--- a/rust/xaynet-server/src/storage/mod.rs
+++ b/rust/xaynet-server/src/storage/mod.rs
@@ -1,18 +1,25 @@
+pub mod api;
 pub(crate) mod impls;
 pub mod redis;
 #[cfg(feature = "model-persistence")]
 pub mod s3;
+pub mod store;
 #[cfg(test)]
 pub(crate) mod tests;
 
 pub use self::{
-    impls::{
-        MaskDictIncr,
-        MaskDictIncrError,
-        SeedDictUpdate,
-        SeedDictUpdateError,
-        SumDictAdd,
-        SumDictAddError,
+    api::{
+        CoordinatorStorage,
+        LocalSeedDictAdd,
+        LocalSeedDictAddError,
+        MaskScoreIncr,
+        MaskScoreIncrError,
+        ModelStorage,
+        StorageError,
+        StorageResult,
+        SumPartAdd,
+        SumPartAddError,
     },
     redis::{RedisError, RedisResult},
+    store::Store,
 };

--- a/rust/xaynet-server/src/storage/store.rs
+++ b/rust/xaynet-server/src/storage/store.rs
@@ -1,0 +1,144 @@
+//! A generic store.
+
+use async_trait::async_trait;
+
+use crate::{
+    state_machine::coordinator::CoordinatorState,
+    storage::{
+        CoordinatorStorage,
+        LocalSeedDictAdd,
+        MaskScoreIncr,
+        ModelStorage,
+        StorageResult,
+        SumPartAdd,
+    },
+};
+use xaynet_core::{
+    common::RoundSeed,
+    mask::{MaskObject, Model},
+    LocalSeedDict,
+    SeedDict,
+    SumDict,
+    SumParticipantEphemeralPublicKey,
+    SumParticipantPublicKey,
+    UpdateParticipantPublicKey,
+};
+
+#[derive(Clone)]
+/// A generic store.
+pub struct Store<C, M>
+where
+    C: CoordinatorStorage,
+    M: ModelStorage,
+{
+    /// A coordinator store.
+    coordinator: C,
+    /// A model store.
+    model: M,
+}
+
+impl<C, M> Store<C, M>
+where
+    C: CoordinatorStorage,
+    M: ModelStorage,
+{
+    /// Creates a new [`Store`].
+    pub fn new(coordinator: C, model: M) -> Self {
+        Self { coordinator, model }
+    }
+}
+
+#[async_trait]
+impl<C, M> CoordinatorStorage for Store<C, M>
+where
+    C: CoordinatorStorage,
+    M: ModelStorage,
+{
+    async fn set_coordinator_state(&mut self, state: &CoordinatorState) -> StorageResult<()> {
+        self.coordinator.set_coordinator_state(state).await
+    }
+
+    async fn coordinator_state(&mut self) -> StorageResult<Option<CoordinatorState>> {
+        self.coordinator.coordinator_state().await
+    }
+
+    async fn add_sum_participant(
+        &mut self,
+        pk: &SumParticipantPublicKey,
+        ephm_pk: &SumParticipantEphemeralPublicKey,
+    ) -> StorageResult<SumPartAdd> {
+        self.coordinator.add_sum_participant(pk, ephm_pk).await
+    }
+
+    async fn sum_dict(&mut self) -> StorageResult<Option<SumDict>> {
+        self.coordinator.sum_dict().await
+    }
+
+    async fn add_local_seed_dict(
+        &mut self,
+        update_pk: &UpdateParticipantPublicKey,
+        local_seed_dict: &LocalSeedDict,
+    ) -> StorageResult<LocalSeedDictAdd> {
+        self.coordinator
+            .add_local_seed_dict(update_pk, local_seed_dict)
+            .await
+    }
+
+    async fn seed_dict(&mut self) -> StorageResult<Option<SeedDict>> {
+        self.coordinator.seed_dict().await
+    }
+
+    async fn incr_mask_score(
+        &mut self,
+        pk: &SumParticipantPublicKey,
+        mask: &MaskObject,
+    ) -> StorageResult<MaskScoreIncr> {
+        self.coordinator.incr_mask_score(pk, mask).await
+    }
+
+    async fn best_masks(&mut self) -> StorageResult<Option<Vec<(MaskObject, u64)>>> {
+        self.coordinator.best_masks().await
+    }
+
+    async fn number_of_unique_masks(&mut self) -> StorageResult<u64> {
+        self.coordinator.number_of_unique_masks().await
+    }
+
+    async fn delete_coordinator_data(&mut self) -> StorageResult<()> {
+        self.coordinator.delete_coordinator_data().await
+    }
+
+    async fn delete_dicts(&mut self) -> StorageResult<()> {
+        self.coordinator.delete_dicts().await
+    }
+
+    async fn set_latest_global_model_id(&mut self, id: &str) -> StorageResult<()> {
+        self.coordinator.set_latest_global_model_id(id).await
+    }
+
+    async fn latest_global_model_id(&mut self) -> StorageResult<Option<String>> {
+        self.coordinator.latest_global_model_id().await
+    }
+}
+
+#[async_trait]
+impl<C, M> ModelStorage for Store<C, M>
+where
+    C: CoordinatorStorage,
+    M: ModelStorage,
+{
+    async fn set_global_model(
+        &mut self,
+        round_id: u64,
+        round_seed: &RoundSeed,
+        global_model: &Model,
+    ) -> StorageResult<String> {
+        self.model
+            .set_global_model(round_id, &round_seed, &global_model)
+            .await
+    }
+
+    async fn global_model(&mut self, id: &str) -> StorageResult<Option<Model>> {
+        self.model.global_model(id).await
+    }
+}

--- a/rust/xaynet-server/src/storage/tests/mod.rs
+++ b/rust/xaynet-server/src/storage/tests/mod.rs
@@ -1,6 +1,6 @@
 use num::{bigint::BigUint, traits::identities::Zero};
 
-use crate::storage::{impls::SeedDictUpdate, redis::Client};
+use crate::storage::{redis::Client, LocalSeedDictAdd};
 use xaynet_core::{
     crypto::{ByteObject, EncryptKeyPair, SigningKeyPair},
     mask::{BoundType, DataType, EncryptedMaskSeed, GroupType, MaskConfig, MaskObject, ModelType},
@@ -116,7 +116,7 @@ pub async fn create_and_write_sum_participant_entries(
 pub async fn write_local_seed_entries(
     client: &Client,
     local_seed_entries: &[(UpdateParticipantPublicKey, LocalSeedDict)],
-) -> Vec<SeedDictUpdate> {
+) -> Vec<LocalSeedDictAdd> {
     let mut update_result = Vec::new();
 
     for (update_pk, local_seed_dict) in local_seed_entries {


### PR DESCRIPTION
**Summary**
- added a `CoordinatorStorage`and a `ModelStorage` trait 
The reason why I chose these names instead of `VolatileStorage` and `PersistentStorage` is that the coordinator state also has values ​​that have to be persistence like the `round_id`. 
- refactored pet wrappers
- added a generic store

