### PR TITLE
update hyper and nb-connect

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1388,9 +1388,9 @@ checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "hyper"
-version = "0.14.2"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12219dc884514cb4a6a03737f4413c0e01c23a1b059b0156004b23f1e19dccbe"
+checksum = "e8e946c2b1349055e0b72ae281b238baf1a3ea7307c7e9f9d64673bdd9c26ac7"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1803,12 +1803,12 @@ dependencies = [
 
 [[package]]
 name = "nb-connect"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8123a81538e457d44b933a02faf885d3fe8408806b23fa700e8f01c6c3a98998"
+checksum = "670361df1bc2399ee1ff50406a0d422587dd3bb0da596e1978fe8e05dabddf4f"
 dependencies = [
  "libc",
- "winapi",
+ "socket2",
 ]
 
 [[package]]


### PR DESCRIPTION
updates sub dependencies via `cargo update -p nb-connect -p hyper`
main reason for this pr is to update `hyper` and `nb-connect`

```
Crate:         hyper
Version:       0.14.2
Title:         Multiple Transfer-Encoding headers misinterprets request payload
Date:          2021-02-05
ID:            RUSTSEC-2021-0020
URL:           https://rustsec.org/advisories/RUSTSEC-2021-0020
Solution:      Upgrade to >=0.14.3 OR >=0.13.10, <0.14.0
Dependency tree: 
hyper 0.14.2
├── warp 0.3.0
│   └── xaynet-server 0.2.0
│       └── xaynet 0.11.0
├── rusoto_signature 0.46.0
│   └── rusoto_core 0.46.0
│       ├── xaynet-server 0.2.0
│       └── rusoto_s3 0.46.0
│           └── xaynet-server 0.2.0
├── rusoto_credential 0.46.0
│   ├── rusoto_signature 0.46.0
│   └── rusoto_core 0.46.0
├── rusoto_core 0.46.0
├── reqwest 0.11.0
│   ├── xaynet-sdk 0.1.0
│   │   ├── xaynet-mobile 0.1.0
│   │   │   └── xaynet 0.11.0
│   │   ├── xaynet 0.11.0
│   │   └── examples 0.0.0
│   ├── xaynet-mobile 0.1.0
│   └── examples 0.0.0
├── hyper-tls 0.5.0
│   └── rusoto_core 0.46.0
└── hyper-rustls 0.22.1
    └── reqwest 0.11.0

Crate:         nb-connect
Version:       1.0.2
Warning:       yanked
Dependency tree: 
nb-connect 1.0.2
└── async-io 1.3.1
    ├── async-std 1.9.0
    │   ├── surf 2.1.0
    │   │   └── influxdb 0.3.0
    │   │       └── xaynet-server 0.2.0
    │   │           └── xaynet 0.11.0
    │   ├── http-types 2.10.0
    │   │   ├── surf 2.1.0
    │   │   ├── http-client 6.2.0
    │   │   │   └── surf 2.1.0
    │   │   └── async-h1 2.3.0
    │   │       └── http-client 6.2.0
    │   ├── http-client 6.2.0
    │   ├── async-native-tls 0.3.3
    │   │   └── http-client 6.2.0
    │   └── async-h1 2.3.0
    └── async-global-executor 2.0.2
        └── async-std 1.9.0
```

[CI job](https://github.com/xaynetwork/xaynet/runs/1901646899?check_suite_focus=true)