### PR TITLE
specify doc forbids

### DIFF
--- a/rust/examples/Cargo.toml
+++ b/rust/examples/Cargo.toml
@@ -2,7 +2,6 @@
 name = "examples"
 version = "0.0.0"
 authors = ["Xayn Engineering <engineering@xaynet.dev>"]
-publish = false
 edition = "2018"
 description = "The Xayn Network project is building a privacy layer for machine learning so that AI projects can meet compliance such as GDPR and CCPA. The approach relies on Federated Learning as enabling technology that allows production AI applications to be fully privacy compliant."
 readme = "../../README.md"
@@ -11,6 +10,7 @@ repository = "https://github.com/xaynetwork/xaynet/"
 license-file = "../../LICENSE"
 keywords = ["federated-learning", "fl", "ai", "machine-learning"]
 categories = ["science", "cryptography"]
+publish = false
 
 # https://github.com/http-rs/tide/issues/225
 # https://github.com/dependabot/dependabot-core/issues/1156

--- a/rust/xaynet-analytics/Cargo.toml
+++ b/rust/xaynet-analytics/Cargo.toml
@@ -10,10 +10,11 @@ repository = "https://github.com/xaynetwork/xaynet/"
 license-file = "../../LICENSE"
 keywords = ["federated-learning", "fl", "ai", "machine-learning"]
 categories = ["science", "cryptography"]
+publish = false
 
-[package.metadata]
-# minimum supported rust version
-msrv = "1.48.0"
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 chrono = "0.4.19"

--- a/rust/xaynet-analytics/src/lib.rs
+++ b/rust/xaynet-analytics/src/lib.rs
@@ -1,3 +1,9 @@
+#![cfg_attr(doc, forbid(broken_intra_doc_links, private_intra_doc_links))]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/xaynetwork/xaynet/master/assets/xaynet_banner.png",
+    html_favicon_url = "https://raw.githubusercontent.com/xaynetwork/xaynet/master/assets/favicon.png",
+    issue_tracker_base_url = "https://github.com/xaynetwork/xaynet/issues"
+)]
 //! This crate containes the Rust component of Federated Analytics,
 //! a framework that allows mobile applications to collect and aggregate
 //! analytics data via the _Privacy-Enhancing Technology_ (PET) protocol.

--- a/rust/xaynet-core/src/lib.rs
+++ b/rust/xaynet-core/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(doc, forbid(warnings))]
+#![cfg_attr(doc, forbid(broken_intra_doc_links, private_intra_doc_links))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/xaynetwork/xaynet/master/assets/xaynet_banner.png",
     html_favicon_url = "https://raw.githubusercontent.com/xaynetwork/xaynet/master/assets/favicon.png",

--- a/rust/xaynet-mobile/src/lib.rs
+++ b/rust/xaynet-mobile/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(doc, forbid(warnings))]
+#![cfg_attr(doc, forbid(broken_intra_doc_links, private_intra_doc_links))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/xaynetwork/xaynet/master/assets/xaynet_banner.png",
     html_favicon_url = "https://raw.githubusercontent.com/xaynetwork/xaynet/master/assets/favicon.png",

--- a/rust/xaynet-sdk/src/lib.rs
+++ b/rust/xaynet-sdk/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(doc, forbid(warnings))]
+#![cfg_attr(doc, forbid(broken_intra_doc_links, private_intra_doc_links))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/xaynetwork/xaynet/master/assets/xaynet_banner.png",
     html_favicon_url = "https://raw.githubusercontent.com/xaynetwork/xaynet/master/assets/favicon.png",

--- a/rust/xaynet-server/src/lib.rs
+++ b/rust/xaynet-server/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(doc, forbid(warnings))]
+#![cfg_attr(doc, forbid(broken_intra_doc_links, private_intra_doc_links))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/xaynetwork/xaynet/master/assets/xaynet_banner.png",
     html_favicon_url = "https://raw.githubusercontent.com/xaynetwork/xaynet/master/assets/favicon.png",

--- a/rust/xaynet/src/lib.rs
+++ b/rust/xaynet/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(doc, forbid(warnings))]
+#![cfg_attr(doc, forbid(broken_intra_doc_links, private_intra_doc_links))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/xaynetwork/xaynet/master/assets/xaynet_banner.png",
     html_favicon_url = "https://raw.githubusercontent.com/xaynetwork/xaynet/master/assets/favicon.png",


### PR DESCRIPTION
**Summary**

the current doc lints deny everything, which leads to errors on the latest nightly, like:
```
error[E0453]: allow(unused_parens) incompatible with previous forbid
  --> xaynet-server/src/services/fetchers/mod.rs:79:81
   |
79 |       async fn round_params(&mut self) -> Result<RoundParamsResponse, FetchError> {
   |  _________________________________________________________________________________^
80 | |         poll_fn(|cx| {
81 | |             <RoundParams as Service<RoundParamsRequest>>::poll_ready(&mut self.round_params, cx)
82 | |         })
...  |
90 | |         .map_err(into_fetch_error)?)
91 | |     }
   | |_____^ overruled by previous forbid
```

this specifies the lints we actually want to deny. later on we also might want to warn about missing docs, like:
```
#![cfg_attr(doc, warn(missing_docs, missing_crate_level_docs))]
```
but for now this throws quite a lot of warnings, therefore i didn't include it yet. nevertheless we should fix the missing docs.
```
warning: 43 warnings emitted
warning: 12 warnings emitted
warning: 26 warnings emitted
warning: 114 warnings emitted
```