### PR TITLE
XN-1508 split count settings and invariants

### DIFF
--- a/configs/config.toml
+++ b/configs/config.toml
@@ -10,12 +10,16 @@ tls_key = "/app/ssl/tls.key"
 [pet]
 min_sum_count = 1
 min_update_count = 3
+min_sum2_count = 1
 max_sum_count = 100
 max_update_count = 10000
+max_sum2_count = 100
 min_sum_time = 5
 min_update_time = 10
+min_sum2_time = 5
 max_sum_time = 3600
 max_update_time = 3600
+max_sum2_time = 3600
 sum = 0.5
 update = 0.9
 

--- a/configs/docker-dev.toml
+++ b/configs/docker-dev.toml
@@ -10,12 +10,16 @@ tls_key = "/app/ssl/tls.key"
 [pet]
 min_sum_count = 1
 min_update_count = 3
+min_sum2_count = 1
 max_sum_count = 100
 max_update_count = 10000
+max_sum2_count = 100
 min_sum_time = 5
 min_update_time = 10
+min_sum2_time = 5
 max_sum_time = 3600
 max_update_time = 3600
+max_sum2_time = 3600
 sum = 0.01
 update = 0.1
 

--- a/k8s/coordinator/development/config.toml
+++ b/k8s/coordinator/development/config.toml
@@ -9,12 +9,16 @@ tls_key = "/app/ssl/tls.key"
 [pet]
 min_sum_count = 1
 min_update_count = 3
+min_sum2_count = 1
 max_sum_count = 100
 max_update_count = 10000
+max_sum2_count = 100
 min_sum_time = 5
 min_update_time = 10
+min_sum2_time = 5
 max_sum_time = 3600
 max_update_time = 3600
+max_sum2_time = 3600
 sum = 0.5
 update = 0.9
 

--- a/rust/xaynet-core/src/message/message.rs
+++ b/rust/xaynet-core/src/message/message.rs
@@ -14,6 +14,12 @@ use crate::{
     message::{Chunk, DecodeError, FromBytes, Payload, Sum, Sum2, ToBytes, Update},
 };
 
+/// The minimum number of accepted `sum`/`sum2` messages for the PET protocol to function correctly.
+pub const MIN_SUM_COUNT: u64 = 1;
+
+/// The minimum number of accepted `update` messages for the PET protocol to function correctly.
+pub const MIN_UPDATE_COUNT: u64 = 3;
+
 pub(crate) mod ranges {
     use std::ops::Range;
 

--- a/rust/xaynet-core/src/message/mod.rs
+++ b/rust/xaynet-core/src/message/mod.rs
@@ -32,7 +32,15 @@ pub(crate) mod traits;
 pub(crate) mod utils;
 
 pub use self::{
-    message::{Flags, Message, MessageBuffer, Tag, HEADER_LENGTH as MESSAGE_HEADER_LENGTH},
+    message::{
+        Flags,
+        Message,
+        MessageBuffer,
+        Tag,
+        HEADER_LENGTH as MESSAGE_HEADER_LENGTH,
+        MIN_SUM_COUNT,
+        MIN_UPDATE_COUNT,
+    },
     payload::{
         chunk::{Chunk, ChunkBuffer},
         sum::{Sum, SumBuffer},

--- a/rust/xaynet-server/src/examples.rs
+++ b/rust/xaynet-server/src/examples.rs
@@ -88,12 +88,16 @@ bind_address = "127.0.0.1:8081"
 [pet]
 min_sum_count = 1
 min_update_count = 3
+min_sum2_count = 1
 max_sum_count = 100
 max_update_count = 10000
+max_sum2_count = 100
 min_sum_time = 5
 min_update_time = 10
+min_sum2_time = 5
 max_sum_time = 3600
 max_update_time = 3600
+max_sum2_time = 3600
 sum = 0.1
 update = 0.9
 
@@ -119,23 +123,20 @@ server and client authentication.
 
 The [`PetSettings`] specify various parameters of the PET protocol:
 
-- The most
-important are [`sum`] and [`update`], which are the probabilities assigned to
-the selection of sum and update participants, respectively (note that if a
-participant is selected for both roles, the *sum* role takes precedence).
+- The most important are [`sum`] and [`update`], which are the probabilities assigned to the
+selection of sum and update participants, respectively (note that if a participant is selected for
+both roles, the *sum* role takes precedence).
 
-- The settings [`min_sum_count`] and [`min_update_count`] specify, respectively,
-the minimum number of `sum`/`sum2` and `update` messages the coordinator should
-accept. By default, they are set to the theoretical minimum in order for the
-protocol to function correctly. Similarly, the [`max_sum_count`] and [`max_update_count`] specify
-the maximum number of `sum`/`sum2` and `update` messages the coordinator should accept.
+- The settings [`min_sum_count`], [`min_update_count`] and [`min_sum2_count`] specify, respectively,
+the minimum number of `sum`, `update` and `sum2` messages the coordinator should accept. Similarly,
+the [`max_sum_count`], [`max_update_count`] and [`max_sum2_count`] specify the maximum number of
+`sum`, `update` and `sum2` messages the coordinator should accept.
 
-- To complement, the settings [`min_sum_time`] and
-[`min_update_time`] specify, respectively, the minimum amount of time (in
-seconds) the coordinator should wait for `sum`/`sum2` and `update` messages. To
-allow for more messages to be processed, increase these times. Similarly, the [`max_sum_time`] and
-[`max_update_time`] specify the maximum amount of time (in seconds) the coordinator should wait for
-`sum`/`sum2` and `update` messages.
+- To complement, the settings [`min_sum_time`], [`min_update_time`] and [`min_sum2_time`] specify,
+respectively, the minimum amount of time (in seconds) the coordinator should wait for `sum`,
+`update` and `sum2` messages. To allow for more messages to be processed, increase these times.
+Similarly, the [`max_sum_time`], [`max_update_time`] and [`max_sum2_time`] specify the maximum
+amount of time (in seconds) the coordinator should wait for `sum`, `update` and `sum2` messages.
 
 The [`MaskSettings`] determines the masking configuration, consisting of the
 group type, data type, bound type and model type. The [`ModelSettings`] specify
@@ -169,12 +170,16 @@ $ RUST_LOG=info cargo run --example test-drive -- -n 10
 [`update`]: crate::settings::PetSettings::update
 [`min_sum_count`]: crate::settings::PetSettings::min_sum_count
 [`min_update_count`]: crate::settings::PetSettings::min_update_count
+[`min_sum2_count`]: crate::settings::PetSettings::min_sum2_count
 [`max_sum_count`]: crate::settings::PetSettings::max_sum_count
 [`max_update_count`]: crate::settings::PetSettings::max_update_count
+[`max_sum2_count`]: crate::settings::PetSettings::max_sum2_count
 [`min_sum_time`]: crate::settings::PetSettings::min_sum_time
 [`min_update_time`]: crate::settings::PetSettings::min_update_time
+[`min_sum2_time`]: crate::settings::PetSettings::min_sum2_time
 [`max_sum_time`]: crate::settings::PetSettings::max_sum_time
 [`max_update_time`]: crate::settings::PetSettings::max_update_time
+[`max_sum2_time`]: crate::settings::PetSettings::max_sum2_time
 [`MaskSettings`]: crate::settings::MaskSettings
 [`ModelSettings`]: crate::settings::ModelSettings
 [`Model`]: xaynet_core::mask::Model

--- a/rust/xaynet-server/src/settings/s3.rs
+++ b/rust/xaynet-server/src/settings/s3.rs
@@ -263,12 +263,16 @@ mod tests {
             [pet]
             min_sum_count = 1
             min_update_count = 3
+            min_sum2_count = 1
             max_sum_count = 100
             max_update_count = 10000
+            max_sum2_count = 100
             min_sum_time = 5
             min_update_time = 10
+            min_sum2_time = 5
             max_sum_time = 3600
             max_update_time = 3600
+            max_sum2_time = 3600
             sum = 0.5
             update = 0.9
             "#;

--- a/rust/xaynet-server/src/state_machine/coordinator.rs
+++ b/rust/xaynet-server/src/state_machine/coordinator.rs
@@ -18,22 +18,30 @@ pub struct CoordinatorState {
     pub round_id: u64,
     /// The round parameters.
     pub round_params: RoundParameters,
-    /// The minimum of required sum/sum2 messages.
+    /// The minimum of required sum messages.
     pub min_sum_count: u64,
     /// The minimum of required update messages.
     pub min_update_count: u64,
-    /// The maximum of accepted sum/sum2 messages.
+    /// The minimum of required sum2 messages.
+    pub min_sum2_count: u64,
+    /// The maximum of accepted sum messages.
     pub max_sum_count: u64,
     /// The maximum of accepted update messages.
     pub max_update_count: u64,
-    /// The minimum time (in seconds) reserved for processing sum/sum2 messages.
+    /// The maximum of accepted sum2 messages.
+    pub max_sum2_count: u64,
+    /// The minimum time (in seconds) reserved for processing sum messages.
     pub min_sum_time: u64,
     /// The minimum time (in seconds) reserved for processing update messages.
     pub min_update_time: u64,
-    /// The maximum time (in seconds) permitted for processing sum/sum2 messages.
+    /// The minimum time (in seconds) reserved for processing sum2 messages.
+    pub min_sum2_time: u64,
+    /// The maximum time (in seconds) permitted for processing sum messages.
     pub max_sum_time: u64,
     /// The maximum time (in seconds) permitted for processing update messages.
     pub max_update_time: u64,
+    /// The maximum time (in seconds) permitted for processing sum2 messages.
+    pub max_sum2_time: u64,
 }
 
 impl CoordinatorState {
@@ -43,13 +51,12 @@ impl CoordinatorState {
         model_settings: ModelSettings,
     ) -> Self {
         let keys = EncryptKeyPair::generate();
-        let mask_config: MaskConfig = mask_settings.into();
         let round_params = RoundParameters {
             pk: keys.public,
             sum: pet_settings.sum,
             update: pet_settings.update,
             seed: RoundSeed::zeroed(),
-            mask_config: mask_config.clone().into(),
+            mask_config: MaskConfig::from(mask_settings).into(),
             model_length: model_settings.length,
         };
         let round_id = 0;
@@ -59,12 +66,16 @@ impl CoordinatorState {
             round_id,
             min_sum_count: pet_settings.min_sum_count,
             min_update_count: pet_settings.min_update_count,
+            min_sum2_count: pet_settings.min_sum2_count,
             max_sum_count: pet_settings.max_sum_count,
             max_update_count: pet_settings.max_update_count,
+            max_sum2_count: pet_settings.max_sum2_count,
             min_sum_time: pet_settings.min_sum_time,
             min_update_time: pet_settings.min_update_time,
+            min_sum2_time: pet_settings.min_sum2_time,
             max_sum_time: pet_settings.max_sum_time,
             max_update_time: pet_settings.max_update_time,
+            max_sum2_time: pet_settings.max_sum2_time,
         }
     }
 }

--- a/rust/xaynet-server/src/state_machine/phases/sum2.rs
+++ b/rust/xaynet-server/src/state_machine/phases/sum2.rs
@@ -39,8 +39,8 @@ where
     const NAME: PhaseName = PhaseName::Sum2;
 
     async fn run(&mut self) -> Result<(), PhaseStateError> {
-        let min_time = self.shared.state.min_sum_time;
-        let max_time = self.shared.state.max_sum_time;
+        let min_time = self.shared.state.min_sum2_time;
+        let max_time = self.shared.state.max_sum2_time;
         debug!(
             "in sum2 phase for min {} and max {} seconds",
             min_time, max_time,
@@ -52,7 +52,9 @@ where
 
         info!(
             "in total {} sum2 messages accepted (min {} and max {} required)",
-            self.private.accepted, self.shared.state.min_sum_count, self.shared.state.max_sum_count,
+            self.private.accepted,
+            self.shared.state.min_sum2_count,
+            self.shared.state.max_sum2_count,
         );
         info!("in total {} sum2 messages rejected", self.private.rejected);
         info!(
@@ -90,18 +92,20 @@ where
     }
 
     fn has_enough_messages(&self) -> bool {
-        self.private.accepted >= self.shared.state.min_sum_count
+        self.private.accepted >= self.shared.state.min_sum2_count
     }
 
     fn has_overmuch_messages(&self) -> bool {
-        self.private.accepted >= self.shared.state.max_sum_count
+        self.private.accepted >= self.shared.state.max_sum2_count
     }
 
     fn increment_accepted(&mut self) {
         self.private.accepted += 1;
         debug!(
             "{} sum2 messages accepted (min {} and max {} required)",
-            self.private.accepted, self.shared.state.min_sum_count, self.shared.state.max_sum_count,
+            self.private.accepted,
+            self.shared.state.min_sum2_count,
+            self.shared.state.max_sum2_count,
         );
     }
 
@@ -233,8 +237,10 @@ mod tests {
             .with_max_sum_count(n_summers + 10)
             .with_min_update_count(n_updaters)
             .with_max_update_count(n_updaters + 10)
-            .with_min_sum_time(1)
-            .with_max_sum_time(2)
+            .with_min_sum2_count(n_summers)
+            .with_max_sum2_count(n_summers + 10)
+            .with_min_sum2_time(1)
+            .with_max_sum2_time(2)
             .with_mask_config(utils::mask_settings().into())
             .build();
         assert!(state_machine.is_sum2());

--- a/rust/xaynet-server/src/state_machine/tests/builder.rs
+++ b/rust/xaynet-server/src/state_machine/tests/builder.rs
@@ -128,6 +128,16 @@ where
         self
     }
 
+    pub fn with_min_sum2_count(mut self, min_sum2: u64) -> Self {
+        self.coordinator_state.min_sum2_count = min_sum2;
+        self
+    }
+
+    pub fn with_max_sum2_count(mut self, max_sum2: u64) -> Self {
+        self.coordinator_state.max_sum2_count = max_sum2;
+        self
+    }
+
     pub fn with_model_length(mut self, model_length: usize) -> Self {
         self.coordinator_state.round_params.model_length = model_length;
         self
@@ -150,6 +160,16 @@ where
 
     pub fn with_max_update_time(mut self, in_secs: u64) -> Self {
         self.coordinator_state.max_update_time = in_secs;
+        self
+    }
+
+    pub fn with_min_sum2_time(mut self, in_secs: u64) -> Self {
+        self.coordinator_state.min_sum2_time = in_secs;
+        self
+    }
+
+    pub fn with_max_sum2_time(mut self, in_secs: u64) -> Self {
+        self.coordinator_state.max_sum2_time = in_secs;
         self
     }
 

--- a/rust/xaynet-server/src/state_machine/tests/mod.rs
+++ b/rust/xaynet-server/src/state_machine/tests/mod.rs
@@ -35,8 +35,9 @@ async fn integration_full_round() {
         mask_config: mask_config(),
         model_length,
     };
+    let n_summers = 3;
     let n_updaters = 3;
-    let n_summers = 2;
+    let n_summers2 = 2;
 
     let mut store = init_store().await;
     let (state_machine, requests, events) = StateMachineBuilder::new(store.clone())
@@ -48,10 +49,14 @@ async fn integration_full_round() {
         .with_max_sum_count(n_summers + 10)
         .with_min_update_count(n_updaters)
         .with_max_update_count(n_updaters + 10)
+        .with_min_sum2_count(n_summers2)
+        .with_max_sum2_count(n_summers2 + 10)
         .with_min_sum_time(1)
         .with_max_sum_time(2)
         .with_min_update_time(1)
         .with_max_update_time(2)
+        .with_min_sum2_time(1)
+        .with_max_sum2_time(2)
         .with_model_length(model_length)
         .build();
 

--- a/rust/xaynet-server/src/state_machine/tests/utils.rs
+++ b/rust/xaynet-server/src/state_machine/tests/utils.rs
@@ -188,12 +188,16 @@ pub fn pet_settings() -> PetSettings {
         update: 0.5,
         min_sum_count: 1,
         min_update_count: 3,
+        min_sum2_count: 1,
         max_sum_count: 100,
         max_update_count: 1000,
+        max_sum2_count: 100,
         min_sum_time: 1,
-        max_sum_time: 2,
         min_update_time: 1,
+        min_sum2_time: 1,
+        max_sum_time: 2,
         max_update_time: 2,
+        max_sum2_time: 2,
     }
 }
 


### PR DESCRIPTION
**References**

- [XN-1508](https://xainag.atlassian.net/browse/XN-1508)

**Summary**

- split protocol count invariants from settings
- update docs and examples
- add sum2 time settings and update tests
- update config files
- update state machine and tests
