### PR TITLE
XN-1579 unify handle request

### DIFF
--- a/rust/xaynet-server/src/metrics/mod.rs
+++ b/rust/xaynet-server/src/metrics/mod.rs
@@ -86,6 +86,30 @@ macro_rules! event {
 /// ```
 #[macro_export]
 macro_rules! metric {
+    (accepted: $round_id: expr, $phase: expr $(,)?) => {
+        crate::metric!(
+            crate::metrics::Measurement::MessageAccepted,
+            1,
+            ("round_id", $round_id),
+            ("phase", $phase as u8),
+        );
+    };
+    (rejected: $round_id: expr, $phase: expr $(,)?) => {
+        crate::metric!(
+            crate::metrics::Measurement::MessageRejected,
+            1,
+            ("round_id", $round_id),
+            ("phase", $phase as u8),
+        );
+    };
+    (discarded: $round_id: expr, $phase: expr $(,)?) => {
+        crate::metric!(
+            crate::metrics::Measurement::MessageDiscarded,
+            1,
+            ("round_id", $round_id),
+            ("phase", $phase as u8),
+        );
+    };
     ($measurement: expr, $value: expr $(,)?) => {
         if let Some(recorder) = crate::metrics::GlobalRecorder::global() {
             recorder.metric::<_, _, crate::metrics::Tags>($measurement, $value, None);

--- a/rust/xaynet-server/src/metrics/mod.rs
+++ b/rust/xaynet-server/src/metrics/mod.rs
@@ -86,30 +86,6 @@ macro_rules! event {
 /// ```
 #[macro_export]
 macro_rules! metric {
-    (accepted: $round_id: expr, $phase: expr $(,)?) => {
-        crate::metric!(
-            crate::metrics::Measurement::MessageAccepted,
-            1,
-            ("round_id", $round_id),
-            ("phase", $phase as u8),
-        );
-    };
-    (rejected: $round_id: expr, $phase: expr $(,)?) => {
-        crate::metric!(
-            crate::metrics::Measurement::MessageRejected,
-            1,
-            ("round_id", $round_id),
-            ("phase", $phase as u8),
-        );
-    };
-    (discarded: $round_id: expr, $phase: expr $(,)?) => {
-        crate::metric!(
-            crate::metrics::Measurement::MessageDiscarded,
-            1,
-            ("round_id", $round_id),
-            ("phase", $phase as u8),
-        );
-    };
     ($measurement: expr, $value: expr $(,)?) => {
         if let Some(recorder) = crate::metrics::GlobalRecorder::global() {
             recorder.metric::<_, _, crate::metrics::Tags>($measurement, $value, None);

--- a/rust/xaynet-server/src/state_machine/coordinator.rs
+++ b/rust/xaynet-server/src/state_machine/coordinator.rs
@@ -19,7 +19,7 @@ use xaynet_core::{
 };
 
 /// The phase count parameters.
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct CountParameters {
     /// The minimal number of required messages.
     pub min: u64,
@@ -35,7 +35,7 @@ impl From<PetSettingsCount> for CountParameters {
 }
 
 /// The phase time parameters.
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct TimeParameters {
     /// The minimal amount of time (in seconds) reserved for processing messages.
     pub min: u64,
@@ -51,7 +51,7 @@ impl From<PetSettingsTime> for TimeParameters {
 }
 
 /// The phase parameters.
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct PhaseParameters {
     /// The number of messages.
     pub count: CountParameters,

--- a/rust/xaynet-server/src/state_machine/mod.rs
+++ b/rust/xaynet-server/src/state_machine/mod.rs
@@ -202,5 +202,47 @@ where
     }
 }
 
+/// Records a message accepted metric.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! accepted {
+    ($round_id: expr, $phase: expr $(,)?) => {
+        crate::metric!(
+            crate::metrics::Measurement::MessageAccepted,
+            1,
+            ("round_id", $round_id),
+            ("phase", $phase as u8),
+        );
+    };
+}
+
+/// Records a message rejected metric.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! rejected {
+    ($round_id: expr, $phase: expr $(,)?) => {
+        crate::metric!(
+            crate::metrics::Measurement::MessageRejected,
+            1,
+            ("round_id", $round_id),
+            ("phase", $phase as u8),
+        );
+    };
+}
+
+/// Records a message discared metric.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! discarded {
+    ($round_id: expr, $phase: expr $(,)?) => {
+        crate::metric!(
+            crate::metrics::Measurement::MessageDiscarded,
+            1,
+            ("round_id", $round_id),
+            ("phase", $phase as u8),
+        );
+    };
+}
+
 #[cfg(test)]
 pub(crate) mod tests;

--- a/rust/xaynet-server/src/state_machine/phases/handler.rs
+++ b/rust/xaynet-server/src/state_machine/phases/handler.rs
@@ -1,0 +1,215 @@
+use async_trait::async_trait;
+use tracing::{debug, Span};
+
+use crate::{
+    state_machine::{
+        phases::{Phase, PhaseState, PhaseStateError},
+        requests::{ResponseSender, StateMachineRequest},
+        RequestError,
+    },
+    storage::Storage,
+};
+
+/// A trait that must be implemented by a state to handle a request.
+#[async_trait]
+pub trait Handler {
+    /// Handles a request.
+    ///
+    /// # Errors
+    /// Fails on PET and storage errors.
+    async fn handle_request(&mut self, req: StateMachineRequest) -> Result<(), RequestError>;
+
+    /// Checks whether enough requests have been processed successfully wrt the PET settings.
+    fn has_enough_messages(&self) -> bool;
+
+    /// Checks whether too many requests are processed wrt the PET settings.
+    fn has_overmuch_messages(&self) -> bool;
+
+    /// Increments the counter for accepted requests.
+    fn increment_accepted(&mut self);
+
+    /// Increments the counter for rejected requests.
+    fn increment_rejected(&mut self);
+
+    /// Increments the counter for discarded requests.
+    fn increment_discarded(&mut self);
+}
+
+/// Implements all [`Handler`] methods for [`PhaseState`] except for [`handle_request()`].
+///
+/// Circumvents the infeasibility of default trait impls due to the dependency on internal state.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! impl_handler_for_phasestate {
+    ($phase: ty) => {
+        paste::paste! {
+            fn has_enough_messages(&self) -> bool {
+                self.private.accepted >= self.shared.state.[<$phase:lower>].count.min
+            }
+
+            fn has_overmuch_messages(&self) -> bool {
+                self.private.accepted >= self.shared.state.[<$phase:lower>].count.max
+            }
+
+            fn increment_accepted(&mut self) {
+                let phase = <Self as crate::state_machine::phases::Phase<_>>::NAME;
+                self.private.accepted += 1;
+                tracing::debug!(
+                    "{} {} messages accepted (min {} and max {} required)",
+                    self.private.accepted,
+                    phase,
+                    self.shared.state.[<$phase:lower>].count.min,
+                    self.shared.state.[<$phase:lower>].count.max,
+                );
+                crate::metric!(accepted: self.shared.state.round_id, phase);
+            }
+
+            fn increment_rejected(&mut self) {
+                let phase = <Self as crate::state_machine::phases::Phase<_>>::NAME;
+                self.private.rejected += 1;
+                tracing::debug!("{} {} messages rejected", self.private.rejected, phase);
+                crate::metric!(rejected: self.shared.state.round_id, phase);
+            }
+
+            fn increment_discarded(&mut self) {
+                let phase = <Self as crate::state_machine::phases::Phase<_>>::NAME;
+                self.private.discarded += 1;
+                tracing::debug!("{} {} messages discarded", self.private.discarded, phase);
+                crate::metric!(discarded: self.shared.state.round_id, phase);
+            }
+        }
+    };
+}
+
+/// Implements `process()` for [`PhaseState`]`: `[`Handler`]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! impl_process_for_phasestate_handler {
+    ($phase: ty) => {
+        paste::paste! {
+            impl<S> crate::state_machine::phases::PhaseState<$phase, S>
+            where
+                Self: crate::state_machine::phases::Handler
+                    + crate::state_machine::phases::Phase<S>,
+                S: crate::storage::Storage,
+            {
+                // Processes requests wrt the phase parameters.
+                //
+                // - Processes at most `count.max` requests during the time interval
+                // `[now, now + time.min]`.
+                // - Processes requests until there are enough (ie `count.min`) for the time
+                // interval `[now + time.min, now + time.max]`.
+                // - Aborts if either all connections were dropped or not enough requests were
+                // processed until timeout.
+                #[doc =
+                    "Processes requests wrt the phase parameters.\n\n"
+                    "- Processes at most `" [<$phase:lower>] ".count.max` requests during the time interval `[now, now + " [<$phase:lower>] ".time.min]`.\n"
+                    "- Processes requests until there are enough (ie `" [<$phase:lower>] ".count.min`) for the time interval `[now + " [<$phase:lower>] ".time.min, now + " [<$phase:lower>] ".time.max]`.\n"
+                    "- Aborts if either all connections were dropped or not enough requests were processed until timeout."
+                ]
+                async fn process(&mut self) -> Result<(), PhaseStateError> {
+                    let phase = <Self as crate::state_machine::phases::Phase<_>>::NAME;
+                    let crate::state_machine::coordinator::PhaseParameters { count, time } =
+                        self.shared.state.[<$phase:lower>];
+                    tracing::info!("processing requests in {} phase", phase);
+                    tracing::debug!(
+                        "in {} phase for min {} and max {} seconds",
+                        phase, time.min, time.max,
+                    );
+                    self.process_during(tokio::time::Duration::from_secs(time.min)).await?;
+
+                    let time_left = time.max - time.min;
+                    tokio::time::timeout(
+                        tokio::time::Duration::from_secs(time_left),
+                        self.process_until_enough()
+                    ).await??;
+
+                    tracing::info!(
+                        "in total {} {} messages accepted (min {} and max {} required)",
+                        self.private.accepted,
+                        phase,
+                        count.min,
+                        count.max,
+                    );
+                    tracing::info!("in total {} {} messages rejected", self.private.rejected, phase);
+                    tracing::info!(
+                        "in total {} {} messages discarded (purged not included)",
+                        self.private.discarded,
+                        phase,
+                    );
+
+                    Ok(())
+                }
+            }
+        }
+    };
+}
+
+impl<S, T> PhaseState<S, T>
+where
+    Self: Handler + Phase<T>,
+    T: Storage,
+{
+    /// Processes requests for as long as the given duration.
+    pub(in crate::state_machine::phases) async fn process_during(
+        &mut self,
+        dur: tokio::time::Duration,
+    ) -> Result<(), PhaseStateError> {
+        let phase = <Self as Phase<_>>::NAME;
+        let deadline = tokio::time::sleep(dur);
+        tokio::pin!(deadline);
+
+        loop {
+            tokio::select! {
+                _ = &mut deadline => {
+                    debug!("{} duration elapsed", phase);
+                    break Ok(());
+                }
+                next = self.next_request() => {
+                    let (req, span, resp_tx) = next?;
+                    self.process_single(req, span, resp_tx).await;
+                }
+            }
+        }
+    }
+
+    /// Processes requests until there are enough.
+    pub(in crate::state_machine::phases) async fn process_until_enough(
+        &mut self,
+    ) -> Result<(), PhaseStateError> {
+        while !self.has_enough_messages() {
+            let (req, span, resp_tx) = self.next_request().await?;
+            self.process_single(req, span, resp_tx).await;
+        }
+        Ok(())
+    }
+
+    /// Processes a single request.
+    ///
+    /// The request is discarded if the maximum message count is reached, accepted if processed
+    /// successfully and rejected otherwise.
+    async fn process_single(
+        &mut self,
+        req: StateMachineRequest,
+        span: Span,
+        resp_tx: ResponseSender,
+    ) {
+        let _span_guard = span.enter();
+
+        let response = if self.has_overmuch_messages() {
+            self.increment_discarded();
+            Err(RequestError::MessageDiscarded)
+        } else {
+            let response = self.handle_request(req).await;
+            if response.is_ok() {
+                self.increment_accepted();
+            } else {
+                self.increment_rejected();
+            }
+            response
+        };
+
+        // This may error out if the receiver has already been dropped but it doesn't matter for us.
+        let _ = resp_tx.send(response);
+    }
+}

--- a/rust/xaynet-server/src/state_machine/phases/mod.rs
+++ b/rust/xaynet-server/src/state_machine/phases/mod.rs
@@ -1,6 +1,7 @@
 //! This module provides the `PhaseStates` of the [`StateMachine`].
 
 mod error;
+mod handler;
 mod idle;
 mod shutdown;
 mod sum;
@@ -18,6 +19,7 @@ use tracing_futures::Instrument;
 
 pub use self::{
     error::PhaseStateError,
+    handler::Handler,
     idle::{Idle, IdleStateError},
     shutdown::Shutdown,
     sum::{Sum, SumStateError},
@@ -79,31 +81,6 @@ where
     ///
     /// [module level documentation]: crate::state_machine
     fn next(self) -> Option<StateMachine<S>>;
-}
-
-/// A trait that must be implemented by a state to handle a request.
-#[async_trait]
-pub trait Handler {
-    /// Handles a request.
-    ///
-    /// # Errors
-    /// Fails on PET and storage errors.
-    async fn handle_request(&mut self, req: StateMachineRequest) -> Result<(), RequestError>;
-
-    /// Checks whether enough requests have been processed successfully wrt the PET settings.
-    fn has_enough_messages(&self) -> bool;
-
-    /// Checks whether too many requests are processed wrt the PET settings.
-    fn has_overmuch_messages(&self) -> bool;
-
-    /// Increments the counter for accepted requests.
-    fn increment_accepted(&mut self);
-
-    /// Increments the counter for rejected requests.
-    fn increment_rejected(&mut self);
-
-    /// Increments the counter for discarded requests.
-    fn increment_discarded(&mut self);
 }
 
 /// A struct that contains the coordinator state and the I/O interfaces that are shared and
@@ -178,180 +155,6 @@ where
     pub(in crate::state_machine) private: S,
     /// The shared coordinator state and I/O interfaces.
     pub(in crate::state_machine) shared: Shared<T>,
-}
-
-/// Implements all [`Handler`] methods for [`PhaseState`] except for [`handle_request()`].
-///
-/// Circumvents the infeasibility of default trait impls due to the dependency on internal state.
-#[doc(hidden)]
-#[macro_export]
-macro_rules! impl_handler_for_phasestate {
-    ($phase: ty) => {
-        paste::paste! {
-            fn has_enough_messages(&self) -> bool {
-                self.private.accepted >= self.shared.state.[<$phase:lower>].count.min
-            }
-
-            fn has_overmuch_messages(&self) -> bool {
-                self.private.accepted >= self.shared.state.[<$phase:lower>].count.max
-            }
-
-            fn increment_accepted(&mut self) {
-                let phase = <Self as crate::state_machine::phases::Phase<_>>::NAME;
-                self.private.accepted += 1;
-                tracing::debug!(
-                    "{} {} messages accepted (min {} and max {} required)",
-                    self.private.accepted,
-                    phase,
-                    self.shared.state.[<$phase:lower>].count.min,
-                    self.shared.state.[<$phase:lower>].count.max,
-                );
-                crate::metric!(accepted: self.shared.state.round_id, phase);
-            }
-
-            fn increment_rejected(&mut self) {
-                let phase = <Self as crate::state_machine::phases::Phase<_>>::NAME;
-                self.private.rejected += 1;
-                tracing::debug!("{} {} messages rejected", self.private.rejected, phase);
-                crate::metric!(rejected: self.shared.state.round_id, phase);
-            }
-
-            fn increment_discarded(&mut self) {
-                let phase = <Self as crate::state_machine::phases::Phase<_>>::NAME;
-                self.private.discarded += 1;
-                tracing::debug!("{} {} messages discarded", self.private.discarded, phase);
-                crate::metric!(discarded: self.shared.state.round_id, phase);
-            }
-        }
-    };
-}
-
-/// Implements `process()` for [`PhaseState`]`: `[`Handler`]
-#[doc(hidden)]
-#[macro_export]
-macro_rules! impl_process_for_phasestate_handler {
-    ($phase: ty) => {
-        paste::paste! {
-            impl<S> crate::state_machine::phases::PhaseState<$phase, S>
-            where
-                Self: crate::state_machine::phases::Handler
-                    + crate::state_machine::phases::Phase<S>,
-                S: crate::storage::Storage,
-            {
-                // Processes requests wrt the phase parameters.
-                //
-                // - Processes at most `count.max` requests during the time interval
-                // `[now, now + time.min]`.
-                // - Processes requests until there are enough (ie `count.min`) for the time
-                // interval `[now + time.min, now + time.max]`.
-                // - Aborts if either all connections were dropped or not enough requests were
-                // processed until timeout.
-                #[doc =
-                    "Processes requests wrt the phase parameters.\n\n"
-                    "- Processes at most `" [<$phase:lower>] ".count.max` requests during the time interval `[now, now + " [<$phase:lower>] ".time.min]`.\n"
-                    "- Processes requests until there are enough (ie `" [<$phase:lower>] ".count.min`) for the time interval `[now + " [<$phase:lower>] ".time.min, now + " [<$phase:lower>] ".time.max]`.\n"
-                    "- Aborts if either all connections were dropped or not enough requests were processed until timeout."
-                ]
-                async fn process(&mut self) -> Result<(), PhaseStateError> {
-                    let phase = <Self as crate::state_machine::phases::Phase<_>>::NAME;
-                    let crate::state_machine::coordinator::PhaseParameters { count, time } =
-                        self.shared.state.[<$phase:lower>];
-                    tracing::info!("processing requests in {} phase", phase);
-                    tracing::debug!(
-                        "in {} phase for min {} and max {} seconds",
-                        phase, time.min, time.max,
-                    );
-                    self.process_during(tokio::time::Duration::from_secs(time.min)).await?;
-
-                    let time_left = time.max - time.min;
-                    tokio::time::timeout(
-                        tokio::time::Duration::from_secs(time_left),
-                        self.process_until_enough()
-                    ).await??;
-
-                    tracing::info!(
-                        "in total {} {} messages accepted (min {} and max {} required)",
-                        self.private.accepted,
-                        phase,
-                        count.min,
-                        count.max,
-                    );
-                    tracing::info!("in total {} {} messages rejected", self.private.rejected, phase);
-                    tracing::info!(
-                        "in total {} {} messages discarded (purged not included)",
-                        self.private.discarded,
-                        phase,
-                    );
-
-                    Ok(())
-                }
-            }
-        }
-    };
-}
-
-impl<S, T> PhaseState<S, T>
-where
-    Self: Handler + Phase<T>,
-    T: Storage,
-{
-    /// Processes requests for as long as the given duration.
-    async fn process_during(&mut self, dur: tokio::time::Duration) -> Result<(), PhaseStateError> {
-        let phase = <Self as Phase<_>>::NAME;
-        let deadline = tokio::time::sleep(dur);
-        tokio::pin!(deadline);
-
-        loop {
-            tokio::select! {
-                _ = &mut deadline => {
-                    debug!("{} duration elapsed", phase);
-                    break Ok(());
-                }
-                next = self.next_request() => {
-                    let (req, span, resp_tx) = next?;
-                    self.process_single(req, span, resp_tx).await;
-                }
-            }
-        }
-    }
-
-    /// Processes requests until there are enough.
-    async fn process_until_enough(&mut self) -> Result<(), PhaseStateError> {
-        while !self.has_enough_messages() {
-            let (req, span, resp_tx) = self.next_request().await?;
-            self.process_single(req, span, resp_tx).await;
-        }
-        Ok(())
-    }
-
-    /// Processes a single request.
-    ///
-    /// The request is discarded if the maximum message count is reached, accepted if processed
-    /// successfully and rejected otherwise.
-    async fn process_single(
-        &mut self,
-        req: StateMachineRequest,
-        span: Span,
-        resp_tx: ResponseSender,
-    ) {
-        let _span_guard = span.enter();
-
-        let response = if self.has_overmuch_messages() {
-            self.increment_discarded();
-            Err(RequestError::MessageDiscarded)
-        } else {
-            let response = self.handle_request(req).await;
-            if response.is_ok() {
-                self.increment_accepted();
-            } else {
-                self.increment_rejected();
-            }
-            response
-        };
-
-        // This may error out if the receiver has already been dropped but it doesn't matter for us.
-        let _ = resp_tx.send(response);
-    }
 }
 
 impl<S, T> PhaseState<S, T>

--- a/rust/xaynet-server/src/state_machine/phases/sum.rs
+++ b/rust/xaynet-server/src/state_machine/phases/sum.rs
@@ -5,8 +5,6 @@ use thiserror::Error;
 use tracing::info;
 
 use crate::{
-    impl_handler_for_phasestate,
-    impl_process_for_phasestate_handler,
     state_machine::{
         events::DictionaryUpdate,
         phases::{Handler, Phase, PhaseName, PhaseState, PhaseStateError, Shared, Update},
@@ -47,7 +45,7 @@ where
     const NAME: PhaseName = PhaseName::Sum;
 
     async fn run(&mut self) -> Result<(), PhaseStateError> {
-        self.process().await?;
+        self.process(self.shared.state.sum).await?;
 
         let sum_dict = self
             .shared
@@ -85,11 +83,7 @@ where
             Err(RequestError::MessageRejected)
         }
     }
-
-    impl_handler_for_phasestate! { Sum }
 }
-
-impl_process_for_phasestate_handler! { Sum }
 
 impl<S> PhaseState<Sum, S>
 where

--- a/rust/xaynet-server/src/state_machine/phases/sum.rs
+++ b/rust/xaynet-server/src/state_machine/phases/sum.rs
@@ -49,7 +49,6 @@ where
     async fn run(&mut self) -> Result<(), PhaseStateError> {
         self.process().await?;
 
-        info!("broadcasting sum dictionary");
         let sum_dict = self
             .shared
             .store
@@ -57,6 +56,7 @@ where
             .await
             .map_err(SumStateError::FetchSumDict)?
             .ok_or(SumStateError::NoSumDict)?;
+        info!("broadcasting sum dictionary");
         self.shared
             .events
             .broadcast_sum_dict(DictionaryUpdate::New(Arc::new(sum_dict)));

--- a/rust/xaynet-server/src/state_machine/phases/sum.rs
+++ b/rust/xaynet-server/src/state_machine/phases/sum.rs
@@ -6,6 +6,7 @@ use tracing::info;
 
 use crate::{
     impl_handler_for_phasestate,
+    impl_process_for_phasestate_handler,
     state_machine::{
         events::DictionaryUpdate,
         phases::{Handler, Phase, PhaseName, PhaseState, PhaseStateError, Shared, Update},
@@ -46,7 +47,7 @@ where
     const NAME: PhaseName = PhaseName::Sum;
 
     async fn run(&mut self) -> Result<(), PhaseStateError> {
-        self.process(self.shared.state.sum).await?;
+        self.process().await?;
 
         info!("broadcasting sum dictionary");
         let sum_dict = self
@@ -87,6 +88,8 @@ where
 
     impl_handler_for_phasestate! { Sum }
 }
+
+impl_process_for_phasestate_handler! { Sum }
 
 impl<S> PhaseState<Sum, S>
 where

--- a/rust/xaynet-server/src/state_machine/phases/sum2.rs
+++ b/rust/xaynet-server/src/state_machine/phases/sum2.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 
 use crate::{
     impl_handler_for_phasestate,
+    impl_process_for_phasestate_handler,
     state_machine::{
         phases::{Handler, Phase, PhaseName, PhaseState, PhaseStateError, Shared, Unmask},
         requests::{StateMachineRequest, Sum2Request},
@@ -37,7 +38,7 @@ where
     const NAME: PhaseName = PhaseName::Sum2;
 
     async fn run(&mut self) -> Result<(), PhaseStateError> {
-        self.process(self.shared.state.sum2).await
+        self.process().await
     }
 
     fn next(self) -> Option<StateMachine<S>> {
@@ -64,6 +65,8 @@ where
 
     impl_handler_for_phasestate! { Sum2 }
 }
+
+impl_process_for_phasestate_handler! { Sum2 }
 
 impl<S> PhaseState<Sum2, S>
 where

--- a/rust/xaynet-server/src/state_machine/phases/sum2.rs
+++ b/rust/xaynet-server/src/state_machine/phases/sum2.rs
@@ -1,8 +1,6 @@
 use async_trait::async_trait;
 
 use crate::{
-    impl_handler_for_phasestate,
-    impl_process_for_phasestate_handler,
     state_machine::{
         phases::{Handler, Phase, PhaseName, PhaseState, PhaseStateError, Shared, Unmask},
         requests::{StateMachineRequest, Sum2Request},
@@ -38,7 +36,7 @@ where
     const NAME: PhaseName = PhaseName::Sum2;
 
     async fn run(&mut self) -> Result<(), PhaseStateError> {
-        self.process().await
+        self.process(self.shared.state.sum2).await
     }
 
     fn next(self) -> Option<StateMachine<S>> {
@@ -62,11 +60,7 @@ where
             Err(RequestError::MessageRejected)
         }
     }
-
-    impl_handler_for_phasestate! { Sum2 }
 }
-
-impl_process_for_phasestate_handler! { Sum2 }
 
 impl<S> PhaseState<Sum2, S>
 where

--- a/rust/xaynet-server/src/state_machine/phases/update.rs
+++ b/rust/xaynet-server/src/state_machine/phases/update.rs
@@ -6,6 +6,7 @@ use tracing::{debug, info, warn};
 
 use crate::{
     impl_handler_for_phasestate,
+    impl_process_for_phasestate_handler,
     state_machine::{
         events::DictionaryUpdate,
         phases::{Handler, Phase, PhaseName, PhaseState, PhaseStateError, Shared, Sum2},
@@ -52,7 +53,7 @@ where
     const NAME: PhaseName = PhaseName::Update;
 
     async fn run(&mut self) -> Result<(), PhaseStateError> {
-        self.process(self.shared.state.update).await?;
+        self.process().await?;
 
         info!("broadcasting the global seed dictionary");
         let seed_dict = self
@@ -99,6 +100,8 @@ where
 
     impl_handler_for_phasestate! { Update }
 }
+
+impl_process_for_phasestate_handler! { Update }
 
 impl<S> PhaseState<Update, S>
 where

--- a/rust/xaynet-server/src/state_machine/phases/update.rs
+++ b/rust/xaynet-server/src/state_machine/phases/update.rs
@@ -55,7 +55,6 @@ where
     async fn run(&mut self) -> Result<(), PhaseStateError> {
         self.process().await?;
 
-        info!("broadcasting the global seed dictionary");
         let seed_dict = self
             .shared
             .store
@@ -63,6 +62,7 @@ where
             .await
             .map_err(UpdateStateError::FetchSeedDict)?
             .ok_or(UpdateStateError::NoSeedDict)?;
+        info!("broadcasting the global seed dictionary");
         self.shared
             .events
             .broadcast_seed_dict(DictionaryUpdate::New(Arc::new(seed_dict)));

--- a/rust/xaynet-server/src/state_machine/phases/update.rs
+++ b/rust/xaynet-server/src/state_machine/phases/update.rs
@@ -5,8 +5,6 @@ use thiserror::Error;
 use tracing::{debug, info, warn};
 
 use crate::{
-    impl_handler_for_phasestate,
-    impl_process_for_phasestate_handler,
     state_machine::{
         events::DictionaryUpdate,
         phases::{Handler, Phase, PhaseName, PhaseState, PhaseStateError, Shared, Sum2},
@@ -53,7 +51,7 @@ where
     const NAME: PhaseName = PhaseName::Update;
 
     async fn run(&mut self) -> Result<(), PhaseStateError> {
-        self.process().await?;
+        self.process(self.shared.state.update).await?;
 
         let seed_dict = self
             .shared
@@ -97,11 +95,7 @@ where
             Err(RequestError::MessageRejected)
         }
     }
-
-    impl_handler_for_phasestate! { Update }
 }
-
-impl_process_for_phasestate_handler! { Update }
 
 impl<S> PhaseState<Update, S>
 where

--- a/rust/xaynet-server/src/state_machine/phases/update.rs
+++ b/rust/xaynet-server/src/state_machine/phases/update.rs
@@ -2,10 +2,10 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use thiserror::Error;
-use tokio::time::{timeout, Duration};
 use tracing::{debug, info, warn};
 
 use crate::{
+    impl_handler_for_phasestate,
     state_machine::{
         events::DictionaryUpdate,
         phases::{Handler, Phase, PhaseName, PhaseState, PhaseStateError, Shared, Sum2},
@@ -52,32 +52,9 @@ where
     const NAME: PhaseName = PhaseName::Update;
 
     async fn run(&mut self) -> Result<(), PhaseStateError> {
-        let min_time = self.shared.state.update.time.min;
-        let max_time = self.shared.state.update.time.max;
-        debug!(
-            "in update phase for min {} and max {} seconds",
-            min_time, max_time,
-        );
-        self.process_during(Duration::from_secs(min_time)).await?;
+        self.process(self.shared.state.update).await?;
 
-        let time_left = max_time - min_time;
-        timeout(Duration::from_secs(time_left), self.process_until_enough()).await??;
-
-        info!(
-            "in total {} update messages accepted (min {} and max {} required)",
-            self.private.accepted,
-            self.shared.state.update.count.min,
-            self.shared.state.update.count.max,
-        );
-        info!(
-            "in total {} update messages rejected",
-            self.private.rejected,
-        );
-        info!(
-            "in total {} update messages discarded",
-            self.private.discarded,
-        );
-
+        info!("broadcasting the global seed dictionary");
         let seed_dict = self
             .shared
             .store
@@ -85,8 +62,6 @@ where
             .await
             .map_err(UpdateStateError::FetchSeedDict)?
             .ok_or(UpdateStateError::NoSeedDict)?;
-
-        info!("broadcasting the global seed dictionary");
         self.shared
             .events
             .broadcast_seed_dict(DictionaryUpdate::New(Arc::new(seed_dict)));
@@ -122,33 +97,7 @@ where
         }
     }
 
-    fn has_enough_messages(&self) -> bool {
-        self.private.accepted >= self.shared.state.update.count.min
-    }
-
-    fn has_overmuch_messages(&self) -> bool {
-        self.private.accepted >= self.shared.state.update.count.max
-    }
-
-    fn increment_accepted(&mut self) {
-        self.private.accepted += 1;
-        debug!(
-            "{} update messages accepted (min {} and max {} required)",
-            self.private.accepted,
-            self.shared.state.update.count.min,
-            self.shared.state.update.count.max,
-        );
-    }
-
-    fn increment_rejected(&mut self) {
-        self.private.rejected += 1;
-        debug!("{} update messages rejected", self.private.rejected);
-    }
-
-    fn increment_discarded(&mut self) {
-        self.private.discarded += 1;
-        debug!("{} update messages discarded", self.private.discarded);
-    }
+    impl_handler_for_phasestate! { Update }
 }
 
 impl<S> PhaseState<Update, S>


### PR DESCRIPTION
**References**

- [XN-1579](https://xainag.atlassian.net/browse/XN-1579)
- ~depends on #707 and must be rebased after that is merged~

**Summary**

reduce code duplication:
- move `Handler` related code into its own module
- add a `Counter` for `Handler` impls and move default impls there
- move `process_during()`/`process_until_enough()` related code from phase-dependent `run()` to a unified `process()` method
- add some `metric!` shortcuts
