### PR TITLE
update tarpaulin

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -230,7 +230,7 @@ jobs:
         run: docker-compose up -d influxdb minio redis
 
       - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1.2
+        uses: actions-rs/tarpaulin@v0.1
         with:
           args: '--manifest-path rust/Cargo.toml --all-features --force-clean --lib --ignore-tests'
 


### PR DESCRIPTION
fixes `The add-path command is deprecated and will be disabled on November 16th. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/`