### PR TITLE
XN-1522 enable client auth

### DIFF
--- a/rust/xaynet-server/src/rest.rs
+++ b/rust/xaynet-server/src/rest.rs
@@ -276,9 +276,9 @@ where
         (None, None) => {}
         _ => return Err(RestError::InvalidTlsConfig),
     }
-    // if let Some(trust_anchor) = tls_client_auth {
-    //     server = server.client_auth_required_path(trust_anchor);
-    // }
+    if let Some(trust_anchor) = tls_client_auth {
+        server = server.client_auth_required_path(trust_anchor);
+    }
     Ok(server)
 }
 

--- a/rust/xaynet-server/src/settings/mod.rs
+++ b/rust/xaynet-server/src/settings/mod.rs
@@ -457,7 +457,7 @@ pub struct ApiSettings {
     /// ```text
     /// XAYNET_API__TLS_CLIENT_AUTH=path/to/tls/files/trust_anchor.pem
     /// ```
-    pub(crate) tls_client_auth: Option<PathBuf>,
+    pub tls_client_auth: Option<PathBuf>,
 }
 
 #[cfg(feature = "tls")]


### PR DESCRIPTION
**References**

- [XN-1522](https://xainag.atlassian.net/browse/XN-1522)

**Summary**

- activates server side client auth again, with stable dependency
