### PR TITLE
XN-1370 stable docs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -191,13 +191,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install nightly toolchain
+      - name: Install stable toolchain
         id: rust-toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
-          default: true
+          toolchain: stable
 
       - name: Cache cargo
         uses: actions/cache@v2
@@ -210,7 +209,7 @@ jobs:
 
       - name: Check the building of docs
         working-directory: ./rust
-        run: cargo +nightly doc --all-features --no-deps --color always
+        run: cargo doc --all-features --no-deps --color always
 
   coverage:
     name: cargo-tarpaulin

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -253,3 +253,39 @@ jobs:
         uses: codecov/codecov-action@v1.0.12
         with:
           token: ${{secrets.CODECOV_TOKEN}}
+
+  readme:
+    name: cargo-readme
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        id: rust-toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+
+      - name: Install cargo readme
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-readme
+
+      - name: Cache cargo
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ${{ github.workspace }}/rust/target
+          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.rustc }}-readme-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Check that readme matches docs
+        working-directory: ./
+        run: |
+          cargo readme --project-root rust/xaynet/ --template ../../README.tpl --output ../../CARGO_README.md
+          git diff --exit-code --no-index README.md CARGO_README.md

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 
 # vscode workspace settings
 .vscode/*
+
+CARGO_README.md

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![crates.io badge](https://img.shields.io/crates/v/xaynet.svg)](https://crates.io/crates/xaynet) [![docs.rs badge](https://docs.rs/xaynet/badge.svg)](https://docs.rs/xaynet) [![rustc badge](https://img.shields.io/badge/rustc-1.46+-lightgray.svg)](https://www.rust-lang.org/learn/get-started) [![Coverage Status](https://codecov.io/gh/xaynetwork/xaynet/branch/master/graph/badge.svg)](https://codecov.io/gh/xaynetwork/xaynet)
+[![crates.io badge](https://img.shields.io/crates/v/xaynet.svg)](https://crates.io/crates/xaynet) [![docs.rs badge](https://docs.rs/xaynet/badge.svg)](https://docs.rs/xaynet) [![rustc badge](https://img.shields.io/badge/rustc-1.48+-lightgray.svg)](https://www.rust-lang.org/learn/get-started) [![Coverage Status](https://codecov.io/gh/xaynetwork/xaynet/branch/master/graph/badge.svg)](https://codecov.io/gh/xaynetwork/xaynet)
+![Maintenance](https://img.shields.io/badge/maintenance-activly--developed-brightgreen.svg)
 
 ![Xaynet banner](./assets/xaynet_banner.png)
 
@@ -101,7 +102,7 @@ that meets these requirements:
 
 ## Minimum supported rust version
 
-rustc 1.46.0
+rustc 1.48.0
 
 ## Running the platform
 
@@ -119,7 +120,6 @@ beyond the scope of this project:
    * [Rust](https://www.rust-lang.org/tools/install)
    * [Docker](https://docs.docker.com/) and [Docker Compose](https://docs.docker.com/compose/)
    * [Kubernetes](https://kubernetes.io/docs/home/)
-
 
 **Note:**
 

--- a/README.tpl
+++ b/README.tpl
@@ -1,4 +1,4 @@
-[![crates.io badge](https://img.shields.io/crates/v/xaynet.svg)](https://crates.io/crates/xaynet) [![docs.rs badge](https://docs.rs/xaynet/badge.svg)](https://docs.rs/xaynet)  [![rustc badge](https://img.shields.io/badge/rustc-1.46+-lightgray.svg)](https://www.rust-lang.org/learn/get-started) {{badges}}
+[![crates.io badge](https://img.shields.io/crates/v/xaynet.svg)](https://crates.io/crates/xaynet) [![docs.rs badge](https://docs.rs/xaynet/badge.svg)](https://docs.rs/xaynet) [![rustc badge](https://img.shields.io/badge/rustc-1.48+-lightgray.svg)](https://www.rust-lang.org/learn/get-started) {{badges}}
 
 ![Xaynet banner](./assets/xaynet_banner.png)
 
@@ -12,7 +12,7 @@
 
 ## Minimum supported rust version
 
-rustc 1.46.0
+rustc 1.48.0
 
 ## Running the platform
 
@@ -31,24 +31,67 @@ beyond the scope of this project:
    * [Docker](https://docs.docker.com/) and [Docker Compose](https://docs.docker.com/compose/)
    * [Kubernetes](https://kubernetes.io/docs/home/)
 
-### Using `docker-compose`
+**Note:**
+
+With Xaynet `v0.11` the coordinator needs a connection to a redis instance in order to save its state.
+
+**Please don't connect the coordinator to a Redis instance that is used in production!**
+
+The coordinator clears the currently selected Redis database each time it is started.
+This behavior will change as soon as the coordinator state can be automatically restored.
+
+### Using Docker
 
 The convenience of using the docker setup is that there's no need to setup a working Rust
 environment on your system, as everything is done inside the container.
 
-Start the coordinator by pointing to the `docker/docker-compose.yml` file. Keep in mind that
-given this is the file used for development, it spins up some infrastructure that is currently
-not essential.
+#### Run an image from Docker Hub
+
+Docker images of the latest releases are provided on
+[Docker Hub](https://hub.docker.com/r/xaynetwork/xaynet).
+
+You can try them out with the default `configs/docker-dev.toml` by running:
+
+**Xaynet below v0.11**
+
+```bash
+docker run -v ${PWD}/configs/docker-dev.toml:/app/config.toml -p 8081:8081 xaynetwork/xaynet:v0.10.0 /app/coordinator -c /app/config.toml
+```
+
+**Xaynet v0.11+**
+
+```bash
+# don't forget to adjust the Redis url in configs/docker-dev.toml
+docker run -v ${PWD}/configs/docker-dev.toml:/app/config.toml -p 8081:8081 xaynetwork/xaynet:v0.11.0
+```
+
+The docker image contains a release build of the coordinator without optional features.
+
+#### Run a coordinator with additional infrastructure
+
+Start the coordinator by pointing to the `docker/docker-compose.yml` file. It spins up all
+infrastructure that is essential to run the coordinator with default or optional features.
+Keep in mind that this file is used for development only.
 
 ```bash
 docker-compose -f docker/docker-compose.yml up --build
 ```
 
-If you would like, you can use the `docker/docker-compose-release.yml` file, but keep in mind
-that given this runs a release build with optimizations, compilation will be slower.
+#### Create a release build
+
+If you would like, you can create an optimized release build of the coordinator,
+but keep in mind that the compilation will be slower.
 
 ```bash
-docker-compose -f docker/docker-compose-release.yml up --build
+docker build --build-arg RELEASE_BUILD=1 -f ./docker/Dockerfile .
+```
+
+#### Build a coordinator with optional features
+
+Optional features can be specified via the build argument `COORDINATOR_FEATURES`.
+
+```bash
+docker build --build-arg COORDINATOR_FEATURES=tls,metrics -f ./docker/Dockerfile .
 ```
 
 ### Using Kubernetes
@@ -91,10 +134,11 @@ kubectl port-forward $(kubectl get pods -l "app=coordinator" -o jsonpath="{.item
 
 ### Building the project manually
 
-The coordinator can be built and started with:
+The coordinator without optional features can be built and started with:
 
 ```bash
-cargo run --bin coordinator --manifest-path rust/Cargo.toml -- -c configs/config.toml
+cd rust
+cargo run --bin coordinator -- -c ../configs/config.toml
 ```
 
 ## Running the example

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -324,6 +324,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "combine"
 version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,7 +457,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -459,18 +468,18 @@ checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0f606a85340376eef0d6d8fec399e6d4a544d648386c6645eb6d0653b27d9f"
+checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
 dependencies = [
  "cfg-if 1.0.0",
  "const_fn",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils",
  "lazy_static",
  "memoffset",
  "scopeguard",
@@ -478,24 +487,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.7.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-dependencies = [
- "autocfg 1.0.1",
- "cfg-if 0.1.10",
- "lazy_static",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec91540d98355f690a86367e566ecad2e9e579f230230eb7c21398372be73ea5"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
 dependencies = [
  "autocfg 1.0.1",
  "cfg-if 1.0.0",
- "const_fn",
  "lazy_static",
 ]
 
@@ -511,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4666154fd004af3fd6f1da2e81a96fd5a81927fe8ddb6ecc79e2aa6e138b54"
+checksum = "f9d58633299b24b515ac72a3f869f8b91306a3cec616a602843a383acd6f9e97"
 dependencies = [
  "bstr",
  "csv-core",
@@ -1159,6 +1156,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1261,9 +1267,9 @@ checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
 
 [[package]]
 name = "lock_api"
-version = "0.3.4"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
+checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
 dependencies = [
  "scopeguard",
 ]
@@ -1319,9 +1325,9 @@ checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "memoffset"
-version = "0.5.6"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
+checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
 dependencies = [
  "autocfg 1.0.1",
 ]
@@ -1365,7 +1371,7 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log",
- "miow 0.2.1",
+ "miow 0.2.2",
  "net2",
  "slab",
  "winapi 0.2.8",
@@ -1396,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
 dependencies = [
  "kernel32-sys",
  "net2",
@@ -1481,9 +1487,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
+checksum = "d7cf75f38f16cb05ea017784dc6dbfd354f76c223dba37701734c4f5a9337d02"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -1692,22 +1698,24 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.10.2"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
 dependencies = [
+ "instant",
  "lock_api",
  "parking_lot_core",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
+checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
 dependencies = [
  "cfg-if 0.1.10",
- "cloudabi",
+ "cloudabi 0.1.0",
+ "instant",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -2026,7 +2034,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
 dependencies = [
- "cloudabi",
+ "cloudabi 0.0.3",
  "fuchsia-cprng",
  "libc",
  "rand_core 0.4.2",
@@ -2073,7 +2081,7 @@ checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils",
  "lazy_static",
  "num_cpus",
 ]
@@ -2206,9 +2214,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.16"
+version = "0.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b72b84d47e8ec5a4f2872e8262b8f8256c5be1c938a7d6d3a867a3ba8f722f74"
+checksum = "70017ed5c555d79ee3538fc63ca09c70ad8f317dcadc1adc2c496b60c22bb24f"
 dependencies = [
  "cc",
  "libc",
@@ -2307,14 +2315,14 @@ dependencies = [
 
 [[package]]
 name = "rust-argon2"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dab61250775933275e84053ac235621dfb739556d5c54a2f2e9313b7cf43a19"
+checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
 dependencies = [
- "base64 0.12.3",
+ "base64 0.13.0",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils 0.7.2",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2525,9 +2533,9 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b15f74add9a9d4a3eb2bf739c9a427d266d3895b53d992c3a7c234fec2ff1f1"
+checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
 dependencies = [
  "lazy_static",
  "parking_lot",
@@ -2536,9 +2544,9 @@ dependencies = [
 
 [[package]]
 name = "serial_test_derive"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65f59259be9fc1bf677d06cc1456e97756004a1a5a577480f71430bd7c17ba33"
+checksum = "b2acd6defeddb41eb60bb468f8825d0cfd0c2a76bc03bfd235b6a1dc4f6a1ad5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2757,9 +2765,9 @@ checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
-version = "1.0.50"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443b4178719c5a851e1bde36ce12da21d74a0e60b4d982ec3385a933c812f0f6"
+checksum = "8833e20724c24de12bbaba5ad230ea61c3eafb05b881c7c9d3cfe8638b187e68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3156,13 +3164,13 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
+checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "log",
- "pin-project-lite 0.1.11",
+ "pin-project-lite 0.2.0",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -3315,9 +3323,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8716a166f290ff49dabc18b44aa407cb7c6dbe1aa0971b44b8a24b0ca35aae"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-width"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -14,4 +14,4 @@ members = [
 
 [workspace.metadata]
 # minimum supported rust version
-msrv = "1.46.0"
+msrv = "1.48.0"

--- a/rust/benches/Cargo.toml
+++ b/rust/benches/Cargo.toml
@@ -14,7 +14,7 @@ publish = false
 
 [package.metadata]
 # minimum supported rust version
-msrv = "1.46.0"
+msrv = "1.48.0"
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/rust/examples/Cargo.toml
+++ b/rust/examples/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["science", "cryptography"]
 
 [package.metadata]
 # minimum supported rust version
-msrv = "1.46.0"
+msrv = "1.48.0"
 
 [dev-dependencies]
 async-trait = "0.1.40"

--- a/rust/xaynet-core/Cargo.toml
+++ b/rust/xaynet-core/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["science", "cryptography"]
 
 [package.metadata]
 # minimum supported rust version
-msrv = "1.46.0"
+msrv = "1.48.0"
 
 [dependencies]
 anyhow = "1.0.32"

--- a/rust/xaynet-macros/Cargo.toml
+++ b/rust/xaynet-macros/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["science", "cryptography"]
 
 [package.metadata]
 # minimum supported rust version
-msrv = "1.46.0"
+msrv = "1.48.0"
 
 [dependencies]
 quote = "1.0.7"

--- a/rust/xaynet-mobile/Cargo.toml
+++ b/rust/xaynet-mobile/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["science", "cryptography"]
 
 [package.metadata]
 # minimum supported rust version
-msrv = "1.46.0"
+msrv = "1.48.0"
 
 [dependencies]
 ffi-support = "0.4.2"

--- a/rust/xaynet-sdk/Cargo.toml
+++ b/rust/xaynet-sdk/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["science", "cryptography"]
 
 [package.metadata]
 # minimum supported rust version
-msrv = "1.46.0"
+msrv = "1.48.0"
 
 [package.metadata."docs.rs"]
 all-features = true

--- a/rust/xaynet-server/Cargo.toml
+++ b/rust/xaynet-server/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["science", "cryptography"]
 
 [package.metadata]
 # minimum supported rust version
-msrv = "1.46.0"
+msrv = "1.48.0"
 
 [dependencies]
 anyhow = "1.0.32"

--- a/rust/xaynet/Cargo.toml
+++ b/rust/xaynet/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["science", "cryptography"]
 
 [package.metadata]
 # minimum supported rust version
-msrv = "1.46.0"
+msrv = "1.48.0"
 
 [badges]
 codecov = { repository = "xaynetwork/xaynet", branch = "master", service = "github" }


### PR DESCRIPTION
**References**

- [XN-1370](https://xainag.atlassian.net/browse/XN-1370)

**Summary**

- updates msrv and github workflow to use stable cargo doc
- update readme and template
- add a readme check to the workflow: use `cargo readme` to generate a readme from the code docs + template. this will notify us if the docs and the readme diverge. in consequence no changes should be made to the readme itself, but only to the docs and the template, then the readme can be generated via `cargo readme > README.md`.
