### PR TITLE
add data combiner unit tests

### DIFF
--- a/rust/xaynet-analytics/src/data_combination/data_combiner.rs
+++ b/rust/xaynet-analytics/src/data_combination/data_combiner.rs
@@ -173,10 +173,10 @@ where
         metadata: DataPointMetadata,
         n_periods_override: Option<u32>,
     ) -> DateTime<Utc> {
-        let n_periods = if n_periods_override == None {
-            metadata.period.n
+        let n_periods = if let Some(n_periods) = n_periods_override {
+            n_periods
         } else {
-            n_periods_override.unwrap()
+            metadata.period.n
         };
         let avg_days_per_month = 365.0 / 12.0;
         let midnight_end_of_period = get_midnight(metadata.end);
@@ -262,15 +262,15 @@ mod tests {
         let metadata = DataPointMetadata::new(Period::new(PeriodUnit::Days, 1), end_period);
         let screen_route = "home_screen".to_string();
         let first_event = AnalyticsEvent::new(
-            "test1".to_string(),
+            "test1",
             AnalyticsEventType::ScreenEnter,
             end_period - Duration::hours(12),
-            Some(screen_route.clone()),
+            screen_route.clone(),
         );
         let all_events = vec![
             first_event.clone(),
             AnalyticsEvent::new(
-                "test1".to_string(),
+                "test1",
                 AnalyticsEventType::AppEvent,
                 end_period - Duration::hours(13),
                 None,
@@ -294,10 +294,10 @@ mod tests {
         let metadata = DataPointMetadata::new(Period::new(PeriodUnit::Days, 1), end_period);
         let screen_route = "home_screen".to_string();
         let events = vec![AnalyticsEvent::new(
-            "test1".to_string(),
+            "test1",
             AnalyticsEventType::ScreenEnter,
             end_period - Duration::hours(12),
-            Some(screen_route.clone()),
+            screen_route.clone(),
         )];
         let expected_output = vec![DataPoint::ScreenEnterCount(CalcScreenEnterCount::new(
             metadata,
@@ -316,7 +316,7 @@ mod tests {
             .with_timezone(&Utc);
         let metadata = DataPointMetadata::new(Period::new(PeriodUnit::Days, 1), end_period);
         let events = vec![AnalyticsEvent::new(
-            "test1".to_string(),
+            "test1",
             AnalyticsEventType::AppEvent,
             end_period - Duration::hours(12),
             None,
@@ -338,7 +338,7 @@ mod tests {
             .with_timezone(&Utc);
         let metadata = DataPointMetadata::new(Period::new(PeriodUnit::Days, 1), end_period);
         let events = vec![AnalyticsEvent::new(
-            "test1".to_string(),
+            "test1",
             AnalyticsEventType::AppEvent,
             end_period - Duration::hours(12),
             None,
@@ -359,19 +359,19 @@ mod tests {
             .with_timezone(&Utc);
         let metadata = DataPointMetadata::new(Period::new(PeriodUnit::Days, 3), end_period);
         let event_before = AnalyticsEvent::new(
-            "test1".to_string(),
+            "test1",
             AnalyticsEventType::AppEvent,
             end_period - Duration::days(5),
             None,
         );
         let event_during = AnalyticsEvent::new(
-            "test2".to_string(),
+            "test2",
             AnalyticsEventType::AppEvent,
             end_period - Duration::days(1),
             None,
         );
         let event_after = AnalyticsEvent::new(
-            "test3".to_string(),
+            "test3",
             AnalyticsEventType::AppEvent,
             end_period + Duration::days(2),
             None,
@@ -435,13 +435,13 @@ mod tests {
         let data_combiner = DataCombiner::new(MockAnalyticsDataProvider {});
         let end_of_period = Utc::now();
         let event_before = AnalyticsEvent::new(
-            "test1".to_string(),
+            "test1",
             AnalyticsEventType::AppEvent,
             end_of_period - Duration::days(1),
             None,
         );
         let event_after = AnalyticsEvent::new(
-            "test2".to_string(),
+            "test2",
             AnalyticsEventType::AppEvent,
             end_of_period + Duration::days(1),
             None,
@@ -458,16 +458,16 @@ mod tests {
         let timestamp = Utc::now();
         let home_route = "home_screen".to_string();
         let home_route_event = AnalyticsEvent::new(
-            "test1".to_string(),
+            "test1",
             AnalyticsEventType::AppEvent,
             timestamp,
-            Some(home_route.clone()),
+            home_route.clone(),
         );
         let other_route_event = AnalyticsEvent::new(
-            "test2".to_string(),
+            "test2",
             AnalyticsEventType::ScreenEnter,
             timestamp,
-            Some("other_screen".to_string()),
+            "other_screen".to_string(),
         );
         let all_events = vec![home_route_event.clone(), other_route_event];
         let expected_output = vec![home_route_event];

--- a/rust/xaynet-analytics/src/data_combination/data_combiner.rs
+++ b/rust/xaynet-analytics/src/data_combination/data_combiner.rs
@@ -40,19 +40,19 @@ where
             DataPointMetadata::new(Period::new(PeriodUnit::Months, 3), end_period),
         ];
         let was_active_past_days_metadatas = vec![
-            one_day_period_metadata.clone(),
+            one_day_period_metadata,
             DataPointMetadata::new(Period::new(PeriodUnit::Days, 7), end_period),
             DataPointMetadata::new(Period::new(PeriodUnit::Days, 28), end_period),
         ];
 
         empty::<DataPoint>()
             .chain(self.init_screen_active_time_vars(
-                one_day_period_metadata.clone(),
+                one_day_period_metadata,
                 events.clone(),
                 &screen_routes,
             ))
             .chain(self.init_screen_enter_count_vars(
-                one_day_period_metadata.clone(),
+                one_day_period_metadata,
                 events.clone(),
                 &screen_routes,
             ))
@@ -60,12 +60,7 @@ where
                 was_active_each_period_metadatas,
                 events.clone(),
             ))
-            .chain(
-                self.init_was_active_past_n_days_vars(
-                    was_active_past_days_metadatas,
-                    events.clone(),
-                ),
-            )
+            .chain(self.init_was_active_past_n_days_vars(was_active_past_days_metadatas, events))
             .collect()
     }
 
@@ -83,7 +78,7 @@ where
         &self,
         metadata: DataPointMetadata,
         events: Vec<AnalyticsEvent>,
-        screen_routes: &Vec<String>,
+        screen_routes: &[String],
     ) -> Vec<DataPoint> {
         let mut screen_active_time_vars: Vec<DataPoint> = screen_routes
             .iter()
@@ -107,7 +102,7 @@ where
         &self,
         metadata: DataPointMetadata,
         events: Vec<AnalyticsEvent>,
-        screen_routes: &Vec<String>,
+        screen_routes: &[String],
     ) -> Vec<DataPoint> {
         screen_routes
             .iter()
@@ -282,17 +277,11 @@ mod tests {
             ),
         ];
         let expected_output = vec![
-            DataPoint::ScreenActiveTime(CalcScreenActiveTime::new(
-                metadata,
-                vec![first_event.clone()],
-            )),
+            DataPoint::ScreenActiveTime(CalcScreenActiveTime::new(metadata, vec![first_event])),
             DataPoint::ScreenActiveTime(CalcScreenActiveTime::new(metadata, all_events.clone())),
         ];
-        let actual_output = data_combiner.init_screen_active_time_vars(
-            metadata,
-            all_events.clone(),
-            &vec![screen_route],
-        );
+        let actual_output =
+            data_combiner.init_screen_active_time_vars(metadata, all_events, &[screen_route]);
         assert_eq!(actual_output, expected_output);
     }
 
@@ -314,11 +303,8 @@ mod tests {
             metadata,
             events.clone(),
         ))];
-        let actual_output = data_combiner.init_screen_enter_count_vars(
-            metadata,
-            events.clone(),
-            &vec![screen_route],
-        );
+        let actual_output =
+            data_combiner.init_screen_enter_count_vars(metadata, events, &[screen_route]);
         assert_eq!(actual_output, expected_output);
     }
 
@@ -340,7 +326,7 @@ mod tests {
             CalcWasActiveEachPastPeriod::new(metadata, events.clone(), period_thresholds),
         )];
         let actual_output =
-            data_combiner.init_was_active_each_past_period_vars(vec![metadata], events.clone());
+            data_combiner.init_was_active_each_past_period_vars(vec![metadata], events);
         assert_eq!(actual_output, expected_output);
     }
 
@@ -361,8 +347,7 @@ mod tests {
             metadata,
             events.clone(),
         ))];
-        let actual_output =
-            data_combiner.init_was_active_past_n_days_vars(vec![metadata], events.clone());
+        let actual_output = data_combiner.init_was_active_past_n_days_vars(vec![metadata], events);
         assert_eq!(actual_output, expected_output);
     }
 
@@ -392,7 +377,7 @@ mod tests {
             None,
         );
         let events = vec![event_before, event_during.clone(), event_after];
-        let expected_output = vec![event_during.clone()];
+        let expected_output = vec![event_during];
         let actual_output = data_combiner.filter_events_in_this_period(metadata, events);
         assert_eq!(actual_output, expected_output);
     }
@@ -462,7 +447,7 @@ mod tests {
             None,
         );
         let events = vec![event_before.clone(), event_after];
-        let expected_output = vec![event_before.clone()];
+        let expected_output = vec![event_before];
         let actual_output = data_combiner.filter_events_before_end_of_period(end_of_period, events);
         assert_eq!(actual_output, expected_output);
     }
@@ -485,7 +470,7 @@ mod tests {
             Some("other_screen".to_string()),
         );
         let all_events = vec![home_route_event.clone(), other_route_event];
-        let expected_output = vec![home_route_event.clone()];
+        let expected_output = vec![home_route_event];
         let actual_output = data_combiner.get_events_single_route(&home_route, all_events);
         assert_eq!(actual_output, expected_output);
     }

--- a/rust/xaynet-analytics/src/data_combination/data_points/data_point.rs
+++ b/rust/xaynet-analytics/src/data_combination/data_points/data_point.rs
@@ -21,7 +21,7 @@ impl Period {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct DataPointMetadata {
     pub period: Period,
     pub end: DateTime<Utc>,
@@ -39,6 +39,7 @@ pub trait CalculateDataPoints {
     fn calculate(&self) -> Vec<u32>;
 }
 
+#[derive(Debug, PartialEq, Eq)]
 pub enum DataPoint {
     ScreenActiveTime(CalcScreenActiveTime),
     ScreenEnterCount(CalcScreenEnterCount),
@@ -59,18 +60,21 @@ impl DataPoint {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
 // TODO: accept an iterator instead of Vec: https://xainag.atlassian.net/browse/XN-1517
 pub struct CalcScreenActiveTime {
     pub metadata: DataPointMetadata,
     pub events: Vec<AnalyticsEvent>,
 }
 
+#[derive(Debug, PartialEq, Eq)]
 // TODO: accept an iterator instead of Vec: https://xainag.atlassian.net/browse/XN-1517
 pub struct CalcScreenEnterCount {
     pub metadata: DataPointMetadata,
     pub events: Vec<AnalyticsEvent>,
 }
 
+#[derive(Debug, PartialEq, Eq)]
 // TODO: accept an iterator instead of Vec: https://xainag.atlassian.net/browse/XN-1517
 pub struct CalcWasActiveEachPastPeriod {
     pub metadata: DataPointMetadata,
@@ -78,6 +82,7 @@ pub struct CalcWasActiveEachPastPeriod {
     pub period_thresholds: Vec<DateTime<Utc>>,
 }
 
+#[derive(Debug, PartialEq, Eq)]
 // TODO: accept an iterator instead of Vec: https://xainag.atlassian.net/browse/XN-1517
 pub struct CalcWasActivePastNDays {
     pub metadata: DataPointMetadata,

--- a/rust/xaynet-analytics/src/data_provision/analytics_event.rs
+++ b/rust/xaynet-analytics/src/data_provision/analytics_event.rs
@@ -20,13 +20,14 @@ impl AnalyticsEvent {
     pub fn new(
         name: String,
         event_type: AnalyticsEventType,
+        timestamp: DateTime<Utc>,
         screen_route: Option<String>,
     ) -> AnalyticsEvent {
         AnalyticsEvent {
             name,
             event_type,
+            timestamp,
             screen_route,
-            timestamp: chrono::offset::Utc::now(),
         }
     }
 }

--- a/rust/xaynet-analytics/src/data_provision/analytics_event.rs
+++ b/rust/xaynet-analytics/src/data_provision/analytics_event.rs
@@ -17,17 +17,17 @@ pub struct AnalyticsEvent {
 }
 
 impl AnalyticsEvent {
-    pub fn new(
-        name: String,
+    pub fn new<N: Into<String>, R: Into<Option<String>>>(
+        name: N,
         event_type: AnalyticsEventType,
         timestamp: DateTime<Utc>,
-        screen_route: Option<String>,
+        screen_route: R,
     ) -> AnalyticsEvent {
         AnalyticsEvent {
-            name,
+            name: name.into(),
             event_type,
             timestamp,
-            screen_route,
+            screen_route: screen_route.into(),
         }
     }
 }


### PR DESCRIPTION
Refers to: [XN-1433](https://xainag.atlassian.net/browse/XN-1433)

---

It changes a bit `DataCombiner` so that it's easier to test, and adds relevant unit tests.

Since the initialisation of `DataPoints` has a common interfaces and is quite repetitive, but the implementation differs, maybe it would make sense in the future to split up this component and have one `DataCombiner` for each type of `DataPoint`, with its own configuration (metadata instances above all).

Anyway, for now i guess this is good enough, and now it has its unit tests. 

---

Follow up: [XN-1542](https://xainag.atlassian.net/browse/XN-1542) -> unit tests for each `DataPoint` type.
