### PR TITLE
set max message size to unlimited

### DIFF
--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -1594,6 +1594,7 @@ dependencies = [
  "tracing-subscriber",
  "xaynet-core",
  "xaynet-mobile",
+ "xaynet-sdk",
 ]
 
 [[package]]

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -42,12 +42,13 @@ requires-dist = [
 msrv = "1.48.0"
 
 [dependencies]
-xaynet-core = { path = "../../rust/xaynet-core"}
-xaynet-mobile = { path = "../../rust/xaynet-mobile"}
-tracing = "0.1.22"
 sodiumoxide = "0.2.6"
+tracing = "0.1.22"
 tracing-subscriber = "0.2.15"
 pyo3 = {version = "0.13.1", features = ["abi3-py36", "extension-module"]}
+xaynet-core = { path = "../../rust/xaynet-core"}
+xaynet-mobile = { path = "../../rust/xaynet-mobile"}
+xaynet-sdk = { path = "../../rust/xaynet-sdk"}
 
 [lib]
 name = "xaynet_sdk"

--- a/bindings/python/src/python_ffi.rs
+++ b/bindings/python/src/python_ffi.rs
@@ -7,6 +7,7 @@ use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
 use xaynet_core::mask::IntoPrimitives;
 use xaynet_core::mask::{DataType, FromPrimitives, Model};
+use xaynet_sdk::settings::MaxMessageSize;
 
 use crate::from_primitives;
 use crate::into_primitives;
@@ -73,9 +74,10 @@ impl Participant {
         } else {
             debug!("initialize participant");
             let mut settings = xaynet_mobile::Settings::new();
-            settings.set_keys(xaynet_core::crypto::SigningKeyPair::generate());
             settings.set_url(url);
+            settings.set_keys(xaynet_core::crypto::SigningKeyPair::generate());
             settings.set_scalar(scalar);
+            settings.set_max_message_size(MaxMessageSize::unlimited());
 
             xaynet_mobile::Participant::new(settings).map_err(|err| {
                 ParticipantInit::new_err(format!("failed to initialize participant: {}", err))

--- a/rust/xaynet-mobile/src/settings.rs
+++ b/rust/xaynet-mobile/src/settings.rs
@@ -10,12 +10,14 @@ use xaynet_sdk::settings::{MaxMessageSize, PetSettings};
 /// A participant settings
 #[derive(Clone, Debug)]
 pub struct Settings {
-    /// The participant signing keys
-    keys: Option<SigningKeyPair>,
-    /// The Xaynet coordinator URL
+    /// The Xaynet coordinator URL.
     url: Option<String>,
-    /// The scalar used for masking
+    /// The participant signing keys.
+    keys: Option<SigningKeyPair>,
+    /// The scalar used for masking.
     scalar: f64,
+    /// The maximum possible size of a message.
+    max_message_size: MaxMessageSize,
 }
 
 impl Default for Settings {
@@ -25,12 +27,13 @@ impl Default for Settings {
 }
 
 impl Settings {
-    /// Create new empty settings
+    /// Create new empty settings.
     pub fn new() -> Self {
         Self {
-            keys: None,
             url: None,
+            keys: None,
             scalar: 1.0,
+            max_message_size: MaxMessageSize::default(),
         }
     }
 
@@ -47,6 +50,11 @@ impl Settings {
     /// Set the Xaynet coordinator address
     pub fn set_url(&mut self, url: String) {
         self.url = Some(url);
+    }
+
+    /// Sets the maximum possible size of a message.
+    pub fn set_max_message_size(&mut self, size: MaxMessageSize) {
+        self.max_message_size = size;
     }
 
     /// Check whether the settings are complete and valid
@@ -74,16 +82,21 @@ impl TryInto<(String, PetSettings)> for Settings {
     type Error = SettingsError;
 
     fn try_into(self) -> Result<(String, PetSettings), Self::Error> {
-        let Settings { keys, url, scalar } = self;
+        let Settings {
+            keys,
+            url,
+            scalar,
+            max_message_size,
+        } = self;
 
         let url = url.ok_or(SettingsError::MissingUrl)?;
 
         let keys = keys.ok_or(SettingsError::MissingKeys)?;
 
         let pet_settings = PetSettings {
-            scalar,
-            max_message_size: MaxMessageSize::default(),
             keys,
+            scalar,
+            max_message_size,
         };
 
         Ok((url, pet_settings))


### PR DESCRIPTION
Small pr that sets the `MaxMessageSize` to `unlimited` in the python participant.
The python bindings are primarily there to experiment with fed ml/secure aggragtion. 
So there is not need to split these messages. 
Does not fix `XN-1503` because we still need to expose this setting to the C API 
and it would be nice to make it configurable in the python participant