### PR TITLE
add Phase<NewRound> test

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -538,6 +538,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,6 +598,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "downcast"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
 
 [[package]]
 name = "dtoa"
@@ -678,6 +690,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
+dependencies = [
+ "num-traits 0.2.14",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,6 +728,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69a039c3498dc930fe810151a34ba0c1c70b02b8625035592e74432f678591f2"
 
 [[package]]
 name = "fuchsia-cprng"
@@ -1374,6 +1401,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cabea45a7fc0e37093f4f30a5e2b62602253f91791c057d5f0470c63260c3d"
+dependencies = [
+ "cfg-if 0.1.10",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c461918bf7f59eefb1459252756bf2351a995d6bd510d0b2061bd86bcdabfa6"
+dependencies = [
+ "cfg-if 0.1.10",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "multipart"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1430,6 +1484,12 @@ dependencies = [
  "memchr",
  "version_check",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num"
@@ -1725,6 +1785,35 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "predicates"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96bfead12e90dccead362d62bb2c90a5f6fc4584963645bc7f71a735e0b0735a"
+dependencies = [
+ "difference",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e63c4859013b38a76eca2414c64911fba30def9e3202ac461a2d22831220124"
+dependencies = [
+ "predicates-core",
+ "treeline",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -3132,6 +3221,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "treeline"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
+
+[[package]]
 name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3582,6 +3677,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "derive_more",
+ "mockall",
  "num",
  "reqwest",
  "serde 1.0.117",

--- a/rust/xaynet-sdk/Cargo.toml
+++ b/rust/xaynet-sdk/Cargo.toml
@@ -32,6 +32,7 @@ bincode = { version = "1.3.1", optional = true }
 reqwest = { version = "0.10.8", default-features = false, optional = true }
 
 [dev-dependencies]
+mockall = "0.8.3"
 num = { version = "0.3.0", features = ["serde"] }
 serde_json = "1.0.58"
 tokio = { version = "0.2.22", features = ["rt-core", "macros"] }

--- a/rust/xaynet-sdk/src/state_machine/io.rs
+++ b/rust/xaynet-sdk/src/state_machine/io.rs
@@ -26,6 +26,8 @@ where
     Box::new(StateMachineIO::new(xaynet_client, model_store, notifier))
 }
 
+#[cfg(test)]
+type DynModel = Box<(dyn ::std::convert::AsRef<xaynet_core::mask::Model> + Send)>;
 /// A trait that gathers all the [`Notify`], [`XaynetClient`] and [`ModelStore`]
 /// methods.
 ///
@@ -40,6 +42,7 @@ where
 /// Box<dyn IO> // allowed
 /// Box<dyn ModelStore + Notify + XaynetClient // not allowed
 /// ```
+#[cfg_attr(test, mockall::automock(type Model=DynModel;))]
 #[async_trait]
 pub(crate) trait IO: Send + 'static {
     type Model;

--- a/rust/xaynet-sdk/src/state_machine/mod.rs
+++ b/rust/xaynet-sdk/src/state_machine/mod.rs
@@ -9,12 +9,67 @@ mod state_machine;
 
 // It is useful to re-export everything within this module because
 // there are lot of interdependencies between all the sub-modules
+#[cfg(test)]
+use self::io::MockIO;
 use self::{
     io::{boxed_io, IO},
     phase::{IntoPhase, Phase, PhaseIo, Progress, SharedState, State, Step},
     phases::{Awaiting, NewRound, Sum, Sum2, Update},
 };
+
 pub use self::{
     phase::SerializableState,
     state_machine::{StateMachine, TransitionOutcome},
 };
+
+#[cfg(test)]
+pub(crate) mod testutils {
+    use xaynet_core::{
+        common::{RoundParameters, RoundSeed},
+        crypto::{ByteObject, EncryptKeySeed, SigningKeyPair, SigningKeySeed},
+        mask::{self, MaskConfig},
+    };
+
+    use crate::settings::MaxMessageSize;
+
+    use super::*;
+
+    /// Task for which the round parameters should be generated.
+    #[derive(Debug, PartialEq, Eq)]
+    pub enum SelectFor {
+        /// Create round parameters that always select participants for the sum task
+        Sum,
+        /// Create round parameters that always select participants for the update task
+        Update,
+        /// Create round parameters that never select participants
+        None,
+    }
+
+    pub fn mask_config() -> MaskConfig {
+        MaskConfig {
+            group_type: mask::GroupType::Prime,
+            data_type: mask::DataType::F32,
+            bound_type: mask::BoundType::B0,
+            model_type: mask::ModelType::M3,
+        }
+    }
+
+    pub fn round_params(task: SelectFor) -> RoundParameters {
+        RoundParameters {
+            pk: EncryptKeySeed::zeroed().derive_encrypt_key_pair().0,
+            sum: if task == SelectFor::Sum { 1.0 } else { 0.0 },
+            update: if task == SelectFor::Update { 1.0 } else { 0.0 },
+            seed: RoundSeed::zeroed(),
+        }
+    }
+
+    pub fn shared_state(task: SelectFor) -> SharedState {
+        SharedState {
+            keys: SigningKeyPair::derive_from_seed(&SigningKeySeed::zeroed()),
+            mask_config: mask_config().into(),
+            scalar: 1.0,
+            message_size: MaxMessageSize::unlimited(),
+            round_params: round_params(task),
+        }
+    }
+}


### PR DESCRIPTION
This first unit test paves the way for writing unit tests for all the
state machine. The crux of it is the `MockIO` type that can be used to
avoid simulating a coordinator.