### PR TITLE
use tarpaulin version 0.16

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -232,6 +232,7 @@ jobs:
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
+          version: '0.16.0'
           args: '--manifest-path rust/Cargo.toml --all-features --force-clean --lib --ignore-tests'
 
       - name: Stop docker-compose


### PR DESCRIPTION
The new release of tarpaulin `v0.17.0` causes segfaults when running our tests.
I don't know yet what the problem is. This pr changes the version back to tarpaulin `v0.16.0`
