### PR TITLE
fix multipart messages

### DIFF
--- a/rust/xaynet-sdk/src/message_encoder/encoder.rs
+++ b/rust/xaynet-sdk/src/message_encoder/encoder.rs
@@ -25,6 +25,8 @@ pub struct MultipartEncoder {
     /// The maximum size allowed for the payload. `self.data` is split
     /// in chunks of this size.
     payload_size: usize,
+    /// A random ID common to all the message chunks.
+    message_id: u16,
 }
 
 /// Overhead induced by wrapping the data in [`Payload::Chunk`]
@@ -43,7 +45,7 @@ impl Iterator for MultipartEncoder {
 
         let chunk = Chunk {
             id: self.id,
-            message_id: rand::random::<u16>(),
+            message_id: self.message_id,
             last: self.id as usize == chunker.nb_chunks() - 1,
             data: chunker.get_chunk(self.id as usize).to_vec(),
         };
@@ -172,6 +174,7 @@ impl MessageEncoder {
             tag,
             coordinator_pk,
             payload_size,
+            message_id: rand::random::<u16>(),
         })
     }
 

--- a/rust/xaynet-server/src/services/messages/multipart/buffer.rs
+++ b/rust/xaynet-server/src/services/messages/multipart/buffer.rs
@@ -57,7 +57,7 @@ impl Iterator for MultipartMessageBuffer {
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         let lower_bound = self.initial_length - self.consumed;
-        let upper_bound = self.initial_length;
+        let upper_bound = self.initial_length - self.consumed;
         (lower_bound, Some(upper_bound))
     }
 }
@@ -78,36 +78,43 @@ mod tests {
         let mut iter = MultipartMessageBuffer::from(map);
         assert_eq!(iter.consumed, 0);
         assert_eq!(iter.initial_length, 6);
+        assert_eq!(iter.len(), 6);
         assert!(iter.current_chunk.is_none());
 
         assert_eq!(iter.next(), Some(0));
         assert_eq!(iter.consumed, 1);
         assert_eq!(iter.initial_length, 6);
+        assert_eq!(iter.len(), 5);
         assert!(iter.current_chunk.is_some());
 
         assert_eq!(iter.next(), Some(1));
         assert_eq!(iter.consumed, 2);
         assert_eq!(iter.initial_length, 6);
+        assert_eq!(iter.len(), 4);
         assert!(iter.current_chunk.is_some());
 
         assert_eq!(iter.next(), Some(2));
         assert_eq!(iter.consumed, 3);
         assert_eq!(iter.initial_length, 6);
+        assert_eq!(iter.len(), 3);
         assert!(iter.current_chunk.is_some());
 
         assert_eq!(iter.next(), Some(3));
         assert_eq!(iter.consumed, 4);
         assert_eq!(iter.initial_length, 6);
+        assert_eq!(iter.len(), 2);
         assert!(iter.current_chunk.is_some());
 
         assert_eq!(iter.next(), Some(4));
         assert_eq!(iter.consumed, 5);
         assert_eq!(iter.initial_length, 6);
+        assert_eq!(iter.len(), 1);
         assert!(iter.current_chunk.is_some());
 
         assert_eq!(iter.next(), Some(5));
         assert_eq!(iter.consumed, 6);
         assert_eq!(iter.initial_length, 6);
+        assert_eq!(iter.len(), 0);
         assert!(iter.current_chunk.is_some());
     }
 }


### PR DESCRIPTION
There were multiple combined issues:

- a bug in the `ExactSizeIterator` implementation for `MultipartMessageBuffer`
- in `xaynet_sdk`, the chunk IDs start at 0, while the server expected
  them to start at 1. The server now expects the chunk IDs to start a 0
- under certain conditions, `MessageBuilder::has_all_chunk()` would
  never return `true`
- in `xaynet_sdk`, we were generating new random message IDs for each
  chunks