### PR TITLE
add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/rust"
+    schedule:
+      interval: daily
+      time: "09:00"
+      timezone: "Europe/Berlin"
+
+  - package-ecosystem: cargo
+    directory: "/bindings/python"
+    schedule:
+      interval: weekly
+      day: "monday"
+
+  - package-ecosystem: pip
+    directory: "/bindings/python/examples/keras_house_prices"
+    schedule:
+      interval: weekly
+      day: "monday"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ The example can be found under [rust/examples/](./rust/examples/). It uses a dum
 but is network-capable, so it's a good starting point for checking connectivity with
 the coordinator.
 
-### `test-drive-net.rs`
+### `test-drive`
 
 Make sure you have a running instance of the coordinator and that the clients
 you will spawn with the command below are able to reach it through the network.
@@ -247,7 +247,7 @@ running on `127.0.0.1:8081`:
 
 ```bash
 cd rust
-RUST_LOG=info cargo run --example test-drive-net -- -n 20 -u http://127.0.0.1:8081
+RUST_LOG=info cargo run --example test-drive -- -n 20 -u http://127.0.0.1:8081
 ```
 
 For more in-depth details on how to run examples, see the accompanying Getting

--- a/README.tpl
+++ b/README.tpl
@@ -147,7 +147,7 @@ The example can be found under [rust/examples/](./rust/examples/). It uses a dum
 but is network-capable, so it's a good starting point for checking connectivity with
 the coordinator.
 
-### `test-drive-net.rs`
+### `test-drive`
 
 Make sure you have a running instance of the coordinator and that the clients
 you will spawn with the command below are able to reach it through the network.
@@ -157,7 +157,7 @@ running on `127.0.0.1:8081`:
 
 ```bash
 cd rust
-RUST_LOG=info cargo run --example test-drive-net -- -n 20 -u http://127.0.0.1:8081
+RUST_LOG=info cargo run --example test-drive -- -n 20 -u http://127.0.0.1:8081
 ```
 
 For more in-depth details on how to run examples, see the accompanying Getting

--- a/rust/examples/Cargo.toml
+++ b/rust/examples/Cargo.toml
@@ -12,6 +12,10 @@ license-file = "../../LICENSE"
 keywords = ["federated-learning", "fl", "ai", "machine-learning"]
 categories = ["science", "cryptography"]
 
+# https://github.com/http-rs/tide/issues/225
+# https://github.com/dependabot/dependabot-core/issues/1156
+autobins = false
+
 [dev-dependencies]
 async-trait = "0.1.42"
 # TODO (XN-1372): can't upgrade yet because of tokio


### PR DESCRIPTION
adds and enables dependabot for:
- xaynet workspace (checks daily whether new versions of the dependencies are available)
- python bindings (weekly checks)
- dependencies of the keras example (weekly checks)
- github actions (weekly checks)
- disable binary auto discovery for `examples` (https://github.com/dependabot/dependabot-core/issues/1156)
- updated README