### PR TITLE
pass ByteBuffer pointer instead of struct

### DIFF
--- a/rust/xaynet-mobile/src/ffi/participant.rs
+++ b/rust/xaynet-mobile/src/ffi/participant.rs
@@ -241,16 +241,21 @@ pub unsafe extern "C" fn xaynet_ffi_participant_save(
 /// assert(n_read == fsize);
 /// fclose(f);
 /// Participant *restored =
-///     xaynet_ffi_participant_restore("http://localhost:8081", buf);
+///     xaynet_ffi_participant_restore("http://localhost:8081", &buf);
 /// free(buf.data);
 /// ```
 #[no_mangle]
 pub unsafe extern "C" fn xaynet_ffi_participant_restore(
     url: FfiStr,
-    buffer: ByteBuffer,
+    buffer: *const ByteBuffer,
 ) -> *mut Participant {
     let url = match url.as_opt_str() {
         Some(url) => url,
+        None => return ptr::null_mut(),
+    };
+
+    let buffer: &ByteBuffer = match unsafe { buffer.as_ref() } {
+        Some(ptr) => ptr,
         None => return ptr::null_mut(),
     };
 

--- a/rust/xaynet-mobile/tests/ffi_test.c
+++ b/rust/xaynet-mobile/tests/ffi_test.c
@@ -110,7 +110,7 @@ static char *test_participant_save_and_restore() {
 
   // restore the participant
   Participant *restored =
-      xaynet_ffi_participant_restore("http://localhost:8081", restore_buf);
+      xaynet_ffi_participant_restore("http://localhost:8081", &restore_buf);
   mu_assert("failed to restore participant", restored != NULL);
 
   // free memory

--- a/rust/xaynet-mobile/xaynet_ffi.h
+++ b/rust/xaynet-mobile/xaynet_ffi.h
@@ -487,11 +487,11 @@ const ByteBuffer *xaynet_ffi_participant_save(Participant *participant);
  * assert(n_read == fsize);
  * fclose(f);
  * Participant *restored =
- *     xaynet_ffi_participant_restore("http://localhost:8081", buf);
+ *     xaynet_ffi_participant_restore("http://localhost:8081", &buf);
  * free(buf.data);
  * ```
  */
-Participant *xaynet_ffi_participant_restore(FfiStr url, ByteBuffer buffer);
+Participant *xaynet_ffi_participant_restore(FfiStr url, const ByteBuffer *buffer);
 
 /**
  * Set the participant's model. Usually this should be called when the value returned


### PR DESCRIPTION
Dart ffi currently does not support passing structs by value
releated issues:
- https://github.com/dart-lang/sdk/issues/41062
- https://github.com/dart-lang/sdk/issues/36730

Therefore we change the function so that a pointer is accepted instead of a struct

This will hopfully be possible in [v1.1](https://github.com/dart-lang/sdk/projects/13#card-20672366)



