### PR TITLE
Implement analytics controller

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1512,7 +1512,7 @@ checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 [[package]]
 name = "isar-core"
 version = "0.0.0"
-source = "git+https://github.com/isar/isar-core?rev=e1e7e08c232d31965d3bf59cbd6f7b43ddc6e5a5#e1e7e08c232d31965d3bf59cbd6f7b43ddc6e5a5"
+source = "git+https://github.com/isar/isar-core?rev=9165741a3660c84747596d2dd5368cd13c1e9171#9165741a3660c84747596d2dd5368cd13c1e9171"
 dependencies = [
  "byteorder",
  "crossbeam-channel",
@@ -1523,6 +1523,7 @@ dependencies = [
  "libc",
  "lmdb-sys",
  "once_cell",
+ "paste",
  "rand 0.8.3",
  "serde 1.0.123",
  "serde_json",
@@ -1630,7 +1631,7 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 [[package]]
 name = "lmdb-sys"
 version = "0.1.0"
-source = "git+https://github.com/isar/isar-core?rev=e1e7e08c232d31965d3bf59cbd6f7b43ddc6e5a5#e1e7e08c232d31965d3bf59cbd6f7b43ddc6e5a5"
+source = "git+https://github.com/isar/isar-core?rev=9165741a3660c84747596d2dd5368cd13c1e9171#9165741a3660c84747596d2dd5368cd13c1e9171"
 dependencies = [
  "cc",
  "libc",

--- a/rust/xaynet-analytics/Cargo.toml
+++ b/rust/xaynet-analytics/Cargo.toml
@@ -19,4 +19,4 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 anyhow = "1.0.38"
 chrono = "0.4.19"
-isar-core = { git = "https://github.com/isar/isar-core", rev = "e1e7e08c232d31965d3bf59cbd6f7b43ddc6e5a5" }
+isar-core = { git = "https://github.com/isar/isar-core", rev = "9165741a3660c84747596d2dd5368cd13c1e9171" }

--- a/rust/xaynet-analytics/src/controller.rs
+++ b/rust/xaynet-analytics/src/controller.rs
@@ -38,7 +38,7 @@ impl<'ctrl> AnalyticsController<'ctrl> {
         path: String,
         is_charging: bool,
         is_connected_to_wifi: bool,
-    ) -> Result<AnalyticsController<'ctrl>, Error> {
+    ) -> Result<Self, Error> {
         let analytics_event_repo = AnalyticsEventRepo::new(Self::ANALYTICS_EVENT_COLLECTION_NAME);
         let controller_data_repo = ControllerDataRepo::new(Self::CONTROLLER_DATA_COLLECTION_NAME);
         let screen_route_repo = ScreenRouteRepo::new(Self::SCREEN_ROUTE_COLLECTION_NAME);
@@ -49,8 +49,8 @@ impl<'ctrl> AnalyticsController<'ctrl> {
         ];
         let db = IsarDb::new(&path, schemas)?;
         let last_time_data_sent = Self::get_last_time_data_sent(&controller_data_repo, &db)?;
-        let combiner = DataCombiner {};
-        let sender = Sender {};
+        let combiner = DataCombiner;
+        let sender = Sender;
         Ok(AnalyticsController {
             db,
             is_charging,
@@ -76,11 +76,11 @@ impl<'ctrl> AnalyticsController<'ctrl> {
     }
 
     pub fn change_connectivity_status(&mut self) {
-        self.is_connected_to_wifi = !self.is_connected_to_wifi
+        self.is_connected_to_wifi = !self.is_connected_to_wifi;
     }
 
     pub fn change_state_of_charge(&mut self) {
-        self.is_charging = !self.is_charging
+        self.is_charging = !self.is_charging;
     }
 
     pub fn maybe_send_data(&mut self) -> Result<(), Error> {

--- a/rust/xaynet-analytics/src/controller.rs
+++ b/rust/xaynet-analytics/src/controller.rs
@@ -128,18 +128,17 @@ impl<'ctrl> AnalyticsController<'ctrl> {
         self.is_charging && self.is_connected_to_wifi
     }
 
+    // TODO: review and debug this method during https://xainag.atlassian.net/browse/XN-1560
     fn did_send_already_in_this_period(&self) -> bool {
-        if self.last_time_data_sent.is_none() {
-            false
-        } else {
+        self.last_time_data_sent.is_some() && {
             let tomorrow = Utc::now() + Duration::days(1);
             let midnight_after_current_time: DateTime<Utc> = DateTime::from_utc(
                 NaiveDate::from_ymd(tomorrow.year(), tomorrow.month(), tomorrow.day())
                     .and_hms(0, 0, 0),
                 Utc,
             );
-            let start_of_curret_period = midnight_after_current_time - self.send_data_frequency;
-            self.last_time_data_sent.unwrap() < start_of_curret_period
+            let start_of_current_period = midnight_after_current_time - self.send_data_frequency;
+            self.last_time_data_sent.unwrap() < start_of_current_period
         }
     }
 

--- a/rust/xaynet-analytics/src/controller.rs
+++ b/rust/xaynet-analytics/src/controller.rs
@@ -1,0 +1,158 @@
+use anyhow::{Error, Result};
+use chrono::{DateTime, Datelike, Duration, NaiveDate, Utc};
+
+use crate::{
+    data_combination::data_combiner::DataCombiner,
+    database::{
+        analytics_event::{data_model::AnalyticsEvent, repo::AnalyticsEventRepo},
+        common::{IsarAdapter, Repo, SchemaGenerator},
+        controller_data::{data_model::ControllerData, repo::ControllerDataRepo},
+        isar::IsarDb,
+        screen_route::{data_model::ScreenRoute, repo::ScreenRouteRepo},
+    },
+    sender::Sender,
+};
+
+struct AnalyticsController<'ctrl> {
+    db: IsarDb,
+    is_charging: bool,
+    is_connected_to_wifi: bool,
+    last_time_data_sent: Option<DateTime<Utc>>,
+    analytics_event_repo: AnalyticsEventRepo<'ctrl>,
+    controller_data_repo: ControllerDataRepo<'ctrl>,
+    screen_route_repo: ScreenRouteRepo<'ctrl>,
+    combiner: DataCombiner,
+    sender: Sender,
+    send_data_frequency: Duration,
+}
+
+// TODO: remove allow dead code when AnalyticsController is integrated with FFI layer: https://xainag.atlassian.net/browse/XN-1415
+#[allow(dead_code)]
+impl<'ctrl> AnalyticsController<'ctrl> {
+    const ANALYTICS_EVENT_COLLECTION_NAME: &'ctrl str = "analytics_events";
+    const CONTROLLER_DATA_COLLECTION_NAME: &'ctrl str = "controller_data";
+    const SCREEN_ROUTE_COLLECTION_NAME: &'ctrl str = "screen_routes";
+    const SEND_DATA_FREQUENCY_HOURS: i64 = 24;
+
+    pub fn init(
+        path: String,
+        is_charging: bool,
+        is_connected_to_wifi: bool,
+    ) -> Result<AnalyticsController<'ctrl>, Error> {
+        let analytics_event_repo = AnalyticsEventRepo::new(Self::ANALYTICS_EVENT_COLLECTION_NAME);
+        let controller_data_repo = ControllerDataRepo::new(Self::CONTROLLER_DATA_COLLECTION_NAME);
+        let screen_route_repo = ScreenRouteRepo::new(Self::SCREEN_ROUTE_COLLECTION_NAME);
+        let schemas = vec![
+            AnalyticsEvent::get_schema(Self::ANALYTICS_EVENT_COLLECTION_NAME)?,
+            ControllerData::get_schema(Self::CONTROLLER_DATA_COLLECTION_NAME)?,
+            ScreenRoute::get_schema(Self::SCREEN_ROUTE_COLLECTION_NAME)?,
+        ];
+        let db = IsarDb::new(&path, schemas)?;
+        let last_time_data_sent = Self::get_last_time_data_sent(&controller_data_repo, &db)?;
+        let combiner = DataCombiner {};
+        let sender = Sender {};
+        Ok(AnalyticsController {
+            db,
+            is_charging,
+            is_connected_to_wifi,
+            last_time_data_sent,
+            analytics_event_repo,
+            controller_data_repo,
+            screen_route_repo,
+            combiner,
+            sender,
+            send_data_frequency: Duration::hours(Self::SEND_DATA_FREQUENCY_HOURS),
+        })
+    }
+
+    pub fn dispose(self) -> Result<(), Error> {
+        self.db.dispose()
+    }
+
+    pub fn save_analytics_event(&self, event_bytes: &[u8]) -> Result<(), Error> {
+        let event = AnalyticsEvent::read(event_bytes);
+        self.check_for_new_screen_route(&event)?;
+        self.analytics_event_repo.add(&event, &self.db)
+    }
+
+    pub fn change_connectivity_status(&mut self) {
+        self.is_connected_to_wifi = !self.is_connected_to_wifi
+    }
+
+    pub fn change_state_of_charge(&mut self) {
+        self.is_charging = !self.is_charging
+    }
+
+    pub fn maybe_send_data(&mut self) -> Result<(), Error> {
+        if self.should_send_data() {
+            self.send_data()
+        } else {
+            Ok(())
+        }
+    }
+
+    fn check_for_new_screen_route(&self, event: &AnalyticsEvent) -> Result<(), Error> {
+        match event.screen_route {
+            Some(screen_route) => self.add_screen_route_if_new(screen_route),
+            None => Ok(()),
+        }
+    }
+
+    fn add_screen_route_if_new(&self, screen_route: &ScreenRoute) -> Result<(), Error> {
+        if !self
+            .screen_route_repo
+            .get_all(&self.db)?
+            .contains(screen_route)
+        {
+            self.screen_route_repo.add(screen_route, &self.db)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn get_last_time_data_sent(
+        repo: &ControllerDataRepo,
+        db: &IsarDb,
+    ) -> Result<Option<DateTime<Utc>>, Error> {
+        match repo.get_all(db)?.last() {
+            Some(data) => Ok(Some(data.time_data_sent)),
+            None => Ok(None),
+        }
+    }
+
+    fn should_send_data(&self) -> bool {
+        self.can_send_data() && !self.did_send_already_in_this_period()
+    }
+
+    fn can_send_data(&self) -> bool {
+        self.is_charging && self.is_connected_to_wifi
+    }
+
+    fn did_send_already_in_this_period(&self) -> bool {
+        if self.last_time_data_sent.is_none() {
+            false
+        } else {
+            let tomorrow = Utc::now() + Duration::days(1);
+            let midnight_after_current_time: DateTime<Utc> = DateTime::from_utc(
+                NaiveDate::from_ymd(tomorrow.year(), tomorrow.month(), tomorrow.day())
+                    .and_hms(0, 0, 0),
+                Utc,
+            );
+            let start_of_curret_period = midnight_after_current_time - self.send_data_frequency;
+            self.last_time_data_sent.unwrap() < start_of_curret_period
+        }
+    }
+
+    fn send_data(&mut self) -> Result<(), Error> {
+        let events = self.analytics_event_repo.get_all(&self.db)?;
+        let screen_routes = self.screen_route_repo.get_all(&self.db)?;
+        let time_data_sent = Utc::now();
+        self.sender
+            .send(self.combiner.init_data_points(&events, &screen_routes)?)
+            .and_then(|_| {
+                self.controller_data_repo
+                    .add(&ControllerData::new(time_data_sent), &self.db)
+            })
+            .map(|_| self.last_time_data_sent = Some(time_data_sent))
+    }
+}

--- a/rust/xaynet-analytics/src/data_combination/data_combiner.rs
+++ b/rust/xaynet-analytics/src/data_combination/data_combiner.rs
@@ -19,7 +19,7 @@ use crate::{
     },
 };
 
-pub struct DataCombiner {}
+pub struct DataCombiner;
 
 impl<'screen> DataCombiner {
     pub fn init_data_points(
@@ -73,7 +73,7 @@ impl<'screen> DataCombiner {
         let mut screen_active_time_vars: Vec<DataPoint> = screen_routes
             .iter()
             .map(|route| {
-                let events_this_route = Self::get_events_single_route(&route, events);
+                let events_this_route = Self::get_events_single_route(route, events);
                 CalcScreenActiveTime::new(
                     metadata,
                     Self::filter_events_in_this_period(metadata, events_this_route.as_slice()),
@@ -252,7 +252,7 @@ mod tests {
             end_period - Duration::hours(12),
             Some(&screen_route),
         );
-        let all_events = [
+        let all_events = vec![
             first_event.clone(),
             AnalyticsEvent::new(
                 "test1",
@@ -263,10 +263,7 @@ mod tests {
         ];
         let expected_output = vec![
             DataPoint::ScreenActiveTime(CalcScreenActiveTime::new(metadata, vec![first_event])),
-            DataPoint::ScreenActiveTime(CalcScreenActiveTime::new(
-                metadata,
-                all_events.clone().into(),
-            )),
+            DataPoint::ScreenActiveTime(CalcScreenActiveTime::new(metadata, all_events.clone())),
         ];
         let actual_output = DataCombiner::init_screen_active_time_vars(
             metadata,
@@ -283,7 +280,7 @@ mod tests {
             .with_timezone(&Utc);
         let metadata = DataPointMetadata::new(Period::new(PeriodUnit::Days, 1), end_period);
         let screen_route = ScreenRoute::new("home_screen", end_period + Duration::days(1));
-        let events = [AnalyticsEvent::new(
+        let events = vec![AnalyticsEvent::new(
             "test1",
             AnalyticsEventType::ScreenEnter,
             end_period - Duration::hours(12),
@@ -291,7 +288,7 @@ mod tests {
         )];
         let expected_output = vec![DataPoint::ScreenEnterCount(CalcScreenEnterCount::new(
             metadata,
-            events.clone().into(),
+            events.clone(),
         ))];
         let actual_output =
             DataCombiner::init_screen_enter_count_vars(metadata, &events, &[screen_route.clone()]);

--- a/rust/xaynet-analytics/src/data_combination/data_points/data_point.rs
+++ b/rust/xaynet-analytics/src/data_combination/data_points/data_point.rs
@@ -16,8 +16,8 @@ pub struct Period {
 }
 
 impl Period {
-    pub fn new(unit: PeriodUnit, n: u32) -> Period {
-        Period { unit, n }
+    pub fn new(unit: PeriodUnit, n: u32) -> Self {
+        Self { unit, n }
     }
 }
 
@@ -28,8 +28,8 @@ pub struct DataPointMetadata {
 }
 
 impl DataPointMetadata {
-    pub fn new(period: Period, end: DateTime<Utc>) -> DataPointMetadata {
-        DataPointMetadata { period, end }
+    pub fn new(period: Period, end: DateTime<Utc>) -> Self {
+        Self { period, end }
     }
 }
 

--- a/rust/xaynet-analytics/src/data_combination/data_points/screen_active_time.rs
+++ b/rust/xaynet-analytics/src/data_combination/data_points/screen_active_time.rs
@@ -10,8 +10,8 @@ use crate::{
 };
 
 impl<'a> CalcScreenActiveTime<'a> {
-    pub fn new(metadata: DataPointMetadata, events: Vec<AnalyticsEvent>) -> CalcScreenActiveTime {
-        CalcScreenActiveTime { metadata, events }
+    pub fn new(metadata: DataPointMetadata, events: Vec<AnalyticsEvent<'a>>) -> Self {
+        Self { metadata, events }
     }
 
     // TODO: return an iterator instead of Vec: https://xainag.atlassian.net/browse/XN-1517

--- a/rust/xaynet-analytics/src/data_combination/data_points/screen_enter_count.rs
+++ b/rust/xaynet-analytics/src/data_combination/data_points/screen_enter_count.rs
@@ -8,8 +8,8 @@ use crate::{
 };
 
 impl<'a> CalcScreenEnterCount<'a> {
-    pub fn new(metadata: DataPointMetadata, events: Vec<AnalyticsEvent>) -> CalcScreenEnterCount {
-        CalcScreenEnterCount { metadata, events }
+    pub fn new(metadata: DataPointMetadata, events: Vec<AnalyticsEvent<'a>>) -> Self {
+        Self { metadata, events }
     }
 }
 

--- a/rust/xaynet-analytics/src/data_combination/data_points/was_active_each_past_period.rs
+++ b/rust/xaynet-analytics/src/data_combination/data_points/was_active_each_past_period.rs
@@ -13,10 +13,10 @@ use crate::{
 impl<'a> CalcWasActiveEachPastPeriod<'a> {
     pub fn new(
         metadata: DataPointMetadata,
-        events: Vec<AnalyticsEvent>,
+        events: Vec<AnalyticsEvent<'a>>,
         period_thresholds: Vec<DateTime<Utc>>,
-    ) -> CalcWasActiveEachPastPeriod {
-        CalcWasActiveEachPastPeriod {
+    ) -> Self {
+        Self {
             metadata,
             events,
             period_thresholds,

--- a/rust/xaynet-analytics/src/data_combination/data_points/was_active_past_n_days.rs
+++ b/rust/xaynet-analytics/src/data_combination/data_points/was_active_past_n_days.rs
@@ -8,8 +8,8 @@ use crate::{
 };
 
 impl<'a> CalcWasActivePastNDays<'a> {
-    pub fn new(metadata: DataPointMetadata, events: Vec<AnalyticsEvent>) -> CalcWasActivePastNDays {
-        CalcWasActivePastNDays { metadata, events }
+    pub fn new(metadata: DataPointMetadata, events: Vec<AnalyticsEvent<'a>>) -> Self {
+        Self { metadata, events }
     }
 }
 

--- a/rust/xaynet-analytics/src/database/analytics_event/data_model.rs
+++ b/rust/xaynet-analytics/src/database/analytics_event/data_model.rs
@@ -3,7 +3,7 @@ use isar_core::object::{data_type::DataType, object_builder::ObjectBuilder};
 use std::vec::IntoIter;
 
 use crate::database::{
-    common::{FieldProperty, IsarAdapter},
+    common::{FieldProperty, IsarAdapter, SchemaGenerator},
     screen_route::data_model::ScreenRoute,
 };
 
@@ -39,7 +39,7 @@ impl<'screen> AnalyticsEvent<'screen> {
     }
 }
 
-impl<'a> IsarAdapter for AnalyticsEvent<'a> {
+impl<'screen> IsarAdapter for AnalyticsEvent<'screen> {
     fn into_field_properties() -> IntoIter<FieldProperty> {
         // NOTE: properties need to be ordered by type. Properties with the same type need to be ordered alphabetically
         // https://github.com/isar/isar-core/blob/1ea9f27edfd6e3708daa47ac6a17995b628f31a6/src/schema/collection_schema.rs
@@ -58,4 +58,11 @@ impl<'a> IsarAdapter for AnalyticsEvent<'a> {
         object_builder.write_string(self.screen_route.map(|screen| screen.name.as_ref()));
         object_builder.write_string(Some(&self.timestamp.to_rfc3339()));
     }
+
+    fn read(_bytes: &[u8]) -> AnalyticsEvent<'screen> {
+        // TODO: implement when Isar will support it: https://xainag.atlassian.net/browse/XN-1604
+        unimplemented!()
+    }
 }
+
+impl<'screen> SchemaGenerator<AnalyticsEvent<'screen>> for AnalyticsEvent<'screen> {}

--- a/rust/xaynet-analytics/src/database/analytics_event/data_model.rs
+++ b/rust/xaynet-analytics/src/database/analytics_event/data_model.rs
@@ -29,8 +29,8 @@ impl<'screen> AnalyticsEvent<'screen> {
         event_type: AnalyticsEventType,
         timestamp: DateTime<Utc>,
         screen_route: Option<&'screen ScreenRoute>,
-    ) -> AnalyticsEvent {
-        AnalyticsEvent {
+    ) -> Self {
+        Self {
             name: name.into(),
             event_type,
             timestamp,
@@ -61,7 +61,7 @@ impl<'screen> IsarAdapter for AnalyticsEvent<'screen> {
 
     fn read(_bytes: &[u8]) -> AnalyticsEvent<'screen> {
         // TODO: implement when Isar will support it: https://xainag.atlassian.net/browse/XN-1604
-        unimplemented!()
+        todo!()
     }
 }
 

--- a/rust/xaynet-analytics/src/database/analytics_event/repo.rs
+++ b/rust/xaynet-analytics/src/database/analytics_event/repo.rs
@@ -33,7 +33,7 @@ impl<'screen, 'db> Repo<AnalyticsEvent<'screen>> for AnalyticsEventRepo<'db> {
 
         // TODO: not sure how to proceed to parse [u8] using the collection schema. didn't find examples in Isar
         // implement when possible: https://xainag.atlassian.net/browse/XN-1604
-        unimplemented!()
+        todo!()
     }
 }
 

--- a/rust/xaynet-analytics/src/database/analytics_event/repo.rs
+++ b/rust/xaynet-analytics/src/database/analytics_event/repo.rs
@@ -8,23 +8,19 @@ use crate::database::{
 
 pub struct AnalyticsEventRepo<'db> {
     collection_name: &'db str,
-    db: &'db IsarDb,
 }
 
 impl<'db> AnalyticsEventRepo<'db> {
-    pub fn new(collection_name: &'db str, db: &'db IsarDb) -> Self {
-        Self {
-            collection_name,
-            db,
-        }
+    pub fn new(collection_name: &'db str) -> Self {
+        Self { collection_name }
     }
 }
 
 impl<'screen, 'db> Repo<AnalyticsEvent<'screen>> for AnalyticsEventRepo<'db> {
-    fn add(&self, event: AnalyticsEvent) -> Result<(), Error> {
-        let mut object_builder = self.db.get_object_builder(self.collection_name)?;
+    fn add(&self, event: &AnalyticsEvent, db: &IsarDb) -> Result<(), Error> {
+        let mut object_builder = db.get_object_builder(self.collection_name)?;
         event.write_with_object_builder(&mut object_builder);
-        self.db.put(
+        db.put(
             &self.collection_name,
             None,
             object_builder.finish().as_bytes(),
@@ -32,8 +28,8 @@ impl<'screen, 'db> Repo<AnalyticsEvent<'screen>> for AnalyticsEventRepo<'db> {
     }
 
     // TODO: return an iterator instead of Vec: https://xainag.atlassian.net/browse/XN-1517
-    fn get_all(&self) -> Result<Vec<AnalyticsEvent<'screen>>, Error> {
-        let _events_as_bytes = self.db.get_all_as_bytes(&self.collection_name)?;
+    fn get_all(&self, db: &IsarDb) -> Result<Vec<AnalyticsEvent<'screen>>, Error> {
+        let _events_as_bytes = db.get_all_as_bytes(&self.collection_name)?;
 
         // TODO: not sure how to proceed to parse [u8] using the collection schema. didn't find examples in Isar
         // implement when possible: https://xainag.atlassian.net/browse/XN-1604
@@ -44,11 +40,11 @@ impl<'screen, 'db> Repo<AnalyticsEvent<'screen>> for AnalyticsEventRepo<'db> {
 pub struct MockAnalyticsEventRepo {}
 
 impl<'screen> Repo<AnalyticsEvent<'screen>> for MockAnalyticsEventRepo {
-    fn add(&self, _object: AnalyticsEvent) -> Result<(), Error> {
+    fn add(&self, _object: &AnalyticsEvent, _db: &IsarDb) -> Result<(), Error> {
         Ok(())
     }
 
-    fn get_all(&self) -> Result<Vec<AnalyticsEvent<'screen>>, Error> {
+    fn get_all(&self, _db: &IsarDb) -> Result<Vec<AnalyticsEvent<'screen>>, Error> {
         Ok(Vec::new())
     }
 }

--- a/rust/xaynet-analytics/src/database/common.rs
+++ b/rust/xaynet-analytics/src/database/common.rs
@@ -62,8 +62,8 @@ pub struct FieldProperty {
 }
 
 impl FieldProperty {
-    pub fn new(name: String, data_type: DataType) -> FieldProperty {
-        FieldProperty {
+    pub fn new(name: String, data_type: DataType) -> Self {
+        Self {
             name,
             data_type,
             string_index_type: StringIndexType::Hash,

--- a/rust/xaynet-analytics/src/database/common.rs
+++ b/rust/xaynet-analytics/src/database/common.rs
@@ -1,20 +1,28 @@
-use anyhow::Error;
+use anyhow::{anyhow, Error, Result};
 use isar_core::{
     index::StringIndexType,
     object::{data_type::DataType, object_builder::ObjectBuilder},
+    schema::collection_schema::CollectionSchema,
 };
 use std::vec::IntoIter;
+
+use crate::database::isar::IsarDb;
 
 pub trait IsarAdapter: Sized {
     fn into_field_properties() -> IntoIter<FieldProperty>;
 
     fn write_with_object_builder(&self, object_builder: &mut ObjectBuilder);
+
+    fn read(bytes: &[u8]) -> Self;
 }
 
-pub trait Repo<T> {
-    fn add(&self, object: T) -> Result<(), Error>;
+pub trait Repo<T>
+where
+    T: IsarAdapter,
+{
+    fn add(&self, object: &T, db: &IsarDb) -> Result<(), Error>;
 
-    fn get_all(&self) -> Result<Vec<T>, Error>;
+    fn get_all(&self, db: &IsarDb) -> Result<Vec<T>, Error>;
 }
 
 pub struct MockRepo {}
@@ -29,14 +37,18 @@ impl IsarAdapter for MockObject {
     fn write_with_object_builder(&self, _object_builder: &mut ObjectBuilder) {
         unimplemented!()
     }
+
+    fn read(_bytes: &[u8]) -> MockObject {
+        unimplemented!()
+    }
 }
 
 impl Repo<MockObject> for MockRepo {
-    fn add(&self, _object: MockObject) -> Result<(), Error> {
+    fn add(&self, _object: &MockObject, _db: &IsarDb) -> Result<(), Error> {
         unimplemented!()
     }
 
-    fn get_all(&self) -> Result<Vec<MockObject>, Error> {
+    fn get_all(&self, _db: &IsarDb) -> Result<Vec<MockObject>, Error> {
         unimplemented!()
     }
 }
@@ -58,5 +70,44 @@ impl FieldProperty {
             is_case_sensitive: true,
             is_unique: true,
         }
+    }
+}
+
+pub trait SchemaGenerator<T>
+where
+    T: IsarAdapter,
+{
+    fn get_schema(name: &str) -> Result<CollectionSchema, Error> {
+        T::into_field_properties().try_fold(
+            CollectionSchema::new(name, &format!("{}_oid", name), DataType::String),
+            |mut schema, prop| {
+                schema
+                    .add_property(&prop.name, prop.data_type)
+                    .map_err(|_| {
+                        anyhow!(
+                            "failed to add property {} to collection {}",
+                            prop.name,
+                            name
+                        )
+                    })?;
+                schema
+                    .add_index(
+                        &[(
+                            &prop.name,
+                            Some(prop.string_index_type),
+                            prop.is_case_sensitive,
+                        )],
+                        prop.is_unique,
+                    )
+                    .map_err(|_| {
+                        anyhow!(
+                            "failed to add index for {} to collection {}",
+                            prop.name,
+                            name
+                        )
+                    })?;
+                Ok(schema)
+            },
+        )
     }
 }

--- a/rust/xaynet-analytics/src/database/controller_data/data_model.rs
+++ b/rust/xaynet-analytics/src/database/controller_data/data_model.rs
@@ -1,0 +1,37 @@
+use chrono::{DateTime, Utc};
+use isar_core::object::{data_type::DataType, object_builder::ObjectBuilder};
+use std::vec::IntoIter;
+
+use crate::database::common::{FieldProperty, IsarAdapter, SchemaGenerator};
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct ControllerData {
+    pub time_data_sent: DateTime<Utc>,
+}
+
+impl ControllerData {
+    pub fn new(time_data_sent: DateTime<Utc>) -> ControllerData {
+        ControllerData { time_data_sent }
+    }
+}
+
+impl IsarAdapter for ControllerData {
+    fn into_field_properties() -> IntoIter<FieldProperty> {
+        vec![FieldProperty::new(
+            "time_data_sent".to_string(),
+            DataType::String,
+        )]
+        .into_iter()
+    }
+
+    fn write_with_object_builder(&self, object_builder: &mut ObjectBuilder) {
+        object_builder.write_string(Some(&self.time_data_sent.to_rfc3339()));
+    }
+
+    fn read(_bytes: &[u8]) -> ControllerData {
+        // TODO: implement when Isar will support it: https://xainag.atlassian.net/browse/XN-1604
+        unimplemented!()
+    }
+}
+
+impl SchemaGenerator<ControllerData> for ControllerData {}

--- a/rust/xaynet-analytics/src/database/controller_data/data_model.rs
+++ b/rust/xaynet-analytics/src/database/controller_data/data_model.rs
@@ -10,8 +10,8 @@ pub struct ControllerData {
 }
 
 impl ControllerData {
-    pub fn new(time_data_sent: DateTime<Utc>) -> ControllerData {
-        ControllerData { time_data_sent }
+    pub fn new(time_data_sent: DateTime<Utc>) -> Self {
+        Self { time_data_sent }
     }
 }
 
@@ -30,7 +30,7 @@ impl IsarAdapter for ControllerData {
 
     fn read(_bytes: &[u8]) -> ControllerData {
         // TODO: implement when Isar will support it: https://xainag.atlassian.net/browse/XN-1604
-        unimplemented!()
+        todo!()
     }
 }
 

--- a/rust/xaynet-analytics/src/database/controller_data/mod.rs
+++ b/rust/xaynet-analytics/src/database/controller_data/mod.rs
@@ -1,0 +1,2 @@
+pub mod data_model;
+pub mod repo;

--- a/rust/xaynet-analytics/src/database/controller_data/repo.rs
+++ b/rust/xaynet-analytics/src/database/controller_data/repo.rs
@@ -1,0 +1,49 @@
+use anyhow::{Error, Result};
+
+use crate::database::{
+    common::{IsarAdapter, Repo},
+    controller_data::data_model::ControllerData,
+    isar::IsarDb,
+};
+
+pub struct ControllerDataRepo<'db> {
+    collection_name: &'db str,
+}
+
+impl<'db> ControllerDataRepo<'db> {
+    pub fn new(collection_name: &'db str) -> Self {
+        Self { collection_name }
+    }
+}
+
+impl<'db> Repo<ControllerData> for ControllerDataRepo<'db> {
+    fn add(&self, data: &ControllerData, db: &IsarDb) -> Result<(), Error> {
+        let mut object_builder = db.get_object_builder(self.collection_name)?;
+        data.write_with_object_builder(&mut object_builder);
+        db.put(
+            &self.collection_name,
+            None,
+            object_builder.finish().as_bytes(),
+        )
+    }
+
+    // TODO: return an iterator instead of Vec: https://xainag.atlassian.net/browse/XN-1517
+    fn get_all(&self, db: &IsarDb) -> Result<Vec<ControllerData>, Error> {
+        let _routes_as_bytes = db.get_all_as_bytes(&self.collection_name)?;
+
+        // TODO: not sure how to proceed to parse [u8] using the collection schema. didn't find examples in Isar
+        unimplemented!()
+    }
+}
+
+pub struct MockControllerDataRepo {}
+
+impl Repo<ControllerData> for MockControllerDataRepo {
+    fn add(&self, _object: &ControllerData, _db: &IsarDb) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn get_all(&self, _db: &IsarDb) -> Result<Vec<ControllerData>, Error> {
+        Ok(Vec::new())
+    }
+}

--- a/rust/xaynet-analytics/src/database/controller_data/repo.rs
+++ b/rust/xaynet-analytics/src/database/controller_data/repo.rs
@@ -32,7 +32,7 @@ impl<'db> Repo<ControllerData> for ControllerDataRepo<'db> {
         let _routes_as_bytes = db.get_all_as_bytes(&self.collection_name)?;
 
         // TODO: not sure how to proceed to parse [u8] using the collection schema. didn't find examples in Isar
-        unimplemented!()
+        todo!()
     }
 }
 

--- a/rust/xaynet-analytics/src/database/isar.rs
+++ b/rust/xaynet-analytics/src/database/isar.rs
@@ -42,7 +42,7 @@ impl IsarDb {
             });
 
         // TODO: not sure how to proceed to parse [u8] using the collection schema. didn't find examples in Isar
-        unimplemented!()
+        todo!()
     }
 
     pub fn put(
@@ -83,7 +83,7 @@ impl IsarDb {
 
     pub fn dispose(self) -> Result<(), Error> {
         match self.instance.close() {
-            Some(_) => Err(anyhow!("err")),
+            Some(_) => Err(anyhow!("could not close the IsarInstance")),
             None => Ok(()),
         }
     }

--- a/rust/xaynet-analytics/src/database/mod.rs
+++ b/rust/xaynet-analytics/src/database/mod.rs
@@ -1,4 +1,5 @@
 pub mod analytics_event;
 pub mod common;
+pub mod controller_data;
 pub mod isar;
 pub mod screen_route;

--- a/rust/xaynet-analytics/src/database/screen_route/data_model.rs
+++ b/rust/xaynet-analytics/src/database/screen_route/data_model.rs
@@ -2,13 +2,12 @@ use chrono::{DateTime, Utc};
 use isar_core::object::{data_type::DataType, object_builder::ObjectBuilder};
 use std::vec::IntoIter;
 
-use crate::database::common::{FieldProperty, IsarAdapter};
+use crate::database::common::{FieldProperty, IsarAdapter, SchemaGenerator};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ScreenRoute {
     pub name: String,
     pub created_at: DateTime<Utc>,
-    pub object_id: Option<String>,
 }
 
 impl ScreenRoute {
@@ -16,7 +15,6 @@ impl ScreenRoute {
         ScreenRoute {
             name: name.into(),
             created_at,
-            object_id: None,
         }
     }
 }
@@ -34,4 +32,11 @@ impl IsarAdapter for ScreenRoute {
         object_builder.write_string(Some(&self.created_at.to_rfc3339()));
         object_builder.write_string(Some(&self.name));
     }
+
+    fn read(_bytes: &[u8]) -> ScreenRoute {
+        // TODO: implement when Isar will support it: https://xainag.atlassian.net/browse/XN-1604
+        unimplemented!()
+    }
 }
+
+impl SchemaGenerator<ScreenRoute> for ScreenRoute {}

--- a/rust/xaynet-analytics/src/database/screen_route/data_model.rs
+++ b/rust/xaynet-analytics/src/database/screen_route/data_model.rs
@@ -11,8 +11,8 @@ pub struct ScreenRoute {
 }
 
 impl ScreenRoute {
-    pub fn new<N: Into<String>>(name: N, created_at: DateTime<Utc>) -> ScreenRoute {
-        ScreenRoute {
+    pub fn new<N: Into<String>>(name: N, created_at: DateTime<Utc>) -> Self {
+        Self {
             name: name.into(),
             created_at,
         }
@@ -35,7 +35,7 @@ impl IsarAdapter for ScreenRoute {
 
     fn read(_bytes: &[u8]) -> ScreenRoute {
         // TODO: implement when Isar will support it: https://xainag.atlassian.net/browse/XN-1604
-        unimplemented!()
+        todo!()
     }
 }
 

--- a/rust/xaynet-analytics/src/database/screen_route/repo.rs
+++ b/rust/xaynet-analytics/src/database/screen_route/repo.rs
@@ -8,26 +8,20 @@ use crate::database::{
 
 pub struct ScreenRouteRepo<'db> {
     collection_name: &'db str,
-    db: &'db IsarDb,
 }
 
 impl<'db> ScreenRouteRepo<'db> {
-    pub fn new(collection_name: &'db str, db: &'db IsarDb) -> Self {
-        Self {
-            collection_name,
-            db,
-        }
+    pub fn new(collection_name: &'db str) -> Self {
+        Self { collection_name }
     }
 }
 
 impl<'db> Repo<ScreenRoute> for ScreenRouteRepo<'db> {
-    fn add(&self, route: ScreenRoute) -> Result<(), Error> {
-        let mut object_builder = self.db.get_object_builder(&self.collection_name)?;
+    fn add(&self, route: &ScreenRoute, db: &IsarDb) -> Result<(), Error> {
+        let mut object_builder = db.get_object_builder(&self.collection_name)?;
         route.write_with_object_builder(&mut object_builder);
-        let object_id = self
-            .db
-            .get_object_id_from_str(&self.collection_name, &route.name)?;
-        self.db.put(
+        let object_id = db.get_object_id_from_str(&self.collection_name, &route.name)?;
+        db.put(
             &self.collection_name,
             Some(object_id),
             object_builder.finish().as_bytes(),
@@ -35,8 +29,8 @@ impl<'db> Repo<ScreenRoute> for ScreenRouteRepo<'db> {
     }
 
     // TODO: return an iterator instead of Vec: https://xainag.atlassian.net/browse/XN-1517
-    fn get_all(&self) -> Result<Vec<ScreenRoute>, Error> {
-        let _routes_as_bytes = self.db.get_all_as_bytes(&self.collection_name)?;
+    fn get_all(&self, db: &IsarDb) -> Result<Vec<ScreenRoute>, Error> {
+        let _routes_as_bytes = db.get_all_as_bytes(&self.collection_name)?;
 
         // TODO: not sure how to proceed to parse [u8] using the collection schema. didn't find examples in Isar
         unimplemented!()
@@ -46,11 +40,11 @@ impl<'db> Repo<ScreenRoute> for ScreenRouteRepo<'db> {
 pub struct MockScreenRouteRepo {}
 
 impl Repo<ScreenRoute> for MockScreenRouteRepo {
-    fn add(&self, _object: ScreenRoute) -> Result<(), Error> {
+    fn add(&self, _object: &ScreenRoute, _db: &IsarDb) -> Result<(), Error> {
         Ok(())
     }
 
-    fn get_all(&self) -> Result<Vec<ScreenRoute>, Error> {
+    fn get_all(&self, _db: &IsarDb) -> Result<Vec<ScreenRoute>, Error> {
         Ok(Vec::new())
     }
 }

--- a/rust/xaynet-analytics/src/database/screen_route/repo.rs
+++ b/rust/xaynet-analytics/src/database/screen_route/repo.rs
@@ -33,7 +33,7 @@ impl<'db> Repo<ScreenRoute> for ScreenRouteRepo<'db> {
         let _routes_as_bytes = db.get_all_as_bytes(&self.collection_name)?;
 
         // TODO: not sure how to proceed to parse [u8] using the collection schema. didn't find examples in Isar
-        unimplemented!()
+        todo!()
     }
 }
 

--- a/rust/xaynet-analytics/src/lib.rs
+++ b/rust/xaynet-analytics/src/lib.rs
@@ -8,5 +8,7 @@
 //! a framework that allows mobile applications to collect and aggregate
 //! analytics data via the _Privacy-Enhancing Technology_ (PET) protocol.
 
+pub mod controller;
 pub mod data_combination;
 pub mod database;
+pub mod sender;

--- a/rust/xaynet-analytics/src/sender.rs
+++ b/rust/xaynet-analytics/src/sender.rs
@@ -2,11 +2,11 @@ use anyhow::{Error, Result};
 
 use crate::data_combination::data_points::data_point::DataPoint;
 
-pub struct Sender {}
+pub struct Sender;
 
 impl<'ctrl> Sender {
     pub fn send(&self, _data_points: Vec<DataPoint<'ctrl>>) -> Result<(), Error> {
         // TODO: https://xainag.atlassian.net/browse/XN-1647
-        unimplemented!()
+        todo!()
     }
 }

--- a/rust/xaynet-analytics/src/sender.rs
+++ b/rust/xaynet-analytics/src/sender.rs
@@ -1,0 +1,12 @@
+use anyhow::{Error, Result};
+
+use crate::data_combination::data_points::data_point::DataPoint;
+
+pub struct Sender {}
+
+impl<'ctrl> Sender {
+    pub fn send(&self, _data_points: Vec<DataPoint<'ctrl>>) -> Result<(), Error> {
+        // TODO: https://xainag.atlassian.net/browse/XN-1647
+        unimplemented!()
+    }
+}


### PR DESCRIPTION
[XN-1557](https://xainag.atlassian.net/browse/XN-1557)

Add `AnalyticsController` component, responsible for initialising all dependencies and expose a simple API for the mobile framework layer to utilise. 

I've added two small refactors:
1) Now `Repo` trait implementations receive the `IsarDb` instance in their `get_all` / `add` methods, because `IsarInstance` is by design a singleton that cannot be cloned.
2) Added a `SchemaGenerator` trait with a default implementation for the various data models to implement as is, so that the `CollectionSchema` can be generated directly by the `AnalyticsController`, and there's no duplication of constant collection names, nor we can forget to register at the `IsarDb` level a new collection (because it's handled by the `AnalyticsController`).

Hope everything makes sense! Please let me know.

Follow ups: 
* Implement read method from Isar + get_all methods in Repos
* Unit / integration tests as if there were no tomorrow.