### PR TITLE
XN-1491 update dependencies

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -195,7 +195,7 @@ dependencies = [
  "memchr",
  "num_cpus",
  "once_cell",
- "pin-project-lite 0.2.0",
+ "pin-project-lite 0.2.1",
  "pin-utils",
  "slab",
  "wasm-bindgen-futures",
@@ -395,9 +395,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "ffea412272c01cbee45e0d34f71c54af698d48f7d404a61fb46b71f48e3f30db"
 
 [[package]]
 name = "bytes"
@@ -493,15 +493,15 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "4.5.1"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01199925a18b00193570e3d70cfe57dcb647eb167c29851983e76fc39e2fee39"
+checksum = "cc4369b5e4c0cddf64ad8981c0111e7df4f7078f4d6ba98fb31f2e17c4c57b7e"
 dependencies = [
  "bytes 0.5.6",
  "bytes 1.0.0",
  "futures-util",
  "memchr",
- "pin-project-lite 0.1.11",
+ "pin-project-lite 0.2.1",
  "tokio",
 ]
 
@@ -532,9 +532,9 @@ dependencies = [
 
 [[package]]
 name = "const_fn"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
+checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
 
 [[package]]
 name = "constant_time_eq"
@@ -972,9 +972,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3b0c040a1fe6529d30b3c5944b280c7f0dcb2930d2c3062bca967b602583d0"
+checksum = "c70be434c505aee38639abccb918163b63158a4b4bb791b45b7023044bdc3c9c"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -987,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7109687aa4e177ef6fe84553af6280ef2778bdb7783ba44c9dc3399110fe64"
+checksum = "f01c61843314e95f96cc9245702248733a3a3d744e43e2e755e3c7af8348a0a9"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -997,15 +997,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "847ce131b72ffb13b6109a221da9ad97a64cbe48feb1028356b836b47b8f1748"
+checksum = "db8d3b0917ff63a2a96173133c02818fac4a746b0a57569d3baca9ec0e945e08"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4caa2b2b68b880003057c1dd49f1ed937e38f22fcf6c212188a121f08cf40a65"
+checksum = "9ee9ca2f7eb4475772cf39dd1cd06208dce2670ad38f4d9c7262b3e15f127068"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1014,9 +1014,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
+checksum = "e37c1a51b037b80922864b8eed90692c5cd8abd4c71ce49b77146caa47f3253b"
 
 [[package]]
 name = "futures-lite"
@@ -1029,15 +1029,15 @@ dependencies = [
  "futures-io",
  "memchr",
  "parking",
- "pin-project-lite 0.2.0",
+ "pin-project-lite 0.2.1",
  "waker-fn",
 ]
 
 [[package]]
 name = "futures-macro"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77408a692f1f97bcc61dc001d752e00643408fbc922e4d634c655df50d595556"
+checksum = "0f8719ca0e1f3c5e34f3efe4570ef2c0610ca6da85ae7990d472e9cbfba13664"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -1047,24 +1047,24 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f878195a49cee50e006b02b93cf7e0a95a38ac7b776b4c4d9cc1207cd20fcb3d"
+checksum = "f6adabac1290109cfa089f79192fb6244ad2c3f1cc2281f3e1dd987592b71feb"
 
 [[package]]
 name = "futures-task"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c554eb5bf48b2426c4771ab68c6b14468b6e76cc90996f528c3338d761a4d0d"
+checksum = "a92a0843a2ff66823a8f7c77bffe9a09be2b64e533562c412d63075643ec0038"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "futures-util"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d304cff4a7b99cfb7986f7d43fbe93d175e72e704a8860787cc95e9ffd85cbd2"
+checksum = "036a2107cdeb57f6d7322f1b6c363dad67cd63ca3b7d1b925bdf75bd5d96cda9"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1073,24 +1073,11 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project 1.0.2",
+ "pin-project-lite 0.2.1",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
  "slab",
-]
-
-[[package]]
-name = "generator"
-version = "0.6.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cdc09201b2e8ca1b19290cf7e65de2246b8e91fb6874279722189c4de7b94dc"
-dependencies = [
- "cc",
- "libc",
- "log",
- "rustc_version",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1121,6 +1108,17 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4060f4657be78b8e766215b02b18a2e862d83745545de804638e2b545e81aee6"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1343,7 +1341,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.2",
+ "pin-project 1.0.3",
  "socket2",
  "tokio",
  "tower-service",
@@ -1526,9 +1524,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
 
 [[package]]
 name = "libsodium-sys"
@@ -1573,19 +1571,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if 0.1.10",
-]
-
-[[package]]
-name = "loom"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e8460f2f2121162705187214720353c517b97bdfb3494c0b1e33d83ebe4bed"
-dependencies = [
- "cfg-if 0.1.10",
- "generator",
- "scoped-tls",
- "serde 1.0.118",
- "serde_json",
 ]
 
 [[package]]
@@ -1706,11 +1691,11 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.8.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cabea45a7fc0e37093f4f30a5e2b62602253f91791c057d5f0470c63260c3d"
+checksum = "619634fd9149c4a06e66d8fd9256e85326d8eeee75abee4565ff76c92e4edfe0"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "downcast",
  "fragile",
  "lazy_static",
@@ -1721,11 +1706,11 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.8.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c461918bf7f59eefb1459252756bf2351a995d6bd510d0b2061bd86bcdabfa6"
+checksum = "83714c95dbf4c24202f0f1b208f0f248e6bd65abfa8989303611a71c0f781548"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -2036,11 +2021,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccc2237c2c489783abd8c4c80e5450fc0e98644555b1364da68cc29aa151ca7"
+checksum = "5a83804639aad6ba65345661744708855f9fbcb71176ea8d28d05aeb11d975e7"
 dependencies = [
- "pin-project-internal 1.0.2",
+ "pin-project-internal 1.0.3",
 ]
 
 [[package]]
@@ -2056,9 +2041,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8e8d2bf0b23038a4424865103a4df472855692821aab4e4f5c3312d461d9e5f"
+checksum = "b7bcc46b8f73443d15bc1c5fecbb315718491fa9187fa483f0e359323cde8b3a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2073,9 +2058,9 @@ checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
+checksum = "e36743d754ccdf9954c2e352ce2d4b106e024c814f6499c2dadff80da9a442d8"
 
 [[package]]
 name = "pin-utils"
@@ -2254,11 +2239,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c24fcd450d3fa2b592732565aa4f17a27a61c65ece4726353e000939b0edee34"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.1",
+ "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -2282,6 +2279,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.1",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2302,7 +2309,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+dependencies = [
+ "getrandom 0.2.1",
 ]
 
 [[package]]
@@ -2321,6 +2337,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core 0.6.1",
 ]
 
 [[package]]
@@ -2444,16 +2469,16 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "redox_syscall",
  "rust-argon2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
+checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2473,9 +2498,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
 name = "remove_dir_all"
@@ -2508,7 +2533,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "percent-encoding",
- "pin-project-lite 0.2.0",
+ "pin-project-lite 0.2.1",
  "rustls",
  "serde 1.0.118",
  "serde_urlencoded",
@@ -2915,12 +2940,11 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4921be914e16899a80adefb821f8ddb7974e3f1250223575a44ed994882127"
+checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
 dependencies = [
  "lazy_static",
- "loom",
 ]
 
 [[package]]
@@ -3100,9 +3124,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4211ce9909eb971f111059df92c45640aad50a619cf55cd76476be803c4c68e6"
+checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3154,9 +3178,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+checksum = "bb9bc092d0d51e76b2b19d9d85534ffc9ec2db959a2523cdae0697e2972cd447"
 dependencies = [
  "lazy_static",
 ]
@@ -3384,9 +3408,9 @@ dependencies = [
 
 [[package]]
 name = "tower-layer"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35d656f2638b288b33495d1053ea74c40dc05ec0b92084dd71ca5566c4ed1dc"
+checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
 
 [[package]]
 name = "tower-limit"
@@ -3493,7 +3517,7 @@ checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
- "pin-project-lite 0.2.0",
+ "pin-project-lite 0.2.1",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -3699,9 +3723,9 @@ checksum = "05e42f7c18b8f902290b009cde6d651262f956c98bc51bca4cd1d511c9cd85c7"
 
 [[package]]
 name = "validator"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4effc922f18d14f3daf201b1d13c61e5ef62f5975e7d18df381f67badd76cfcd"
+checksum = "841d6937c33ec6039d8071bcf72933146b5bbe378d645d8fa59bdadabfc2a249"
 dependencies = [
  "idna",
  "lazy_static",
@@ -3716,9 +3740,9 @@ dependencies = [
 
 [[package]]
 name = "validator_derive"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15529099583e8ce2b070ab6a637454a1b42c7146e6daee4a6817a82bee33bd41"
+checksum = "4286b4497f270f59276a89ae0ad109d5f8f18c69b613e3fb22b61201aadb0c4d"
 dependencies = [
  "if_chain",
  "lazy_static",
@@ -3732,9 +3756,9 @@ dependencies = [
 
 [[package]]
 name = "validator_types"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add324da7950ac1f76b1c16ce8b5406147953d5d6a2ac1c5da93785f2cfc738b"
+checksum = "ad9680608df133af2c1ddd5eaf1ddce91d60d61b6bc51494ef326458365a470a"
 
 [[package]]
 name = "vcpkg"
@@ -3790,7 +3814,7 @@ dependencies = [
 [[package]]
 name = "warp"
 version = "0.2.5"
-source = "git+https://github.com/seanmonstar/warp?rev=cca5b54a48bd846ae0fcff91eafd6681f1cd9f7d#cca5b54a48bd846ae0fcff91eafd6681f1cd9f7d"
+source = "git+https://github.com/seanmonstar/warp?rev=42fd14fdab8145d27ae770fe4b5c843a99bc2a44#42fd14fdab8145d27ae770fe4b5c843a99bc2a44"
 dependencies = [
  "bytes 0.5.6",
  "futures",
@@ -3802,7 +3826,7 @@ dependencies = [
  "mime_guess",
  "multipart",
  "percent-encoding",
- "pin-project 1.0.2",
+ "pin-project 1.0.3",
  "scoped-tls",
  "serde 1.0.118",
  "serde_json",
@@ -4013,8 +4037,8 @@ dependencies = [
  "derive_more",
  "num",
  "paste",
- "rand 0.7.3",
- "rand_chacha 0.2.2",
+ "rand 0.8.1",
+ "rand_chacha 0.3.0",
  "serde 1.0.118",
  "sodiumoxide",
  "thiserror",
@@ -4048,7 +4072,7 @@ dependencies = [
  "derive_more",
  "mockall",
  "num",
- "rand 0.7.3",
+ "rand 0.8.1",
  "reqwest",
  "serde 1.0.118",
  "serde_json",
@@ -4084,8 +4108,8 @@ dependencies = [
  "num_enum",
  "once_cell",
  "paste",
- "rand 0.7.3",
- "rand_chacha 0.2.2",
+ "rand 0.8.1",
+ "rand_chacha 0.3.0",
  "rayon",
  "redis",
  "rusoto_core",

--- a/rust/benches/Cargo.toml
+++ b/rust/benches/Cargo.toml
@@ -12,10 +12,6 @@ keywords = ["federated-learning", "fl", "ai", "machine-learning"]
 categories = ["science", "cryptography"]
 publish = false
 
-[package.metadata]
-# minimum supported rust version
-msrv = "1.48.0"
-
 [dev-dependencies]
 criterion = "0.3.3"
 xaynet-core = { path = "../xaynet-core", features = ["testutils"] }

--- a/rust/examples/Cargo.toml
+++ b/rust/examples/Cargo.toml
@@ -12,18 +12,16 @@ license-file = "../../LICENSE"
 keywords = ["federated-learning", "fl", "ai", "machine-learning"]
 categories = ["science", "cryptography"]
 
-[package.metadata]
-# minimum supported rust version
-msrv = "1.48.0"
-
 [dev-dependencies]
-async-trait = "0.1.40"
-reqwest = { version = "0.10", default-features = false, features = ["rustls-tls"] }
-structopt = "0.3.17"
-tokio = { version = "0.2.22", features = ["sync", "time", "macros", "rt-threaded", "signal"] }
-tracing = "0.1.19"
+async-trait = "0.1.42"
+# TODO (XN-1372): can't upgrade yet because of tokio
+reqwest = { version = "0.10.10", default-features = false, features = ["rustls-tls"] }
+structopt = "0.3.21"
+# TODO (XN-1372): upgrade
+tokio = { version = "0.2.24", features = ["sync", "time", "macros", "rt-threaded", "signal"] }
+tracing = "0.1.22"
 tracing-futures = "0.2.4"
-tracing-subscriber = "0.2.12"
+tracing-subscriber = "0.2.15"
 xaynet-core = { path = "../xaynet-core" }
 xaynet-sdk = { path = "../xaynet-sdk", features = ["reqwest-client"] }
 

--- a/rust/xaynet-core/Cargo.toml
+++ b/rust/xaynet-core/Cargo.toml
@@ -11,14 +11,10 @@ license-file = "../../LICENSE"
 keywords = ["federated-learning", "fl", "ai", "machine-learning"]
 categories = ["science", "cryptography"]
 
-[package.metadata]
-# minimum supported rust version
-msrv = "1.48.0"
-
 [dependencies]
-anyhow = "1.0.32"
+anyhow = "1.0.37"
 bitflags = "1.2.1"
-derive_more = { version = "0.99.10", default-features = false, features = [
+derive_more = { version = "0.99.11", default-features = false, features = [
     "as_ref",
     "as_mut",
     "display",
@@ -27,15 +23,15 @@ derive_more = { version = "0.99.10", default-features = false, features = [
     "index_mut",
     "into",
 ] }
-num = { version = "0.3.0", features = ["serde"] }
-rand = "0.7.3"
-rand_chacha = "0.2.2"
-serde = { version = "1.0.116", features = ["derive"] }
+num = { version = "0.3.1", features = ["serde"] }
+rand = "0.8.1"
+rand_chacha = "0.3.0"
+serde = { version = "1.0.118", features = ["derive"] }
 sodiumoxide = "0.2.6"
-thiserror = "1.0.20"
+thiserror = "1.0.23"
 
 [features]
 testutils = []
 
 [dev-dependencies]
-paste = "1.0.3"
+paste = "1.0.4"

--- a/rust/xaynet-mobile/Cargo.toml
+++ b/rust/xaynet-mobile/Cargo.toml
@@ -11,23 +11,21 @@ license-file = "../../LICENSE"
 keywords = ["federated-learning", "fl", "ai", "machine-learning"]
 categories = ["science", "cryptography"]
 
-[package.metadata]
-# minimum supported rust version
-msrv = "1.48.0"
-
 [dependencies]
-ffi-support = "0.4.2"
-xaynet-sdk = { path = "../xaynet-sdk", default-features = false, version = "0.1.0", features = ["reqwest-client"]}
-xaynet-core = { path = "../xaynet-core", version = "0.1.0" }
-async-trait = "0.1.41"
-tracing = "0.1.21"
-tokio = { version = "0.2.22", default-features = false, features = ["rt-core"] }
-thiserror = "1.0.21"
+async-trait = "0.1.42"
 bincode = "1.3.1"
-zeroize = "1.1.1"
-sodiumoxide = "0.2.6"
+ffi-support = "0.4.2"
 # Note that this MUST match the version used in `xaynet-sdk`.
-reqwest = { version = "0.10", default-features = false, features = ["rustls-tls"]}
+# TODO (XN-1372): can't upgrade yet because of tokio
+reqwest = { version = "0.10.10", default-features = false, features = ["rustls-tls"]}
+sodiumoxide = "0.2.6"
+thiserror = "1.0.23"
+tracing = "0.1.22"
+# TODO (XN-1372): upgrade
+tokio = { version = "0.2.24", default-features = false, features = ["rt-core"] }
+xaynet-core = { path = "../xaynet-core", version = "0.1.0" }
+xaynet-sdk = { path = "../xaynet-sdk", default-features = false, version = "0.1.0", features = ["reqwest-client"]}
+zeroize = "1.2.0"
 
 [lib]
 name = "xaynet_mobile"

--- a/rust/xaynet-sdk/Cargo.toml
+++ b/rust/xaynet-sdk/Cargo.toml
@@ -11,40 +11,39 @@ license-file = "../../LICENSE"
 keywords = ["federated-learning", "fl", "ai", "machine-learning"]
 categories = ["science", "cryptography"]
 
-[package.metadata]
-# minimum supported rust version
-msrv = "1.48.0"
-
 [package.metadata."docs.rs"]
 all-features = true
 
 [dependencies]
-async-trait = "0.1.40"
-derive_more = { version = "0.99.10", default-features = false, features = ["from"] }
-serde = { version = "1.0.116", features = ["derive"] }
+async-trait = "0.1.42"
+derive_more = { version = "0.99.11", default-features = false, features = ["from"] }
+serde = { version = "1.0.118", features = ["derive"] }
 sodiumoxide = "0.2.6"
-thiserror = "1.0.20"
-tracing = "0.1.21"
+thiserror = "1.0.23"
+tracing = "0.1.22"
 xaynet-core = { path = "../xaynet-core", version = "0.1.0" }
 
 url = "2.2.0"
 base64 = "0.13.0"
-bincode = { version = "1.3.1" }
+bincode = "1.3.1"
 
 # feature: reqwest client
-reqwest = { version = "0.10", default-features = false, optional = true }
+# TODO (XN-1372): can't upgrade yet because of tokio
+reqwest = { version = "0.10.10", default-features = false, optional = true }
 # This has to match the version used by reqwest. It would be nice if
 # reqwest just re-exported it
-bytes = { version = "0.5", optional = true }
-rand = "0.7.3"
+bytes = { version = "0.5.6", optional = true }
+rand = "0.8.1"
 
 [dev-dependencies]
-mockall = "0.8.3"
-num = { version = "0.3.0", features = ["serde"] }
-serde_json = "1.0.58"
-tokio = { version = "0.2.22", features = ["rt-core", "macros"] }
+mockall = "0.9.0"
+num = { version = "0.3.1", features = ["serde"] }
+serde_json = "1.0.61"
+# TODO (XN-1372): upgrade
+tokio = { version = "0.2.24", features = ["rt-core", "macros"] }
+# TODO (XN-1372): can't upgrade yet because of tokio
 tokio-test = "0.2.1"
-xaynet-core = { path = "../xaynet-core", version = "0.1.0", features = ["testutils"] }
+xaynet-core = { path = "../xaynet-core", features = ["testutils"] }
 
 [features]
 default = []

--- a/rust/xaynet-server/Cargo.toml
+++ b/rust/xaynet-server/Cargo.toml
@@ -11,19 +11,16 @@ license-file = "../../LICENSE"
 keywords = ["federated-learning", "fl", "ai", "machine-learning"]
 categories = ["science", "cryptography"]
 
-[package.metadata]
-# minimum supported rust version
-msrv = "1.48.0"
-
 [dependencies]
-anyhow = "1.0.32"
-async-trait = "0.1.40"
+anyhow = "1.0.37"
+async-trait = "0.1.42"
 bincode = "1.3.1"
 bitflags = "1.2.1"
+# TODO (XN-1527): can't upgrade yet because of warp
 bytes = "0.5.6"
 config = "0.10.1"
 chrono = "0.4.19"
-derive_more = { version = "0.99.10", default-features = false, features = [
+derive_more = { version = "0.99.11", default-features = false, features = [
     "as_mut",
     "as_ref",
     "deref",
@@ -34,18 +31,19 @@ derive_more = { version = "0.99.10", default-features = false, features = [
     "into",
 ] }
 displaydoc = "0.1.7"
-futures = "0.3.5"
+futures = "0.3.9"
 hex = "0.4.2"
-http = "0.2.1"
-influxdb = "0.3"
-num = { version = "0.3.0", features = ["serde"] }
+http = "0.2.2"
+influxdb = "0.3.0"
+num = { version = "0.3.1", features = ["serde"] }
 num_enum = "0.5.1"
 once_cell = "1.5.2"
-paste = "1.0.1"
-rand = "0.7.3"
-rand_chacha = "0.2.2"
-serde = { version = "1.0.116", features = ["derive"] }
-rayon = "1.4.0"
+paste = "1.0.4"
+rand = "0.8.1"
+rand_chacha = "0.3.0"
+serde = { version = "1.0.118", features = ["derive"] }
+rayon = "1.5.0"
+# TODO (XN-1372): can't upgrade yet because of tokio
 redis = { version = "0.17.0", default-features = false, features = [
     "aio",
     "connection-manager",
@@ -53,9 +51,10 @@ redis = { version = "0.17.0", default-features = false, features = [
     "tokio-rt-core",
 ] }
 sodiumoxide = "0.2.6"
-structopt = "0.3.17"
-thiserror = "1.0.20"
-tokio = { version = "0.2.22", features = [
+structopt = "0.3.21"
+thiserror = "1.0.23"
+# TODO (XN-1372): upgrade
+tokio = { version = "0.2.24", features = [
     "macros",
     "rt-core",
     "rt-threaded",
@@ -65,25 +64,30 @@ tokio = { version = "0.2.22", features = [
     "tcp",
     "time",
 ] }
+# TODO (XN-1372): can't upgrade yet because of tokio
 tower = "0.3.1"
-tracing = "0.1.19"
+tracing = "0.1.22"
 tracing-futures = "0.2.4"
-tracing-subscriber = "0.2.12"
-validator = { version = "0.11.0", features = ["derive"] }
-warp = { git = "https://github.com/seanmonstar/warp", rev = "cca5b54a48bd846ae0fcff91eafd6681f1cd9f7d" }
+tracing-subscriber = "0.2.15"
+validator = { version = "0.12.0", features = ["derive"] }
+warp = { git = "https://github.com/seanmonstar/warp", rev = "42fd14fdab8145d27ae770fe4b5c843a99bc2a44" }
 xaynet-core = { path = "../xaynet-core", version = "0.1.0" }
 
 # feature: model-persistence
-fancy-regex = { version = "0.4.0", optional = true }
+fancy-regex = { version = "0.4.1", optional = true }
+# TODO (XN-1372): can't upgrade yet because of tokio
 rusoto_core = { version = "0.45.0", optional = true }
+# TODO (XN-1372): can't upgrade yet because of tokio
 rusoto_s3 = { version = "0.45.0", optional = true }
 base64 = "0.13.0"
 
 [dev-dependencies]
 # We can't run tarpaulin with the flag `--test-threads=1` because it can trigger a segfault:
 # https://github.com/xd009642/tarpaulin/issues/317. A workaround is to use `serial_test`.
-serial_test = "0.5.0"
+serial_test = "0.5.1"
+# TODO (XN-1372): can't upgrade yet because of tokio
 tokio-test = "0.2.1"
+# TODO (XN-1372): can't upgrade yet because of tokio
 tower-test = "0.3.0"
 
 [[bin]]

--- a/rust/xaynet/Cargo.toml
+++ b/rust/xaynet/Cargo.toml
@@ -11,18 +11,16 @@ license-file = "../../LICENSE"
 keywords = ["federated-learning", "fl", "ai", "machine-learning"]
 categories = ["science", "cryptography"]
 
-[package.metadata]
-# minimum supported rust version
-msrv = "1.48.0"
-
 [badges]
 codecov = { repository = "xaynetwork/xaynet", branch = "master", service = "github" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
 xaynet-core = { path = "../xaynet-core", version = "0.1.0" }
+
 # feature: sdk
 xaynet-sdk = { path = "../xaynet-sdk", version = "0.1.0", optional = true }
+
 # feature: server
 xaynet-server = { path = "../xaynet-server", version = "0.1.0", optional = true }
 


### PR DESCRIPTION
**References**

- [XN-1491](https://xainag.atlassian.net/browse/XN-1491)

**Summary**

- updated most of the dependencies
- the remaining dependencies are either blocked by `warp` or `tokio`, put some todos there
- the `xaynet` dependency versions have to be bumped during release
- removed the duplicate `msrv` from the `[package.metadata]`, because already present in `[workspace.metadata]`
