### PR TITLE
add python migration guide

### DIFF
--- a/bindings/python/examples/keras_house_prices/README.md
+++ b/bindings/python/examples/keras_house_prices/README.md
@@ -1,5 +1,9 @@
 # `keras_house_prices` Example
 
+**Prerequisites**
+
+- Python 3.7.1 or higher
+
 1. Adjust the coordinator settings
 
 Change the model length to `55117` and the `bound_type` to `B2`

--- a/bindings/python/examples/keras_house_prices/keras_house_prices/participant.py
+++ b/bindings/python/examples/keras_house_prices/keras_house_prices/participant.py
@@ -100,10 +100,10 @@ class Participant(  # pylint: disable=too-few-public-methods,too-many-instance-a
 
         return self.regressor.get_weights()
 
-    def deserialize_training_input(self, global_model: list) -> Optional[np.ndarray]:
+    def deserialize_training_input(self, global_model: list) -> np.ndarray:
         return np.array(global_model)
 
-    def serialize_training_result(self, training_result: np.ndarray) -> bytes:
+    def serialize_training_result(self, training_result: np.ndarray) -> list:
         return training_result.tolist()
 
     def on_stop(self) -> None:

--- a/bindings/python/examples/keras_house_prices/setup.py
+++ b/bindings/python/examples/keras_house_prices/setup.py
@@ -7,14 +7,14 @@ setup(
     author=["Xayn Engineering"],
     author_email="engineering@xaynet.dev",
     license="Apache License Version 2.0",
-    python_requires=">=3.6",
+    python_requires=">=3.7.1",
     packages=find_packages(),
     install_requires=[
         "pandas==1.2.0",
         "scikit-learn==0.24.0",
         "tensorflow==2.4.0",
         "numpy~=1.19.2",
-        "tabulate~=0.8",
+        "tabulate~=0.8.7",
     ],
     entry_points={
         "console_scripts": [

--- a/bindings/python/examples/participate_in_update.py
+++ b/bindings/python/examples/participate_in_update.py
@@ -36,7 +36,7 @@ class Participant(xaynet_sdk.ParticipantABC):
         if get_battery_level() < 20:
             LOG.info("low battery, skip training")
             return False
-        LOG.info("enough battery, participate in update")
+        LOG.info("enough battery, participate in update task")
         return True
 
     def on_new_global_model(self, global_model: Optional[list]) -> None:

--- a/bindings/python/migration_guide.md
+++ b/bindings/python/migration_guide.md
@@ -1,0 +1,114 @@
+# Migration from `v0.8.0` to `v.0.11.0`
+
+To demonstrate the API changes from `v0.8.0` to `v.0.11.0`, we will use the keras example
+which is available in both versions. For reasons of clarity, some parts of the code have
+been removed.
+
+## [`v0.8.0`](https://github.com/xaynetwork/xaynet/blob/v0.8.0/python/sdk/xain_sdk/participant.py#L24)
+
+```bash
+pip install xain-sdk
+```
+
+```python
+from xain_sdk import ParticipantABC, configure_logging, run_participant
+
+class Participant(ParticipantABC):
+    def train_round(
+        self, training_input: Optional[np.ndarray]
+    ) -> Tuple[np.ndarray, int]:
+        if training_input is None:
+            self.regressor = Regressor(len(self.trainset_x.columns))
+            return (self.regressor.get_weights(), 0)
+
+        return (self.regressor.get_weights(), self.number_of_samples)
+
+    def deserialize_training_input(self, data: bytes) -> Optional[np.ndarray]:
+        if not data:
+            return None
+
+        reader = BytesIO(data)
+        return np.load(reader, allow_pickle=False)
+
+    def serialize_training_result(
+        self, training_result: Tuple[np.ndarray, int]
+    ) -> bytes:
+        (weights, number_of_samples) = training_result
+
+        writer = BytesIO()
+        writer.write(number_of_samples.to_bytes(4, byteorder="big"))
+        np.save(writer, weights, allow_pickle=False)
+        return writer.getbuffer()[:]
+
+def main() -> None:
+    participant = Participant(args.data_directory)
+
+    run_participant(
+        participant, args.coordinator_url, heartbeat_period=args.heartbeat_period
+    )
+```
+
+## `v0.11.0`
+
+```bash
+pip install xaynet-sdk-python
+```
+
+```python
+# - renamed `run_participant` to `spawn_participant`
+# - removed `configure_logging`
+from xaynet_sdk import ParticipantABC, spawn_participant
+
+class Participant(ParticipantABC):
+    # Returns:
+    #   - returns a `np.ndarray` instead of `Tuple[np.ndarray, int]`
+    #     The scalar has been moved to the `spawn_participant` function.
+    #     This change is only temporary. In a future version it will again
+    #     be possible to set the scalar in the `train_round` method.
+    def train_round(self, training_input: Optional[np.ndarray]) -> np.ndarray:
+        if training_input is None:
+            self.regressor = Regressor(len(self.trainset_x.columns))
+            return self.regressor.get_weights()
+
+        return self.regressor.get_weights()
+
+    # Args:
+    #   - renamed `data` to `global_model`
+    #   - provides a `list` instead of `Optional[bytes]`
+    #   - `deserialize_training_input` is not called if `global_model` is `None`
+    #     therefore the `None` case no longer needs to be handled.
+    #
+    # Returns:
+    #   - returns a `np.ndarray` instead of `Optional[np.ndarray]`
+    def deserialize_training_input(self, global_model: list) -> np.ndarray:
+        return np.array(global_model)
+
+    # Args:
+    #   - provides a `np.ndarray` instead of `Tuple[np.ndarray, int]`
+    #
+    # Returns:
+    #   - returns a `list` instead of `bytes`
+    def serialize_training_result(self, training_result: np.ndarray) -> list:
+        return training_result.tolist()
+
+def main() -> None:
+    # - `spawn_participant` spawns the participant in a separate thread instead of the main thread.
+    #
+    # Args:
+    #   - removed `heartbeat_period`
+    #   - `Participant` is instantiated in the participant thread instead of the main thread.
+    #     This ensures that both the participant as well as the model of `Participant` live on
+    #     the same thread. If they don't live on the same thread, it can cause problems with some
+    #     of the ml frameworks.
+    participant = spawn_participant(
+        args.coordinator_url,
+        Participant,
+        args=(args.data_directory,)
+        scalar = 1 / number_of_samples
+    )
+
+    try:
+        participant.join()
+    except KeyboardInterrupt:
+        participant.stop()
+```

--- a/bindings/python/migration_guide.md
+++ b/bindings/python/migration_guide.md
@@ -48,7 +48,7 @@ def main() -> None:
     )
 ```
 
-## `v0.11.0`
+## [`v0.11.0`](https://github.com/xaynetwork/xaynet/blob/v0.11.0/bindings/python/xaynet_sdk/participant.py)
 
 ```bash
 pip install xaynet-sdk-python

--- a/bindings/python/xaynet_sdk/__init__.py
+++ b/bindings/python/xaynet_sdk/__init__.py
@@ -26,6 +26,14 @@ def spawn_participant(
         state: A serialized participant state. Defaults to `None`.
         scalar: The scalar used for masking. Defaults to `1.0`.
 
+    Note:
+        The `scalar` is used later when the models are aggregated in order to scale their weights.
+        It can be used when you want to weight the participants updates differently.
+
+        For example:
+        If not all participant updates should be weighted equally but proportionally to their
+        training samples, the scalar would be set to `scalar = 1 / number_of_samples`.
+
     Returns:
         The `InternalParticipant`.
 
@@ -60,6 +68,14 @@ def spawn_async_participant(
         coordinator_url: The url of the coordinator.
         state: A serialized participant state. Defaults to `None`.
         scalar: The scalar used for masking. Defaults to `1.0`.
+
+    Note:
+        The `scalar` is used later when the models are aggregated in order to scale their weights.
+        It can be used when you want to weight the participants updates differently.
+
+        For example:
+        If not all participant updates should be weighted equally but proportionally to their
+        training samples, the scalar would be set to `scalar = 1 / number_of_samples`.
 
     Returns:
         A tuple which consists of an `AsyncParticipant` and a global model notifier.

--- a/bindings/python/xaynet_sdk/async_participant.py
+++ b/bindings/python/xaynet_sdk/async_participant.py
@@ -93,7 +93,7 @@ class AsyncParticipant(threading.Thread):
     def set_local_model(self, local_model: list):
         """
         Sets a local model. This method can be called at any time. Internally the
-        participant first caches the local model. As soon as the participant is selected as the
+        participant first caches the local model. As soon as the participant is selected as an
         update participant, the currently cached local model is used. This means that the cache
         is empty after this operation.
 

--- a/bindings/python/xaynet_sdk/participant.py
+++ b/bindings/python/xaynet_sdk/participant.py
@@ -71,7 +71,7 @@ class ParticipantABC(ABC):
         A callback used by the `InternalParticipant` to determine whether the
         `train_round` method should be called. This callback is only called
         if the participant is selected as an update participant. If `participate_in_update_task`
-        returns the `False`, `train_round` will not be called by the `InternalParticipant`.
+        returns `False`, `train_round` will not be called by the `InternalParticipant`.
 
         If the method is not overridden, it returns `True` by default.
 


### PR DESCRIPTION
- added python migration guide ([rendered version](https://github.com/xaynetwork/xaynet/blob/python-migration-guide/bindings/python/migration_guide.md))
- fixed type issues in the example
- added a note that Python 3.7.1 or higher (because of pandas) is required to run the example 