### PR TITLE
update dependencies

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -263,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.62"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1770ced377336a88a67c473594ccc14eca6f4559217c34f64aac8f83d641b40"
+checksum = "ad9c6140b5a2c7db40ea56eb1821245e5362b44385c05b76288b1a599934ac87"
 
 [[package]]
 name = "cfg-if"
@@ -319,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "4.3.2"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2809f67365382d65fd2b6d9c22577231b954ed27400efeafbe687bda75abcc0b"
+checksum = "b9417a0c314565e2abffaece67e95a8cb51f9238cd39f3764d9dfdf09e72b20c"
 dependencies = [
  "bytes",
  "futures-util",
@@ -845,7 +845,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project 1.0.1",
+ "pin-project 1.0.2",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1041,7 +1041,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.1",
+ "pin-project 1.0.2",
  "socket2",
  "tokio",
  "tower-service",
@@ -1721,11 +1721,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee41d838744f60d959d7074e3afb6b35c7456d0f61cad38a24e35e6553f73841"
+checksum = "9ccc2237c2c489783abd8c4c80e5450fc0e98644555b1364da68cc29aa151ca7"
 dependencies = [
- "pin-project-internal 1.0.1",
+ "pin-project-internal 1.0.2",
 ]
 
 [[package]]
@@ -1741,9 +1741,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a4ffa594b66bff340084d4081df649a7dc049ac8d7fc458d8e628bfbbb2f86"
+checksum = "f8e8d2bf0b23038a4424865103a4df472855692821aab4e4f5c3312d461d9e5f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2183,9 +2183,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.15"
+version = "0.16.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "952cd6b98c85bbc30efa1ba5783b8abf12fec8b3287ffa52605b9432313e34e4"
+checksum = "b72b84d47e8ec5a4f2872e8262b8f8256c5be1c938a7d6d3a867a3ba8f722f74"
 dependencies = [
  "cc",
  "libc",
@@ -2278,7 +2278,7 @@ dependencies = [
  "rustc_version",
  "serde 1.0.117",
  "sha2",
- "time 0.2.22",
+ "time 0.2.23",
  "tokio",
 ]
 
@@ -2611,9 +2611,9 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smallvec"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
+checksum = "7acad6f34eb9e8a259d3283d1e8c1d34d7415943d4895f65cc73813c7396fc85"
 
 [[package]]
 name = "socket2"
@@ -2646,9 +2646,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "standback"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e0831040d2cf2bdfd51b844be71885783d489898a192f254ae25d57cce725c"
+checksum = "cf906c8b8fc3f6ecd1046e01da1d8ddec83e48c8b08b84dcc02b585a6bedf5a8"
 dependencies = [
  "version_check",
 ]
@@ -2832,9 +2832,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55b7151c9065e80917fbf285d9a5d1432f60db41d170ccafc749a136b41a93af"
+checksum = "bcdaeea317915d59b2b4cd3b5efcd156c309108664277793f5351700c02ce98b"
 dependencies = [
  "const_fn",
  "libc",
@@ -3295,9 +3295,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f98e67a4d84f730d343392f9bfff7d21e3fca562b9cb7a43b768350beeddc6"
+checksum = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"
 dependencies = [
  "tinyvec",
 ]
@@ -3437,7 +3437,7 @@ dependencies = [
  "mime_guess",
  "multipart",
  "percent-encoding",
- "pin-project 1.0.1",
+ "pin-project 1.0.2",
  "scoped-tls",
  "serde 1.0.117",
  "serde_json",


### PR DESCRIPTION
rusoto depends on time 0.2.22 for which a CVE exists: https://github.com/time-rs/time/security/advisories/GHSA-wcg3-cvx6-7396

`cargo-audit` still spits a few warnings

### `dirs` 2.0.2

```
Crate:         dirs
Version:       2.0.2
Warning:       unmaintained
Title:         dirs is unmaintained, use dirs-next instead
Date:          2020-10-16
ID:            RUSTSEC-2020-0053
URL:           https://rustsec.org/advisories/RUSTSEC-2020-0053
Dependency tree:
dirs 2.0.2
└── rusoto_credential 0.45.0
    ├── rusoto_signature 0.45.0
    │   └── rusoto_core 0.45.0
    │       ├── xaynet-server 0.1.0
    │       │   └── xaynet 0.10.0
    │       └── rusoto_s3 0.45.0
    │           └── xaynet-server 0.1.0
    └── rusoto_core 0.45.0
```

This should be fixed by https://github.com/rusoto/rusoto/pull/1846

### `failure` 0.1.8

```
Crate:         failure
Version:       0.1.8
Warning:       unmaintained
Title:         failure is officially deprecated/unmaintained
Date:          2020-05-02
ID:            RUSTSEC-2020-0036
URL:           https://rustsec.org/advisories/RUSTSEC-2020-0036
Dependency tree:
failure 0.1.8
└── influxdb 0.1.0
    └── xaynet-server 0.1.0
        └── xaynet 0.10.0
```

It is fixed in `influxdb` 0.2:
https://github.com/Empty2k12/influxdb-rust/pull/70. We should upgrade.

### `net2`

Much more tricky. This comes from `tokio` 0.2, which we heavily
depends on, both explicitely and transitively. This is going to take
time, but at the same time, there's not real emergency.

```
Crate:         net2
Version:       0.2.35
Warning:       unmaintained
Title:         `net2` crate has been deprecated; use `socket2` instead
Date:          2020-05-01
ID:            RUSTSEC-2020-0016
URL:           https://rustsec.org/advisories/RUSTSEC-2020-0016
Dependency tree:
net2 0.2.35
├── miow 0.2.1
└── mio 0.6.22
    ├── tokio 0.2.23
    │   ├── xaynet-server 0.1.0
    │   │   └── xaynet 0.10.0
    │   ├── xaynet-sdk 0.1.0
    │   │   ├── xaynet-mobile 0.0.0
    │   │   ├── xaynet 0.10.0
    │   │   └── examples 0.0.0
    │   ├── xaynet-mobile 0.0.0
    │   ├── warp 0.2.5
    │   │   └── xaynet-server 0.1.0
    │   ├── tower-timeout 0.3.0
    │   │   └── tower 0.3.1
    │   │       └── xaynet-server 0.1.0
    │   ├── tower-test 0.3.0
    │   │   └── xaynet-server 0.1.0
    │   ├── tower-retry 0.3.0
    │   │   └── tower 0.3.1
    │   ├── tower-load 0.3.0
    │   │   └── tower-limit 0.3.1
    │   │       └── tower 0.3.1
    │   ├── tower-limit 0.3.1
    │   ├── tower-buffer 0.3.0
    │   │   └── tower 0.3.1
    │   ├── tokio-util 0.3.1
    │   │   ├── redis 0.17.0
    │   │   │   └── xaynet-server 0.1.0
    │   │   └── h2 0.2.7
    │   │       └── hyper 0.13.9
    │   │           ├── warp 0.2.5
    │   │           ├── rusoto_signature 0.45.0
    │   │           │   └── rusoto_core 0.45.0
    │   │           │       ├── xaynet-server 0.1.0
    │   │           │       └── rusoto_s3 0.45.0
    │   │           │           └── xaynet-server 0.1.0
    │   │           ├── rusoto_credential 0.45.0
    │   │           │   ├── rusoto_signature 0.45.0
    │   │           │   └── rusoto_core 0.45.0
    │   │           ├── rusoto_core 0.45.0
    │   │           ├── reqwest 0.10.8
    │   │           │   ├── xaynet-sdk 0.1.0
    │   │           │   ├── influxdb 0.1.0
    │   │           │   │   └── xaynet-server 0.1.0
    │   │           │   └── examples 0.0.0
    │   │           ├── hyper-tls 0.4.3
    │   │           │   ├── rusoto_core 0.45.0
    │   │           │   └── reqwest 0.10.8
    │   │           └── hyper-rustls 0.21.0
    │   │               └── reqwest 0.10.8
    │   ├── tokio-tungstenite 0.11.0
    │   │   └── warp 0.2.5
    │   ├── tokio-tls 0.3.1
    │   │   ├── reqwest 0.10.8
    │   │   └── hyper-tls 0.4.3
    │   ├── tokio-test 0.2.1
    │   │   ├── xaynet-server 0.1.0
    │   │   ├── xaynet-sdk 0.1.0
    │   │   └── tower-test 0.3.0
    │   ├── tokio-rustls 0.14.1
    │   │   ├── warp 0.2.5
    │   │   ├── reqwest 0.10.8
    │   │   └── hyper-rustls 0.21.0
    │   ├── rusoto_signature 0.45.0
    │   ├── rusoto_credential 0.45.0
    │   ├── rusoto_core 0.45.0
    │   ├── reqwest 0.10.8
    │   ├── redis 0.17.0
    │   ├── hyper-tls 0.4.3
    │   ├── hyper-rustls 0.21.0
    │   ├── hyper 0.13.9
    │   ├── h2 0.2.7
    │   ├── examples 0.0.0
    │   └── combine 4.4.0
    │       └── redis 0.17.0
    ├── mio-uds 0.6.8
    │   └── tokio 0.2.23
    └── mio-named-pipes 0.1.7
        └── tokio 0.2.23
```

### `stdweb` 0.4.20

```
Crate:         stdweb
Version:       0.4.20
Warning:       unmaintained
Title:         stdweb is unmaintained
Date:          2020-05-04
ID:            RUSTSEC-2020-0056
URL:           https://rustsec.org/advisories/RUSTSEC-2020-0056
Dependency tree:
stdweb 0.4.20
└── time 0.2.23
```

This is fixed in `time` 0.3, which hasn't been released yet. I don't
think we depend on it anyway, because this is an optional dependency
for webassembly.