### PR TITLE
fix rustfmt deprecation

### DIFF
--- a/rust/rustfmt.toml
+++ b/rust/rustfmt.toml
@@ -1,4 +1,4 @@
-# requires unstable rustfmt until the options are stabilized
+# requires nightly rustfmt until the options are stabilized
 format_code_in_doc_comments = true
+imports_granularity = "Crate"
 imports_layout = "HorizontalVertical"
-merge_imports = true


### PR DESCRIPTION
**Summary**

`rustfmt` throws a deprecation warning in the latest `nightly` which we run on the ci:
```
Warning: the `merge_imports` option is deprecated. Use `imports_granularity=Crate` instead
```

this pr replaces the deprecated option with the new one. obviously, the new option is not known to older `rustfmt` version, hence everyone must update it locally after this pr, which can be done by:
```
rustup update nightly
rustup toolchain install nightly-2021-01-31
rustup toolchain uninstall nightly-2021-01-31
```
then `rustfmt` can be run as usual via `cargo +nightly fmt`.

the last uninstall is optional and just for toolchain cleanup. we have to install a fixed nightly version (same version as the ci uses), because `rustfmt` is not always available on the nightly channel ([see availability](https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu.html)). nevertheless, the nightly components stay updated even if one of the nightly toolchains get removed.
