### PR TITLE
Reset should_set_model on new round

### DIFF
--- a/rust/xaynet-mobile/src/participant.rs
+++ b/rust/xaynet-mobile/src/participant.rs
@@ -275,6 +275,7 @@ impl Participant {
                     self.task = Task::Sum;
                 }
                 Some(Event::NewRound) => {
+                    self.should_set_model = false;
                     self.new_global_model = true;
                 }
                 Some(Event::LoadModel) => {


### PR DESCRIPTION
When a new round has started, the participant may no longer have an update participant therefore we reset the `should_set_model` flag on a new round event.