### PR TITLE
XN-1582 simplify metrics

### DIFF
--- a/rust/xaynet-server/src/metrics/mod.rs
+++ b/rust/xaynet-server/src/metrics/mod.rs
@@ -8,10 +8,12 @@ pub use self::recorders::influxdb::{Measurement, Recorder, Tags};
 
 static RECORDER: OnceCell<Recorder> = OnceCell::new();
 
+/// A wrapper around a static global metrics/events recorder.
 pub struct GlobalRecorder;
 
 impl GlobalRecorder {
     /// Gets the reference to the global recorder.
+    ///
     /// Returns `None` if no recorder is set or is currently being initialized.
     /// This method never blocks.
     pub fn global() -> Option<&'static Recorder> {
@@ -19,6 +21,7 @@ impl GlobalRecorder {
     }
 
     /// Installs a new global recorder.
+    ///
     /// Returns Err(Recorder) if a recorder has already been set.
     pub fn install(recorder: Recorder) -> Result<(), Recorder> {
         RECORDER.set(recorder)

--- a/rust/xaynet-server/src/metrics/mod.rs
+++ b/rust/xaynet-server/src/metrics/mod.rs
@@ -50,17 +50,17 @@ impl GlobalRecorder {
 macro_rules! event {
     ($title: expr $(,)?) => {
         if let Some(recorder) = crate::metrics::GlobalRecorder::global() {
-            recorder.event($title, Option::<&str>::None, Option::<&[&str]>::None)
+            recorder.event::<_, _, &str, _, &[_], &str>($title, None, None);
         }
     };
     ($title: expr, $description: expr $(,)?) => {
         if let Some(recorder) = crate::metrics::GlobalRecorder::global() {
-            recorder.event($title, Some($description), Option::<&[&str]>::None)
+            recorder.event::<_, _, _, _, &[_], &str>($title, $description, None);
         }
     };
     ($title: expr, $description: expr, [$($tags: expr),+] $(,)?) => {
         if let Some(recorder) = crate::metrics::GlobalRecorder::global() {
-            recorder.event($title, Some($description), Some(&[$($tags),+]))
+            recorder.event($title, $description, [$($tags),+])
         }
     };
 }
@@ -88,7 +88,7 @@ macro_rules! event {
 macro_rules! metric {
     ($measurement: expr, $value: expr $(,)?) => {
         if let Some(recorder) = crate::metrics::GlobalRecorder::global() {
-            recorder.metric($measurement, $value, Option::<crate::metrics::Tags>::None)
+            recorder.metric::<_, _, crate::metrics::Tags>($measurement, $value, None);
         }
     };
     ($measurement: expr, $value: expr, $(($tag: expr, $val: expr)),+ $(,)?) => {
@@ -97,7 +97,7 @@ macro_rules! metric {
             $(
                 tags.add($tag, $val);
             )+
-            recorder.metric($measurement, $value, Some(tags))
+            recorder.metric($measurement, $value, tags);
         }
     };
 }

--- a/rust/xaynet-server/src/metrics/recorders/influxdb/models.rs
+++ b/rust/xaynet-server/src/metrics/recorders/influxdb/models.rs
@@ -1,5 +1,7 @@
+use std::{borrow::Borrow, iter::IntoIterator};
+
 use chrono::{DateTime, Utc};
-use influxdb::InfluxDbWriteable;
+use influxdb::{InfluxDbWriteable, Timestamp, Type, WriteQuery};
 
 /// An enum that contains all supported measurements.
 pub enum Measurement {
@@ -15,8 +17,8 @@ pub enum Measurement {
     MessageRejected,
 }
 
-impl From<&Measurement> for &'static str {
-    fn from(measurement: &Measurement) -> &'static str {
+impl From<Measurement> for &'static str {
+    fn from(measurement: Measurement) -> &'static str {
         match measurement {
             Measurement::RoundParamSum => "round_param_sum",
             Measurement::RoundParamUpdate => "round_param_update",
@@ -32,14 +34,14 @@ impl From<&Measurement> for &'static str {
     }
 }
 
-impl ToString for Measurement {
-    fn to_string(&self) -> String {
-        Into::<&str>::into(self).into()
+impl From<Measurement> for String {
+    fn from(measurement: Measurement) -> Self {
+        <&str>::from(measurement).into()
     }
 }
 
 /// A container that contains the tags of a metric.
-pub struct Tags(Vec<(String, influxdb::Type)>);
+pub struct Tags(Vec<(String, Type)>);
 
 impl Tags {
     /// Creates a new empty container for tags.
@@ -48,22 +50,17 @@ impl Tags {
     }
 
     /// Adds a tag to the metric.
-    pub fn add<K, V>(&mut self, key: K, value: V)
-    where
-        K: Into<String>,
-        V: Into<influxdb::Type>,
-    {
-        self.0.push((key.into(), value.into()))
-    }
-
-    pub(in crate::metrics) fn into_inner(self) -> Vec<(String, influxdb::Type)> {
-        self.0
+    pub fn add(&mut self, tag: impl Into<String>, value: impl Into<Type>) {
+        self.0.push((tag.into(), value.into()))
     }
 }
 
-impl Default for Tags {
-    fn default() -> Self {
-        Self::new()
+impl IntoIterator for Tags {
+    type Item = <Vec<(String, Type)> as IntoIterator>::Item;
+    type IntoIter = <Vec<(String, Type)> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
     }
 }
 
@@ -71,16 +68,16 @@ impl Default for Tags {
 pub(in crate::metrics) struct Metric {
     name: Measurement,
     time: DateTime<Utc>,
-    value: influxdb::Type,
+    value: Type,
     tags: Option<Tags>,
 }
 
 impl Metric {
-    pub(in crate::metrics) fn new(measurement: Measurement, value: influxdb::Type) -> Self {
+    pub(in crate::metrics) fn new(measurement: Measurement, value: impl Into<Type>) -> Self {
         Self {
             name: measurement,
             time: Utc::now(),
-            value,
+            value: value.into(),
             tags: None,
         }
     }
@@ -92,14 +89,15 @@ impl Metric {
         // when `self.tags` already contains tags.
         self.tags = Some(tags)
     }
+}
 
-    pub(in crate::metrics) fn into_query(self) -> influxdb::WriteQuery {
-        let timestamp: ::influxdb::Timestamp = self.time.into();
-        let mut query = timestamp.into_query(self.name.to_string());
-        query = query.add_field("value", self.value);
+impl From<Metric> for WriteQuery {
+    fn from(metric: Metric) -> Self {
+        let mut query = Timestamp::from(metric.time).into_query(metric.name);
+        query = query.add_field("value", metric.value);
 
-        if let Some(tags) = self.tags {
-            for (tag, value) in tags.into_inner() {
+        if let Some(tags) = metric.tags {
+            for (tag, value) in tags {
                 query = query.add_tag(tag, value);
             }
         }
@@ -118,7 +116,7 @@ pub(in crate::metrics) struct Event {
 }
 
 impl Event {
-    pub(in crate::metrics) fn new<T: Into<String>>(title: T) -> Self {
+    pub(in crate::metrics) fn new(title: impl Into<String>) -> Self {
         Self {
             name: "event",
             time: Utc::now(),
@@ -128,28 +126,29 @@ impl Event {
         }
     }
 
-    pub(in crate::metrics) fn with_description<D: Into<String>>(&mut self, description: D) {
+    pub(in crate::metrics) fn with_description(&mut self, description: impl Into<String>) {
         self.description = Some(description.into())
     }
 
-    pub(in crate::metrics) fn with_tags(&mut self, tags: &[&str]) {
+    pub(in crate::metrics) fn with_tags(&mut self, tags: &[impl Borrow<str>]) {
         // It is by design that this function should only be called once.
         // see `Recorder::metric`
         // Therefore, we don't cover the case where we would extend `self.tags`
         // when `self.tags` already contains tags.
         self.tags = Some(tags.join(","))
     }
+}
 
-    pub(in crate::metrics) fn into_query(self) -> influxdb::WriteQuery {
-        let timestamp: influxdb::Timestamp = self.time.into();
-        let mut query = timestamp.into_query(self.name);
-        query = query.add_field("title", self.title);
+impl From<Event> for WriteQuery {
+    fn from(event: Event) -> Self {
+        let mut query = Timestamp::from(event.time).into_query(event.name);
+        query = query.add_field("title", event.title);
 
-        if let Some(description) = self.description {
+        if let Some(description) = event.description {
             query = query.add_field("description", description);
         }
 
-        if let Some(tags) = self.tags {
+        if let Some(tags) = event.tags {
             query = query.add_field("tags", tags);
         }
 
@@ -159,14 +158,14 @@ impl Event {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use influxdb::Query;
+
+    use super::*;
 
     #[test]
     fn test_basic_metric() {
-        let metric = Metric::new(Measurement::Phase, 1.into());
-        assert!(metric
-            .into_query()
+        let metric = Metric::new(Measurement::Phase, 1);
+        assert!(WriteQuery::from(metric)
             .build()
             .unwrap()
             .get()
@@ -175,12 +174,11 @@ mod tests {
 
     #[test]
     fn test_metric_with_tag() {
-        let mut metric = Metric::new(Measurement::Phase, 1.into());
-        let mut tag = Tags::default();
+        let mut metric = Metric::new(Measurement::Phase, 1);
+        let mut tag = Tags::new();
         tag.add("key", 42);
         metric.with_tags(tag);
-        assert!(metric
-            .into_query()
+        assert!(WriteQuery::from(metric)
             .build()
             .unwrap()
             .get()
@@ -189,14 +187,13 @@ mod tests {
 
     #[test]
     fn test_metric_with_tags() {
-        let mut metric = Metric::new(Measurement::Phase, 1.into());
+        let mut metric = Metric::new(Measurement::Phase, 1);
         let mut tag = Tags::new();
         tag.add("key_1", 42);
         tag.add("key_2", "42");
         tag.add("key_3", 1.0f32);
         metric.with_tags(tag);
-        assert!(metric
-            .into_query()
+        assert!(WriteQuery::from(metric)
             .build()
             .unwrap()
             .get()
@@ -206,8 +203,7 @@ mod tests {
     #[test]
     fn test_basic_event() {
         let event = Event::new("error");
-        assert!(event
-            .into_query()
+        assert!(WriteQuery::from(event)
             .build()
             .unwrap()
             .get()
@@ -218,8 +214,7 @@ mod tests {
     fn test_event_with_description() {
         let mut event = Event::new("error");
         event.with_description("description");
-        assert!(event
-            .into_query()
+        assert!(WriteQuery::from(event)
             .build()
             .unwrap()
             .get()
@@ -231,8 +226,7 @@ mod tests {
         let mut event = Event::new("error");
         event.with_description("description");
         event.with_tags(&["tag"]);
-        assert!(event
-            .into_query()
+        assert!(WriteQuery::from(event)
             .build()
             .unwrap()
             .get()
@@ -244,8 +238,7 @@ mod tests {
         let mut event = Event::new("error");
         event.with_description("description");
         event.with_tags(&["tag_1", "tag_2"]);
-        assert!(event
-            .into_query()
+        assert!(WriteQuery::from(event)
             .build()
             .unwrap()
             .get()
@@ -256,8 +249,7 @@ mod tests {
     fn test_event_with_tag() {
         let mut event = Event::new("error");
         event.with_tags(&["tag"]);
-        assert!(event
-            .into_query()
+        assert!(WriteQuery::from(event)
             .build()
             .unwrap()
             .get()

--- a/rust/xaynet-server/src/metrics/recorders/influxdb/models.rs
+++ b/rust/xaynet-server/src/metrics/recorders/influxdb/models.rs
@@ -10,9 +10,7 @@ pub enum Measurement {
     Phase,
     MasksTotalNumber,
     RoundTotalNumber,
-    MessageSum,
-    MessageUpdate,
-    MessageSum2,
+    MessageAccepted,
     MessageDiscarded,
     MessageRejected,
 }
@@ -25,9 +23,7 @@ impl From<Measurement> for &'static str {
             Measurement::Phase => "phase",
             Measurement::MasksTotalNumber => "masks_total_number",
             Measurement::RoundTotalNumber => "round_total_number",
-            Measurement::MessageSum => "message_sum",
-            Measurement::MessageUpdate => "message_update",
-            Measurement::MessageSum2 => "message_sum2",
+            Measurement::MessageAccepted => "message_accepted",
             Measurement::MessageDiscarded => "message_discarded",
             Measurement::MessageRejected => "message_rejected",
         }
@@ -52,6 +48,12 @@ impl Tags {
     /// Adds a tag to the metric.
     pub fn add(&mut self, tag: impl Into<String>, value: impl Into<Type>) {
         self.0.push((tag.into(), value.into()))
+    }
+}
+
+impl Default for Tags {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/rust/xaynet-server/src/metrics/recorders/influxdb/recorder.rs
+++ b/rust/xaynet-server/src/metrics/recorders/influxdb/recorder.rs
@@ -24,33 +24,30 @@ impl Recorder {
     }
 
     /// Records a new metric and dispatches it to an InfluxDB instance.
-    pub fn metric(&self, measurement: Measurement, value: impl Into<Type>, tags: Option<Tags>) {
-        let mut metric = Metric::new(measurement, value);
-        if let Some(tags) = tags {
-            metric.with_tags(tags);
-        }
-
-        self.call(metric.into())
+    pub fn metric<V, T, I>(&self, measurement: Measurement, value: V, tags: T)
+    where
+        V: Into<Type>,
+        T: Into<Option<I>>,
+        I: Into<Tags>,
+    {
+        let metric = Metric::new(measurement, value).with_tags(tags);
+        self.call(metric.into());
     }
 
     /// Records a new event and dispatches it to an InfluxDB instance.
-    pub fn event(
-        &self,
-        title: impl Into<String>,
-        description: Option<impl Into<String>>,
-        tags: Option<&[impl Borrow<str>]>,
-    ) {
-        let mut event = Event::new(title);
-
-        if let Some(description) = description {
-            event.with_description(description);
-        }
-
-        if let Some(tags) = tags {
-            event.with_tags(tags);
-        }
-
-        self.call(event.into())
+    pub fn event<H, D, S, T, A, B>(&self, title: H, description: D, tags: T)
+    where
+        H: Into<String>,
+        D: Into<Option<S>>,
+        S: Into<String>,
+        T: Into<Option<A>>,
+        A: AsRef<[B]>,
+        B: Borrow<str>,
+    {
+        let event = Event::new(title)
+            .with_description(description)
+            .with_tags(tags);
+        self.call(event.into());
     }
 
     fn call(&self, req: Request) {

--- a/rust/xaynet-server/src/state_machine/phases/error.rs
+++ b/rust/xaynet-server/src/state_machine/phases/error.rs
@@ -78,7 +78,7 @@ where
     async fn run(&mut self) -> Result<(), PhaseStateError> {
         error!("phase state error: {}", self.private);
 
-        event!("Phase error", &self.private.to_string());
+        event!("Phase error", self.private.to_string());
 
         self.wait_for_store_readiness().await;
 

--- a/rust/xaynet-server/src/state_machine/phases/idle.rs
+++ b/rust/xaynet-server/src/state_machine/phases/idle.rs
@@ -80,13 +80,13 @@ where
             Measurement::RoundParamSum,
             self.shared.state.round_params.sum,
             ("round_id", self.shared.state.round_id),
-            ("phase", Self::NAME as u8)
+            ("phase", Self::NAME as u8),
         );
         metric!(
             Measurement::RoundParamUpdate,
             self.shared.state.round_params.update,
             ("round_id", self.shared.state.round_id),
-            ("phase", Self::NAME as u8)
+            ("phase", Self::NAME as u8),
         );
 
         Ok(())

--- a/rust/xaynet-server/src/state_machine/phases/unmask.rs
+++ b/rust/xaynet-server/src/state_machine/phases/unmask.rs
@@ -174,7 +174,7 @@ where
                     Measurement::MasksTotalNumber,
                     number_of_masks,
                     ("round_id", round_id),
-                    ("phase", phase_name as u8)
+                    ("phase", phase_name as u8),
                 ),
                 Err(err) => error!("failed to fetch total number of masks: {}", err),
             };


### PR DESCRIPTION
**References**

- [XN-1582](https://xainag.atlassian.net/browse/XN-1582)

**Summary**

- simplify message accepted metrics to one call differentiated by phase tags
- make most of the metrics function signatures more ergonomic to use via `Into` trait bounds
- replace custom metric/request/query conversions with `From` impls
