### PR TITLE
integration tests flag

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -209,14 +209,14 @@ jobs:
         working-directory: ./docker
         run: docker-compose up -d influxdb minio redis
 
-      - name: Run tests
+      - name: Run tests (unit & integration & doc)
         working-directory: ./rust
         env:
           RUSTFLAGS: "-D warnings"
         run: |
-          cargo test --all-targets
-          cargo test --all-targets --all-features
-          cargo test --all-features --doc
+          cargo test --lib --bins --examples --tests -- -Z unstable-options --include-ignored
+          cargo test --lib --bins --examples --tests --all-features -- -Z unstable-options --include-ignored
+          cargo test --doc --all-features
 
       - name: Stop docker-compose
         working-directory: ./docker

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -337,7 +337,7 @@ jobs:
         uses: actions-rs/tarpaulin@v0.1
         with:
           version: '0.16.0'
-          args: '--manifest-path rust/Cargo.toml --all-features --force-clean --lib --ignore-tests'
+          args: '--manifest-path rust/Cargo.toml --all-features --force-clean --lib --ignore-tests --ignored'
 
       - name: Stop docker-compose
         working-directory: ./docker

--- a/rust/xaynet-core/src/message/utils/chunkable_iterator.rs
+++ b/rust/xaynet-core/src/message/utils/chunkable_iterator.rs
@@ -26,10 +26,8 @@ pub trait ChunkableIterator: Iterator + Sized {
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// # use std::iter::Iterator;
-    /// # use xaynet_core::message::utils::ChunkableIterator;
-    ///
+    /// ```compile_fail
+    /// # // private items can't be tested with doc tests
     /// let chunks = vec![0, 1, 2, 3, 4].into_iter().chunks(2);
     /// let mut chunks_iter = chunks.into_iter();
     ///
@@ -52,10 +50,8 @@ pub trait ChunkableIterator: Iterator + Sized {
     ///
     /// Attempting to consume chunks out of order fails:
     ///
-    /// ```ignore
-    /// # use std::iter::Iterator;
-    /// # use xaynet_core::message::utils::ChunkableIterator;
-    ///
+    /// ```compile_fail
+    /// # // private items can't be tested with doc tests
     /// let chunks = vec![0, 1, 2, 3, 4].into_iter().chunks(2);
     /// let mut chunks_iter = chunks.into_iter();
     ///
@@ -67,10 +63,8 @@ pub trait ChunkableIterator: Iterator + Sized {
     ///
     /// Similarly, not _fully_ consuming the chunks fails:
     ///
-    /// ```ignore
-    /// # use std::iter::Iterator;
-    /// # use xaynet_core::message::utils::ChunkableIterator;
-    ///
+    /// ```compile_fail
+    /// # // private items can't be tested with doc tests
     /// let chunks = vec![0, 1, 2, 3, 4].into_iter().chunks(2);
     /// let mut chunks_iter = chunks.into_iter();
     ///
@@ -227,8 +221,8 @@ where
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// # use xaynet_core::message::utils::IntoChunks;
+    /// ```compile_fail
+    /// # // private items can't be tested with doc tests
     /// let iter = vec![0, 1, 2, 3, 4, 5].into_iter();
     /// let chunk_size = 2;
     /// let chunks = IntoChunks::new(iter, chunk_size);

--- a/rust/xaynet-sdk/src/lib.rs
+++ b/rust/xaynet-sdk/src/lib.rs
@@ -91,7 +91,7 @@
 //! is the full code:
 //!
 //! ```no_run
-//! # #[cfg(feature = "reqwest-client")]
+//! # #[cfg(all(feature = "reqwest-client", feature = "tokio/rt-muli-thread"))]
 //! # mod feature_reqwest_client {
 //! use std::{
 //!     sync::{mpsc, Arc},
@@ -182,7 +182,7 @@
 //!     }
 //! }
 //!
-//! #[tokio::main(flavor = "current_thread")]
+//! #[tokio::main]
 //! async fn main() -> Result<(), std::convert::Infallible> {
 //!     let keys = SigningKeyPair::generate();
 //!     let settings = PetSettings::new(keys);
@@ -203,7 +203,7 @@
 //!     }
 //! }
 //! # }
-//! # fn main() {}
+//! # fn main() {} // don't actually run anything, because the client never terminates
 //! ```
 
 pub mod client;

--- a/rust/xaynet-sdk/src/lib.rs
+++ b/rust/xaynet-sdk/src/lib.rs
@@ -44,7 +44,7 @@
 //!
 //! A simple agent can be implemented as a function.
 //!
-//! ```rust
+//! ```
 //! use std::time::Duration;
 //!
 //! use tokio::time::sleep;
@@ -71,42 +71,46 @@
 //! This agent needs to be fed a [`StateMachine`] in order to run. A
 //! state machine requires found components:
 //!
-//! - PET settings: a cryptographic key identifying the participant and a
-//!   masking configuration. This is provided by [`settings::PetSettings`]
+//! - a cryptographic key identifying the participant, see [`PetSettings`]
 //! - a store from which it can load a model when the participant is
-//!   selected for the updat etask. This can be any type that
+//!   selected for the update task. This can be any type that
 //!   implements the [`ModelStore`] trait. In our case, we'll use a
 //!   dummy in-memory store that always returns the same model.
 //! - a client to talk with the Xaynet coordinator. This can be any
-//!   type that implements the [`XaynetClient`] trait. For this we're
-//!   going to use the [`Client`] that is available when compiling
-//!   with `--features reqwest-client`.
+//!   type that implements the [`XaynetClient`] trait, like the [`Client`].
+//!   For this we're going to use the trait implementations on the `reqwest`
+//!   client that is available when compiling with `--features reqwest-client`.
 //! - a notifier that the state machine can use to send
 //!   notifications. This can be any type that implements the
 //!   [`Notify`] trait. We'll use channels for this.
 //!
+//! [`PetSettings`]: crate::settings::PetSettings
 //! [`Client`]: crate::client::Client
 //!
 //! Finally we can start our agent and log the events it emits. Here
 //! is the full code:
 //!
-//! ```rust,ignore
+//! ```no_run
+//! # #[cfg(feature = "reqwest-client")]
+//! # mod feature_reqwest_client {
 //! use std::{
 //!     sync::{mpsc, Arc},
 //!     time::Duration,
 //! };
 //!
 //! use async_trait::async_trait;
+//! use reqwest::Client as ReqwestClient;
 //! use tokio::time::sleep;
+//!
 //! use xaynet_core::{
 //!     crypto::SigningKeyPair,
 //!     mask::{BoundType, DataType, FromPrimitives, GroupType, MaskConfig, Model, ModelType},
 //! };
 //! use xaynet_sdk::{
 //!     client::Client,
+//!     settings::PetSettings,
 //!     ModelStore,
 //!     Notify,
-//!     settings::PetSettings,
 //!     StateMachine,
 //!     TransitionOutcome,
 //! };
@@ -136,23 +140,29 @@
 //!     // event sent by the state machine when the participant
 //!     // becomes inactive (after finishing a task for instance)
 //!     Idle,
+//!     // event sent by the state machine when the participant
+//!     // is supposed to populate the model store
+//!     LoadModel,
 //! }
 //!
 //! // Our notifier is a simple wrapper around a channel.
 //! struct Notifier(mpsc::Sender<Event>);
 //!
 //! impl Notify for Notifier {
-//!     fn notify_new_round(&mut self) {
+//!     fn new_round(&mut self) {
 //!         self.0.send(Event::NewRound).unwrap();
 //!     }
-//!     fn notify_sum(&mut self) {
+//!     fn sum(&mut self) {
 //!         self.0.send(Event::Sum).unwrap();
 //!     }
-//!     fn notify_update(&mut self) {
+//!     fn update(&mut self) {
 //!         self.0.send(Event::Update).unwrap();
 //!     }
-//!     fn notify_idle(&mut self) {
+//!     fn idle(&mut self) {
 //!         self.0.send(Event::Idle).unwrap();
+//!     }
+//!     fn load_model(&mut self) {
+//!         self.0.send(Event::LoadModel).unwrap();
 //!     }
 //! }
 //!
@@ -172,17 +182,11 @@
 //!     }
 //! }
 //!
-//! #[tokio::main]
+//! #[tokio::main(flavor = "current_thread")]
 //! async fn main() -> Result<(), std::convert::Infallible> {
-//!     let mask_config = MaskConfig {
-//!         group_type: GroupType::Prime,
-//!         data_type: DataType::F32,
-//!         bound_type: BoundType::B0,
-//!         model_type: ModelType::M3,
-//!     };
 //!     let keys = SigningKeyPair::generate();
-//!     let settings = PetSettings::new(keys, mask_config);
-//!     let xaynet_client = Client::new("http://localhost:8081", None).unwrap();
+//!     let settings = PetSettings::new(keys);
+//!     let xaynet_client = Client::new(ReqwestClient::new(), "http://localhost:8081").unwrap();
 //!     let (tx, rx) = mpsc::channel::<Event>();
 //!     let notifier = Notifier(tx);
 //!     let model = Model::from_primitives(vec![0; 100].into_iter()).unwrap();
@@ -198,6 +202,8 @@
 //!         println!("{:?}", rx.recv().unwrap());
 //!     }
 //! }
+//! # }
+//! # fn main() {}
 //! ```
 
 pub mod client;

--- a/rust/xaynet-sdk/src/state_machine/io.rs
+++ b/rust/xaynet-sdk/src/state_machine/io.rs
@@ -38,9 +38,9 @@ type DynModel = Box<(dyn std::convert::AsRef<xaynet_core::mask::Model> + Send)>;
 /// Note that by having only one trait, we can also use dynamic dispatch and actually
 /// get rid of all the generic parameters in the state machine.
 ///
-/// ```ignore
+/// ```compile_fail
 /// Box<dyn IO> // allowed
-/// Box<dyn ModelStore + Notify + XaynetClient // not allowed
+/// Box<dyn ModelStore + Notify + XaynetClient> // not allowed
 /// ```
 #[cfg_attr(test, mockall::automock(type Model=DynModel;))]
 #[async_trait]

--- a/rust/xaynet-sdk/src/state_machine/phase.rs
+++ b/rust/xaynet-sdk/src/state_machine/phase.rs
@@ -296,7 +296,7 @@ pub enum RoundFreshness {
 ///
 /// We cannot serialize the state directly, even though it implements `Serialize`, because deserializing it would require knowing its type in advance:
 ///
-/// ```ignore
+/// ```compile_fail
 /// // `buf` is a Vec<u8> that contains a serialized state that we want to deserialize
 /// let state: State<???> = State::deserialize(&buf[..]).unwrap();
 /// ```

--- a/rust/xaynet-server/src/metrics/mod.rs
+++ b/rust/xaynet-server/src/metrics/mod.rs
@@ -32,7 +32,7 @@ impl GlobalRecorder {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```compile_fail
 /// // An event with just a title:
 /// event!("Error");
 ///
@@ -69,7 +69,7 @@ macro_rules! event {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```compile_fail
 /// // A basic metric:
 /// metric!(Measurement::RoundTotalNumber, 1);
 ///

--- a/rust/xaynet-server/src/metrics/recorders/influxdb/dispatcher.rs
+++ b/rust/xaynet-server/src/metrics/recorders/influxdb/dispatcher.rs
@@ -79,6 +79,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     async fn integration_dispatch_metric() {
         let settings = influx_settings();
         let mut task = Spawn::new(Dispatcher::new(settings.url, settings.db));
@@ -90,6 +91,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     async fn integration_dispatch_event() {
         let settings = influx_settings();
         let mut task = Spawn::new(Dispatcher::new(settings.url, settings.db));
@@ -101,6 +103,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     async fn integration_wrong_url() {
         let settings = influx_settings();
         let mut task = Spawn::new(Dispatcher::new("http://127.0.0.1:9998", settings.db));

--- a/rust/xaynet-server/src/state_machine/tests/initializer.rs
+++ b/rust/xaynet-server/src/state_machine/tests/initializer.rs
@@ -25,6 +25,7 @@ use crate::{
 #[cfg(feature = "model-persistence")]
 #[tokio::test]
 #[serial]
+#[ignore]
 async fn integration_state_machine_initializer_no_restore() {
     let store = init_store().await;
     let smi = StateMachineInitializer::new(
@@ -58,6 +59,7 @@ async fn integration_state_machine_initializer_no_restore() {
 #[cfg(feature = "model-persistence")]
 #[tokio::test]
 #[serial]
+#[ignore]
 async fn integration_state_machine_initializer_no_state() {
     let store = init_store().await;
     let smi = StateMachineInitializer::new(
@@ -91,6 +93,7 @@ async fn integration_state_machine_initializer_no_state() {
 #[cfg(feature = "model-persistence")]
 #[tokio::test]
 #[serial]
+#[ignore]
 async fn integration_state_machine_initializer_without_global_model() {
     let pet_settings = pet_settings();
     let mask_settings = mask_settings();
@@ -137,6 +140,7 @@ async fn integration_state_machine_initializer_without_global_model() {
 #[cfg(feature = "model-persistence")]
 #[tokio::test]
 #[serial]
+#[ignore]
 async fn integration_state_machine_initializer_with_global_model() {
     let pet_settings = pet_settings();
     let mask_settings = mask_settings();
@@ -196,6 +200,7 @@ async fn integration_state_machine_initializer_with_global_model() {
 #[cfg(feature = "model-persistence")]
 #[tokio::test]
 #[serial]
+#[ignore]
 async fn integration_state_machine_initializer_failed_because_of_wrong_size() {
     let pet_settings = pet_settings();
     let mask_settings = mask_settings();
@@ -241,6 +246,7 @@ async fn integration_state_machine_initializer_failed_because_of_wrong_size() {
 #[cfg(feature = "model-persistence")]
 #[tokio::test]
 #[serial]
+#[ignore]
 async fn integration_state_machine_initializer_failed_to_find_global_model() {
     let pet_settings = pet_settings();
     let mask_settings = mask_settings();
@@ -277,6 +283,7 @@ async fn integration_state_machine_initializer_failed_to_find_global_model() {
 
 #[tokio::test]
 #[serial]
+#[ignore]
 async fn integration_state_machine_initializer_reset_state() {
     let pet_settings = pet_settings();
     let mask_settings = mask_settings();

--- a/rust/xaynet-server/src/storage/coordinator_storage/redis/impls.rs
+++ b/rust/xaynet-server/src/storage/coordinator_storage/redis/impls.rs
@@ -50,7 +50,7 @@ fn error_code_type_error(response: &Value) -> RedisError {
 ///
 /// Example:
 ///
-/// ```ignore
+/// ```compile_fail
 /// let sum_pks: Vec<PublicSigningKeyRead> = self.connection.hkeys("sum_dict").await?;
 /// for sum_pk in sum_pks {
 ///    let sum_pk_seed_dict: HashMap<PublicSigningKeyRead, EncryptedMaskSeedRead>

--- a/rust/xaynet-server/src/storage/coordinator_storage/redis/mod.rs
+++ b/rust/xaynet-server/src/storage/coordinator_storage/redis/mod.rs
@@ -567,6 +567,7 @@ pub(in crate) mod tests {
 
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn integration_set_and_get_coordinator_state() {
         // test the writing and reading of the coordinator state
         let mut client = init_client().await;
@@ -581,6 +582,7 @@ pub(in crate) mod tests {
 
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn integration_get_coordinator_empty() {
         // test the reading of a non existing coordinator state
         let mut client = init_client().await;
@@ -592,6 +594,7 @@ pub(in crate) mod tests {
 
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn integration_incr_mask_score() {
         // test the increment of the mask counter
         let mut client = init_client().await;
@@ -616,6 +619,7 @@ pub(in crate) mod tests {
 
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn integration_get_incr_mask_count_unknown_sum_pk() {
         // test the writing and reading of one mask
         let mut client = init_client().await;
@@ -635,6 +639,7 @@ pub(in crate) mod tests {
 
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn integration_get_incr_mask_score_sum_pk_already_submitted() {
         // test the writing and reading of one mask
         let mut client = init_client().await;
@@ -658,6 +663,7 @@ pub(in crate) mod tests {
 
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn integration_get_best_masks_only_one_mask() {
         // test the writing and reading of one mask
         let mut client = init_client().await;
@@ -680,6 +686,7 @@ pub(in crate) mod tests {
 
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn integration_get_best_masks_two_masks() {
         // test the writing and reading of two masks
         // the first mask is incremented twice
@@ -716,6 +723,7 @@ pub(in crate) mod tests {
 
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn integration_get_best_masks_no_mask() {
         // ensure that get_best_masks returns an empty vec if no mask exist
         let mut client = init_client().await;
@@ -726,6 +734,7 @@ pub(in crate) mod tests {
 
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn integration_get_number_of_unique_masks_empty() {
         // ensure that get_best_masks returns an empty vec if no mask exist
         let mut client = init_client().await;
@@ -736,6 +745,7 @@ pub(in crate) mod tests {
 
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn integration_get_number_of_unique_masks() {
         // ensure that get_best_masks returns an empty vec if no mask exist
         let mut client = init_client().await;
@@ -756,6 +766,7 @@ pub(in crate) mod tests {
 
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn integration_sum_dict() {
         // test multiple sum dict related methods
         let mut client = init_client().await;
@@ -811,6 +822,7 @@ pub(in crate) mod tests {
 
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn integration_seed_dict() {
         let mut client = init_client().await;
 
@@ -829,6 +841,7 @@ pub(in crate) mod tests {
 
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn integration_seed_dict_len_mis_match() {
         let mut client = init_client().await;
 
@@ -849,6 +862,7 @@ pub(in crate) mod tests {
 
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn integration_seed_dict_unknown_sum_participant() {
         let mut client = init_client().await;
 
@@ -871,6 +885,7 @@ pub(in crate) mod tests {
 
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn integration_seed_dict_update_pk_already_submitted() {
         let mut client = init_client().await;
         let sum_pks = create_and_add_sum_participant_entries(&mut client, 2).await;
@@ -890,6 +905,7 @@ pub(in crate) mod tests {
 
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn integration_seed_dict_update_pk_already_exists_in_update_seed_dict() {
         let mut client = init_client().await;
         let sum_pks = create_and_add_sum_participant_entries(&mut client, 2).await;
@@ -917,6 +933,7 @@ pub(in crate) mod tests {
 
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn integration_seed_dict_get_seed_dict_for_sum_pk() {
         let mut client = init_client().await;
         let mut sum_pks = create_and_add_sum_participant_entries(&mut client, 2).await;
@@ -937,6 +954,7 @@ pub(in crate) mod tests {
 
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn integration_seed_dict_get_seed_dict_for_sum_pk_empty() {
         let mut client = init_client().await;
         let (sum_pk, _) = create_sum_participant_entry();
@@ -947,6 +965,7 @@ pub(in crate) mod tests {
 
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn integration_flush_dicts() {
         let mut client = init_client().await;
 
@@ -996,6 +1015,7 @@ pub(in crate) mod tests {
 
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn integration_flush_coordinator_data() {
         let mut client = init_client().await;
 
@@ -1029,6 +1049,7 @@ pub(in crate) mod tests {
 
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn integration_set_and_get_latest_global_model_id() {
         // test the writing and reading of the global model id
         let mut client = init_client().await;
@@ -1043,6 +1064,7 @@ pub(in crate) mod tests {
 
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn integration_is_ready_ok() {
         // test is_ready command
         let mut client = init_client().await;
@@ -1053,6 +1075,7 @@ pub(in crate) mod tests {
 
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn integration_get_latest_global_model_id_empty() {
         // test the reading of a non existing global model id
         let mut client = init_client().await;

--- a/rust/xaynet-server/src/storage/model_storage/s3.rs
+++ b/rust/xaynet-server/src/storage/model_storage/s3.rs
@@ -395,6 +395,7 @@ pub(in crate) mod tests {
 
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn integration_test_set_and_get_global_model() {
         let mut client = init_client().await;
 
@@ -410,6 +411,7 @@ pub(in crate) mod tests {
 
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn integration_test_get_global_model_non_existent() {
         let mut client = init_client().await;
 
@@ -420,6 +422,7 @@ pub(in crate) mod tests {
 
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn integration_test_global_model_already_exists() {
         let mut client = init_client().await;
 
@@ -446,6 +449,7 @@ pub(in crate) mod tests {
 
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn integration_test_is_ready_ok() {
         let mut client = init_client().await;
 
@@ -455,6 +459,7 @@ pub(in crate) mod tests {
 
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn integration_test_is_ready_ok_no_such_bucket() {
         // test that is_ready returns Ok even if the bucket doesn't exist
         let mut client = init_client().await;
@@ -469,6 +474,7 @@ pub(in crate) mod tests {
 
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn integration_test_is_ready_err() {
         let mut client = init_disconnected_client().await;
 


### PR DESCRIPTION
**Summary**

- disable integration tests by default, enable them on the ci (opt-in instead of opt-out)
- fix doc tests

currently the integration tests fail by default, meaning that they fail if the required resources are not available. i made an attempt to disable them by default such that tests can be run locally without false negatives and changed the ci to run all of them.

unfortunately the `#[ignore]` for tests is binary, having configurable flags would be nice (could be done with feature flags, but this would pollute the features namespace on the other hand). anyways, ignored tests can be run locally or on the ci with `cargo test -- --ignored` or all tests can be run with `cargo test -- -Z unstable-options --include-ignored` (the latter is only marked unstable because it doesn't work with `cargo test --benches` but we have a separate benchmarks job anyways, other that that it is obviously using the stable compiler).
