### PR TITLE
alternative aggregation PoC

### DIFF
--- a/configs/docker-dev.toml
+++ b/configs/docker-dev.toml
@@ -14,8 +14,8 @@ min_sum_time = 5
 min_update_time = 10
 max_sum_time = 3600
 max_update_time = 3600
-sum = 0.01
-update = 0.1
+sum = 0.5
+update = 0.9
 
 [mask]
 group_type = "Prime"
@@ -31,7 +31,7 @@ url = "http://influxdb:8086"
 db = "metrics"
 
 [redis]
-url = "redis://redis"
+url = "redis://127.00.0.1/"
 
 [s3]
 access_key = "minio"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -946,6 +946,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 
 [[package]]
+name = "hist"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca1d61bc7e668d28d2a9759992dc83e73461f6efc5da114d5ab8502780cebd6c"
+
+[[package]]
 name = "hmac"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3532,6 +3538,7 @@ dependencies = [
  "anyhow",
  "bitflags",
  "derive_more",
+ "hist",
  "num",
  "paste",
  "rand 0.7.3",

--- a/rust/examples/test-drive/main.rs
+++ b/rust/examples/test-drive/main.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<(), ClientError> {
 
     // dummy local model for clients
     let len = opt.len as usize;
-    let model = Arc::new(Model::from_primitives(vec![0; len].into_iter()).unwrap());
+    // let model = Arc::new(Model::from_primitives(vec![0; len].into_iter()).unwrap());
 
     // optional certificates for TLS server authentication
     let certificates = opt
@@ -39,6 +39,17 @@ async fn main() -> Result<(), ClientError> {
         .transpose()?;
 
     for id in 0..opt.nb_client {
+        let mut v = Vec::with_capacity(len);
+        for i in 0..len as u32 {
+            if i == id % (len as u32) {
+                v.push(1)
+            } else {
+                v.push(0)
+            }
+        }
+        println!("private model {:?}", v);
+        let it = v.into_iter();
+        let model = Arc::new(Model::from_primitives(it).unwrap());
         spawn_participant(
             id as u32,
             &opt.url,
@@ -53,6 +64,7 @@ async fn main() -> Result<(), ClientError> {
 }
 
 fn generate_agent_config() -> PetSettings {
+    // TODO check this config is ok
     let mask_config = MaskConfig {
         group_type: GroupType::Prime,
         data_type: DataType::F32,

--- a/rust/examples/test-drive/participant.rs
+++ b/rust/examples/test-drive/participant.rs
@@ -64,6 +64,7 @@ impl Agent {
 
 impl Participant {
     pub fn new(settings: PetSettings, xaynet_client: Client, model: Arc<Model>) -> (Self, Agent) {
+        info!("private model {:?}", model);
         let (tx, rx) = mpsc::channel::<Event>(10);
         let notifier = Notifier(tx);
         let agent = Agent::new(settings, xaynet_client.clone(), LocalModel(model), notifier);

--- a/rust/xaynet-core/Cargo.toml
+++ b/rust/xaynet-core/Cargo.toml
@@ -27,6 +27,7 @@ derive_more = { version = "0.99.10", default-features = false, features = [
     "index_mut",
     "into",
 ] }
+hist = "0.1.0"
 num = { version = "0.3.0", features = ["serde"] }
 paste = "1.0.1"
 rand = "0.7.3"


### PR DESCRIPTION
**Warning.** The changes here are meant just for illustrative PoC purposes, and should not be merged.

This branch contains some test code to prove that it is possible, in principle, to support an alternative aggregation to "federated averaging" in the PET protocol. The particular example illustrated here is a _histogram_ aggregation. A quick breakdown of the experiment:

- the coordinator and participants are assumed to be in agreement about the ranges of values in the histogram, e.g. `0 - 5`, `5 - 10`, `10 - 15`, `15 - 20`. 
- the test-drive is used to simulate clients providing a "measurement" in one of those ranges, e.g. for a measurement of 7.5, this falls into the `5 - 10` range. To convey this range to the coordinator, it would construct a "model" `[0, 1, 0, 0]`.
- the PET protocol runs as usual (not completely true - explained later), so that the coordinator learns none of the individual models, but still unmasks their overall sum. From this, the coordinator has the histogram.

In a particular test run of this, spinning up a coordinator and running the test-drive with `-n 10`, I observed

- 7 update participants computed a masked model. Of these:
- 2 sent `[1, 0, 0, 0]`
- 3 sent `[0, 1, 0, 0]`
- 2 sent `[0, 0, 0, 1]`

On the coordinator, the unmasked model and histogram is visible in the console output:

```
histogram for [2, 3, 0, 2]

    *        
*   *       *
*   *       *
*************
```
**Further remarks.** 

- with some refinements to the histogram protocol above (not shown here), it is possible to compute other kinds of aggregations, such as a maximum or minimum. This is still done in a privacy-preserving way (whether these cover a reasonable amount of our mobile analytics use cases, is still to be investigated).
- how one _parametrises_ the aggregation, e.g. switch between averaging or histogram or something else, is something to be considered elsewhere.
- the test-drive still uses dummy models (just in this slightly different form). In the real implementation, a client would construct a model based on some value accessible on the device.
- as mentioned above, every party was assumed to know the ranges of the histogram upfront. In practice, this would need to be communicated somehow - clients need this information to compute their models.
- a small modification was made to the unmasking part of the PET protocol - we skip the "correction" step which re-scales the unmasked vector. The reason is because we would like a straightforward _sum_ of the models, rather than a weighted average. 
- (minor point) to print the mini-histogram, I used a tiny crate `hist`. While the above output looks sensible, my mileage varied a lot! it behaves a little peculiarly, sometimes adding / removing a point. It's not documented so perhaps I'm misusing it.

