### PR TITLE
XN-1318 sdk clippy warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -278,7 +278,7 @@ jobs:
 
       - name: Check the building of docs
         working-directory: ./rust
-        run: cargo doc --all-features --no-deps --color always
+        run: cargo doc --all-features --document-private-items --no-deps --color always
 
   coverage:
     name: cargo-tarpaulin

--- a/rust/xaynet-core/src/mask/object/serialization/unit.rs
+++ b/rust/xaynet-core/src/mask/object/serialization/unit.rs
@@ -73,7 +73,9 @@ impl<T: AsRef<[u8]>> MaskUnitBuffer<T> {
 
     /// Return the expected length of the underlying byte buffer,
     /// based on the masking config field of numbers field. This is
-    /// similar to [`len`] but cannot panic.
+    /// similar to [`len()`] but cannot panic.
+    ///
+    /// [`len()`]: MaskUnitBuffer::len
     pub fn try_len(&self) -> Result<usize, DecodeError> {
         let config =
             MaskConfig::from_byte_slice(&self.config()).context("invalid mask unit buffer")?;

--- a/rust/xaynet-core/src/mask/object/serialization/vect.rs
+++ b/rust/xaynet-core/src/mask/object/serialization/vect.rs
@@ -79,7 +79,9 @@ impl<T: AsRef<[u8]>> MaskVectBuffer<T> {
 
     /// Return the expected length of the underlying byte buffer,
     /// based on the masking config field of numbers field. This is
-    /// similar to [`len`] but cannot panic.
+    /// similar to [`len()`] but cannot panic.
+    ///
+    /// [`len()`]: MaskVectBuffer::len
     fn try_len(&self) -> Result<usize, DecodeError> {
         let config =
             MaskConfig::from_byte_slice(&self.config()).context("invalid mask vector buffer")?;

--- a/rust/xaynet-sdk/src/message_encoder/encoder.rs
+++ b/rust/xaynet-sdk/src/message_encoder/encoder.rs
@@ -109,7 +109,7 @@ impl MessageEncoder {
     ///
     /// # Errors
     ///
-    /// An [`InvalidPayload`] error is returned when `payload` is of
+    /// An [`InvalidEncodingInput`] error is returned when `payload` is of
     /// type [`Payload::Chunk`]. Only [`Payload::Sum`],
     /// [`Payload::Update`], [`Payload::Sum2`] are accepted.
     pub fn new(

--- a/rust/xaynet-sdk/src/state_machine/phases/new_round.rs
+++ b/rust/xaynet-sdk/src/state_machine/phases/new_round.rs
@@ -58,13 +58,13 @@ impl Phase<NewRound> {
     }
 
     fn into_sum(self, sum_signature: Signature) -> Phase<Sum> {
-        let sum = Sum::new(sum_signature);
+        let sum = Box::new(Sum::new(sum_signature));
         let state = State::new(self.state.shared, sum);
         state.into_phase(self.io)
     }
 
     fn into_update(self, sum_signature: Signature, update_signature: Signature) -> Phase<Update> {
-        let update = Update::new(sum_signature, update_signature);
+        let update = Box::new(Update::new(sum_signature, update_signature));
         let state = State::new(self.state.shared, update);
         state.into_phase(self.io)
     }

--- a/rust/xaynet-sdk/src/state_machine/phases/sum.rs
+++ b/rust/xaynet-sdk/src/state_machine/phases/sum.rs
@@ -74,10 +74,10 @@ impl Phase<Sum> {
     }
 
     pub fn into_sum2(self) -> Phase<Sum2> {
-        let sum2 = Sum2::new(
+        let sum2 = Box::new(Sum2::new(
             self.state.private.ephm_keys,
             self.state.private.sum_signature,
-        );
+        ));
         let state = State::new(self.state.shared, sum2);
         state.into_phase(self.io)
     }

--- a/rust/xaynet-sdk/src/state_machine/state_machine.rs
+++ b/rust/xaynet-sdk/src/state_machine/state_machine.rs
@@ -28,7 +28,6 @@ pub enum TransitionOutcome {
 
 /// PET state machine.
 #[derive(From, Debug)]
-#[allow(clippy::large_enum_variant)]
 pub enum StateMachine {
     /// PET state machine in the "new round" phase
     NewRound(Phase<NewRound>),
@@ -37,7 +36,6 @@ pub enum StateMachine {
     /// PET state machine in the "sum" phase
     Sum(Phase<Sum>),
     /// PET state machine in the "update" phase
-    // FIXME: box this
     Update(Phase<Update>),
     /// PET state machine in the "sum2" phase
     Sum2(Phase<Sum2>),
@@ -101,7 +99,7 @@ impl StateMachine {
         N: Notify + Send + 'static,
     {
         let io = boxed_io(xaynet_client, model_store, notifier);
-        let state = State::new(SharedState::new(settings), Awaiting);
+        let state = State::new(Box::new(SharedState::new(settings)), Box::new(Awaiting));
         state.into_phase(io).into()
     }
 

--- a/rust/xaynet-sdk/src/state_machine/tests/phases/new_round.rs
+++ b/rust/xaynet-sdk/src/state_machine/tests/phases/new_round.rs
@@ -50,7 +50,8 @@ fn make_phase(task: SelectFor, io: MockIO) -> Phase<NewRound> {
     // Check IntoPhase<NewRound> implementation
     let mut mock = MockIO::new();
     mock.expect_notify_new_round().times(1).return_const(());
-    let mut phase: Phase<NewRound> = State::new(shared, NewRound).into_phase(Box::new(mock));
+    let mut phase: Phase<NewRound> =
+        State::new(shared, Box::new(NewRound)).into_phase(Box::new(mock));
 
     // Set `phase.io` to the mock the test wants to use. Note that this drops the `mock` we
     // created above, so the expectations we set on `mock` run now.

--- a/rust/xaynet-sdk/src/state_machine/tests/phases/sum.rs
+++ b/rust/xaynet-sdk/src/state_machine/tests/phases/sum.rs
@@ -30,16 +30,16 @@ fn make_phase(io: MockIO) -> Phase<Sum> {
     phase
 }
 
-fn make_sum(shared: &SharedState) -> Sum {
+fn make_sum(shared: &SharedState) -> Box<Sum> {
     let ephm_keys = EncryptKeyPair::derive_from_seed(&EncryptKeySeed::zeroed());
     let sk = &shared.keys.secret;
     let seed = shared.round_params.seed.as_slice();
     let signature = sk.sign_detached(&[seed, b"sum"].concat());
-    Sum {
+    Box::new(Sum {
         ephm_keys,
         sum_signature: signature,
         message: None,
-    }
+    })
 }
 
 async fn check_step_1() -> Phase<Sum> {

--- a/rust/xaynet-sdk/src/state_machine/tests/phases/sum2.rs
+++ b/rust/xaynet-sdk/src/state_machine/tests/phases/sum2.rs
@@ -33,19 +33,19 @@ fn make_phase() -> Phase<Sum2> {
     phase
 }
 
-fn make_sum2(shared: &SharedState) -> Sum2 {
+fn make_sum2(shared: &SharedState) -> Box<Sum2> {
     let ephm_keys = EncryptKeyPair::derive_from_seed(&EncryptKeySeed::zeroed());
     let sk = &shared.keys.secret;
     let seed = shared.round_params.seed.as_slice();
     let signature = sk.sign_detached(&[seed, b"sum"].concat());
-    Sum2 {
+    Box::new(Sum2 {
         ephm_keys,
         sum_signature: signature,
         seed_dict: None,
         seeds: None,
         mask: None,
         message: None,
-    }
+    })
 }
 
 fn make_seed_dict(mask_config: MaskConfigPair, ephm_pk: PublicEncryptKey) -> UpdateSeedDict {

--- a/rust/xaynet-sdk/src/state_machine/tests/phases/update.rs
+++ b/rust/xaynet-sdk/src/state_machine/tests/phases/update.rs
@@ -36,12 +36,12 @@ fn make_phase() -> Phase<Update> {
     phase
 }
 
-fn make_update(shared: &SharedState) -> Update {
+fn make_update(shared: &SharedState) -> Box<Update> {
     let sk = &shared.keys.secret;
     let seed = shared.round_params.seed.as_slice();
     let sum_signature = sk.sign_detached(&[seed, b"sum"].concat());
     let update_signature = sk.sign_detached(&[seed, b"update"].concat());
-    Update {
+    Box::new(Update {
         sum_signature,
         update_signature,
         sum_dict: None,
@@ -49,7 +49,7 @@ fn make_update(shared: &SharedState) -> Update {
         model: None,
         mask: None,
         message: None,
-    }
+    })
 }
 
 fn make_model() -> Model {

--- a/rust/xaynet-sdk/src/state_machine/tests/utils.rs
+++ b/rust/xaynet-sdk/src/state_machine/tests/utils.rs
@@ -130,13 +130,13 @@ pub fn round_params(task: SelectFor) -> RoundParameters {
     }
 }
 
-pub fn shared_state(task: SelectFor) -> SharedState {
-    SharedState {
+pub fn shared_state(task: SelectFor) -> Box<SharedState> {
+    Box::new(SharedState {
         keys: SigningKeyPair::derive_from_seed(&SigningKeySeed::zeroed()),
         scalar: 1.0,
         message_size: MaxMessageSize::unlimited(),
         round_params: round_params(task),
-    }
+    })
 }
 
 pub struct EncryptKeyGenerator(EncryptKeySeed);

--- a/rust/xaynet-server/src/services/messages/multipart/service.rs
+++ b/rust/xaynet-server/src/services/messages/multipart/service.rs
@@ -18,7 +18,9 @@ use xaynet_core::{
 
 /// A `MessageBuilder` stores chunks of a multipart message. Once it
 /// has all the chunks, it can be consumed and turned into a
-/// full-blown [`Message`] (see [`into_message`]).
+/// full-blown [`Message`] (see [`into_message()`]).
+///
+/// [`into_message()`]: MessageBuilder::into_message
 #[derive(Debug)]
 #[cfg_attr(test, derive(Clone))]
 pub struct MessageBuilder {

--- a/rust/xaynet-server/src/services/messages/state_machine.rs
+++ b/rust/xaynet-server/src/services/messages/state_machine.rs
@@ -23,9 +23,9 @@ pub struct StateMachine {
 impl StateMachine {
     /// Create a new service with the given handle for forwarding
     /// requests to the state machine. The handle should be obtained
-    /// via [`StateMachine::new`].
+    /// via [`init()`].
     ///
-    /// [`StateMachine::new`]: crate::state_machine::StateMachine::new
+    /// [`init()`]: crate::state_machine::initializer::StateMachineInitializer::init
     pub fn new(handle: RequestSender) -> Self {
         Self { handle }
     }

--- a/rust/xaynet-server/src/state_machine/phases/mod.rs
+++ b/rust/xaynet-server/src/state_machine/phases/mod.rs
@@ -342,10 +342,10 @@ where
     C: CoordinatorStorage,
     M: ModelStorage,
 {
-    /// Receives the next [`Request`].
+    /// Receives the next [`StateMachineRequest`].
     ///
     /// # Errors
-    /// Returns [`StateError::ChannelError`] when all sender halves have been dropped.
+    /// Returns [`PhaseStateError::RequestChannel`] when all sender halves have been dropped.
     async fn next_request(
         &mut self,
     ) -> Result<(StateMachineRequest, Span, ResponseSender), PhaseStateError> {


### PR DESCRIPTION
**References**

- [XN-1318](https://xainag.atlassian.net/browse/XN-1318) (addresses [#578](https://github.com/xaynetwork/xaynet/pull/578#discussion_r516009877))

**Summary**

*documentation regression:*

while working on the actual issue i noticed regression in the documentation which is not yet caught by the ci. hence:
- add doc check for all docs including private docs
- fix broken doc links

*clippy warnings for large enum variants:*

some of the state machine enum variants are quite large (up to 500-800 bytes) and some of the enums differ between the variants (200 vs 800 bytes), which caused the clippy lint. just boxing the variants leads to some negative side effects:
- boxing of subsequent fields of the variant to avoid unboxing/reboxing for our various from/into impls, which also spirals down to all fields of the hierarchically constructed structs
- adjusting many function signatures from `self` to `self: Box<Self>` which makes it less nice to read
- just boxing the variants related to `Update` would leave us with the same problems for `Sum`/`Sum2`

but working from the root cause upwards, it only requires us to box the fields of `State<P>`, then all enums/structs building on top of this are effectively box-sized as well without extra box annotations. for `Sum`/`Update`/`Sum` the `State<P>` is reasonably large to justify boxing and for the zero-sized `Awaiting`/`NewRound` boxing is a no-op.
