### PR TITLE
implement read and get methods + refactor

### DIFF
--- a/rust/xaynet-analytics/src/controller.rs
+++ b/rust/xaynet-analytics/src/controller.rs
@@ -115,10 +115,11 @@ impl AnalyticsController {
     }
 
     fn get_last_time_data_sent(db: &IsarDb) -> Result<Option<DateTime<Utc>>, Error> {
-        match ControllerData::get_all(db, &CollectionNames::CONTROLLER_DATA)?.last() {
-            Some(data) => Ok(Some(data.time_data_sent)),
-            None => Ok(None),
-        }
+        Ok(
+            ControllerData::get_all(db, &CollectionNames::CONTROLLER_DATA)?
+                .last()
+                .map(|data| data.time_data_sent),
+        )
     }
 
     // TODO: review and debug this method during https://xainag.atlassian.net/browse/XN-1560

--- a/rust/xaynet-analytics/src/controller.rs
+++ b/rust/xaynet-analytics/src/controller.rs
@@ -28,7 +28,7 @@ struct AnalyticsController {
 
 // TODO: remove allow dead code when AnalyticsController is integrated with FFI layer: https://xainag.atlassian.net/browse/XN-1415
 #[allow(dead_code)]
-impl<'ctrl> AnalyticsController {
+impl AnalyticsController {
     const SEND_DATA_FREQUENCY_HOURS: i64 = 24;
 
     pub fn init(
@@ -66,12 +66,9 @@ impl<'ctrl> AnalyticsController {
         event_type: AnalyticsEventType,
         option_screen_route_name: Option<&str>,
     ) -> Result<(), Error> {
-        let option_screen_route = if let Some(screen_route_name) = option_screen_route_name {
-            let screen_route = self.add_screen_route_if_new(screen_route_name)?;
-            Some(screen_route)
-        } else {
-            None
-        };
+        let option_screen_route = option_screen_route_name
+            .map(|screen_route_name| self.add_screen_route_if_new(screen_route_name))
+            .transpose()?;
 
         let event = AnalyticsEvent::new(
             name.to_string(),
@@ -105,10 +102,10 @@ impl<'ctrl> AnalyticsController {
         let existing_screen_routes =
             ScreenRoute::get_all(&self.db, &CollectionNames::SCREEN_ROUTES)?;
         if let Some(existing_screen_route) = existing_screen_routes
-            .iter()
+            .into_iter()
             .find(|existing_route| existing_route.name == screen_route_name)
         {
-            Ok(existing_screen_route.clone())
+            Ok(existing_screen_route)
         } else {
             let screen_route = ScreenRoute::new(screen_route_name, Utc::now());
             let screen_route_clone = screen_route.clone();

--- a/rust/xaynet-analytics/src/controller.rs
+++ b/rust/xaynet-analytics/src/controller.rs
@@ -4,23 +4,23 @@ use chrono::{DateTime, Datelike, Duration, NaiveDate, Utc};
 use crate::{
     data_combination::data_combiner::DataCombiner,
     database::{
-        analytics_event::{data_model::AnalyticsEvent, repo::AnalyticsEventRepo},
-        common::{IsarAdapter, Repo, SchemaGenerator},
-        controller_data::{data_model::ControllerData, repo::ControllerDataRepo},
+        analytics_event::{
+            adapter::AnalyticsEventAdapter,
+            data_model::{AnalyticsEvent, AnalyticsEventType},
+        },
+        common::{CollectionNames, Repo, SchemaGenerator},
+        controller_data::{adapter::ControllerDataAdapter, data_model::ControllerData},
         isar::IsarDb,
-        screen_route::{data_model::ScreenRoute, repo::ScreenRouteRepo},
+        screen_route::{adapter::ScreenRouteAdapter, data_model::ScreenRoute},
     },
     sender::Sender,
 };
 
-struct AnalyticsController<'ctrl> {
+struct AnalyticsController {
     db: IsarDb,
     is_charging: bool,
     is_connected_to_wifi: bool,
     last_time_data_sent: Option<DateTime<Utc>>,
-    analytics_event_repo: AnalyticsEventRepo<'ctrl>,
-    controller_data_repo: ControllerDataRepo<'ctrl>,
-    screen_route_repo: ScreenRouteRepo<'ctrl>,
     combiner: DataCombiner,
     sender: Sender,
     send_data_frequency: Duration,
@@ -28,10 +28,7 @@ struct AnalyticsController<'ctrl> {
 
 // TODO: remove allow dead code when AnalyticsController is integrated with FFI layer: https://xainag.atlassian.net/browse/XN-1415
 #[allow(dead_code)]
-impl<'ctrl> AnalyticsController<'ctrl> {
-    const ANALYTICS_EVENT_COLLECTION_NAME: &'ctrl str = "analytics_events";
-    const CONTROLLER_DATA_COLLECTION_NAME: &'ctrl str = "controller_data";
-    const SCREEN_ROUTE_COLLECTION_NAME: &'ctrl str = "screen_routes";
+impl<'ctrl> AnalyticsController {
     const SEND_DATA_FREQUENCY_HOURS: i64 = 24;
 
     pub fn init(
@@ -39,16 +36,13 @@ impl<'ctrl> AnalyticsController<'ctrl> {
         is_charging: bool,
         is_connected_to_wifi: bool,
     ) -> Result<Self, Error> {
-        let analytics_event_repo = AnalyticsEventRepo::new(Self::ANALYTICS_EVENT_COLLECTION_NAME);
-        let controller_data_repo = ControllerDataRepo::new(Self::CONTROLLER_DATA_COLLECTION_NAME);
-        let screen_route_repo = ScreenRouteRepo::new(Self::SCREEN_ROUTE_COLLECTION_NAME);
         let schemas = vec![
-            AnalyticsEvent::get_schema(Self::ANALYTICS_EVENT_COLLECTION_NAME)?,
-            ControllerData::get_schema(Self::CONTROLLER_DATA_COLLECTION_NAME)?,
-            ScreenRoute::get_schema(Self::SCREEN_ROUTE_COLLECTION_NAME)?,
+            AnalyticsEventAdapter::get_schema(&CollectionNames::ANALYTICS_EVENTS)?,
+            ControllerDataAdapter::get_schema(&CollectionNames::CONTROLLER_DATA)?,
+            ScreenRouteAdapter::get_schema(&CollectionNames::SCREEN_ROUTES)?,
         ];
         let db = IsarDb::new(&path, schemas)?;
-        let last_time_data_sent = Self::get_last_time_data_sent(&controller_data_repo, &db)?;
+        let last_time_data_sent = Self::get_last_time_data_sent(&db)?;
         let combiner = DataCombiner;
         let sender = Sender;
         Ok(AnalyticsController {
@@ -56,9 +50,6 @@ impl<'ctrl> AnalyticsController<'ctrl> {
             is_charging,
             is_connected_to_wifi,
             last_time_data_sent,
-            analytics_event_repo,
-            controller_data_repo,
-            screen_route_repo,
             combiner,
             sender,
             send_data_frequency: Duration::hours(Self::SEND_DATA_FREQUENCY_HOURS),
@@ -69,10 +60,27 @@ impl<'ctrl> AnalyticsController<'ctrl> {
         self.db.dispose()
     }
 
-    pub fn save_analytics_event(&self, event_bytes: &[u8]) -> Result<(), Error> {
-        let event = AnalyticsEvent::read(event_bytes);
-        self.check_for_new_screen_route(&event)?;
-        self.analytics_event_repo.add(&event, &self.db)
+    pub fn save_analytics_event(
+        &self,
+        name: &str,
+        event_type: AnalyticsEventType,
+        option_screen_route_name: Option<&str>,
+    ) -> Result<(), Error> {
+        let option_screen_route = if let Some(screen_route_name) = option_screen_route_name {
+            let screen_route = self.add_screen_route_if_new(screen_route_name)?;
+            Some(screen_route)
+        } else {
+            None
+        };
+
+        let event = AnalyticsEvent::new(
+            name.to_string(),
+            event_type,
+            Utc::now(),
+            option_screen_route,
+        );
+        event.add(&self.db, &CollectionNames::ANALYTICS_EVENTS)?;
+        Ok(())
     }
 
     pub fn change_connectivity_status(&mut self) {
@@ -84,48 +92,36 @@ impl<'ctrl> AnalyticsController<'ctrl> {
     }
 
     pub fn maybe_send_data(&mut self) -> Result<(), Error> {
-        if self.should_send_data() {
+        let can_send_data = self.is_charging && self.is_connected_to_wifi;
+        let should_send_data = can_send_data && !self.did_send_already_in_this_period();
+        if should_send_data {
             self.send_data()
         } else {
             Ok(())
         }
     }
 
-    fn check_for_new_screen_route(&self, event: &AnalyticsEvent) -> Result<(), Error> {
-        match event.screen_route {
-            Some(screen_route) => self.add_screen_route_if_new(screen_route),
-            None => Ok(()),
-        }
-    }
-
-    fn add_screen_route_if_new(&self, screen_route: &ScreenRoute) -> Result<(), Error> {
-        if !self
-            .screen_route_repo
-            .get_all(&self.db)?
-            .contains(screen_route)
+    fn add_screen_route_if_new(&self, screen_route_name: &str) -> Result<ScreenRoute, Error> {
+        let existing_screen_routes =
+            ScreenRoute::get_all(&self.db, &CollectionNames::SCREEN_ROUTES)?;
+        if let Some(existing_screen_route) = existing_screen_routes
+            .iter()
+            .find(|existing_route| existing_route.name == screen_route_name)
         {
-            self.screen_route_repo.add(screen_route, &self.db)
+            Ok(existing_screen_route.clone())
         } else {
-            Ok(())
+            let screen_route = ScreenRoute::new(screen_route_name, Utc::now());
+            let screen_route_clone = screen_route.clone();
+            screen_route.add(&self.db, &CollectionNames::SCREEN_ROUTES)?;
+            Ok(screen_route_clone)
         }
     }
 
-    fn get_last_time_data_sent(
-        repo: &ControllerDataRepo,
-        db: &IsarDb,
-    ) -> Result<Option<DateTime<Utc>>, Error> {
-        match repo.get_all(db)?.last() {
+    fn get_last_time_data_sent(db: &IsarDb) -> Result<Option<DateTime<Utc>>, Error> {
+        match ControllerData::get_all(db, &CollectionNames::CONTROLLER_DATA)?.last() {
             Some(data) => Ok(Some(data.time_data_sent)),
             None => Ok(None),
         }
-    }
-
-    fn should_send_data(&self) -> bool {
-        self.can_send_data() && !self.did_send_already_in_this_period()
-    }
-
-    fn can_send_data(&self) -> bool {
-        self.is_charging && self.is_connected_to_wifi
     }
 
     // TODO: review and debug this method during https://xainag.atlassian.net/browse/XN-1560
@@ -143,14 +139,13 @@ impl<'ctrl> AnalyticsController<'ctrl> {
     }
 
     fn send_data(&mut self) -> Result<(), Error> {
-        let events = self.analytics_event_repo.get_all(&self.db)?;
-        let screen_routes = self.screen_route_repo.get_all(&self.db)?;
+        let events = AnalyticsEvent::get_all(&self.db, &CollectionNames::ANALYTICS_EVENTS)?;
+        let screen_routes = ScreenRoute::get_all(&self.db, &CollectionNames::SCREEN_ROUTES)?;
         let time_data_sent = Utc::now();
         self.sender
             .send(self.combiner.init_data_points(&events, &screen_routes)?)
             .and_then(|_| {
-                self.controller_data_repo
-                    .add(&ControllerData::new(time_data_sent), &self.db)
+                ControllerData::new(time_data_sent).add(&self.db, &CollectionNames::CONTROLLER_DATA)
             })
             .map(|_| self.last_time_data_sent = Some(time_data_sent))
     }

--- a/rust/xaynet-analytics/src/data_combination/data_combiner.rs
+++ b/rust/xaynet-analytics/src/data_combination/data_combiner.rs
@@ -196,13 +196,7 @@ impl<'screen> DataCombiner {
     ) -> Vec<AnalyticsEvent> {
         all_events
             .iter()
-            .filter(|event| {
-                event
-                    .screen_route
-                    .as_ref()
-                    .map(|screen_route| screen_route == route)
-                    .unwrap_or(false)
-            })
+            .filter(|event| event.screen_route.as_ref() == Some(route))
             .cloned()
             .collect()
     }

--- a/rust/xaynet-analytics/src/data_combination/data_combiner.rs
+++ b/rust/xaynet-analytics/src/data_combination/data_combiner.rs
@@ -197,11 +197,11 @@ impl<'screen> DataCombiner {
         all_events
             .iter()
             .filter(|event| {
-                if let Some(screen_route) = &event.screen_route {
-                    screen_route == route
-                } else {
-                    false
-                }
+                event
+                    .screen_route
+                    .as_ref()
+                    .map(|screen_route| screen_route == route)
+                    .unwrap_or(false)
             })
             .cloned()
             .collect()

--- a/rust/xaynet-analytics/src/data_combination/data_combiner.rs
+++ b/rust/xaynet-analytics/src/data_combination/data_combiner.rs
@@ -24,9 +24,9 @@ pub struct DataCombiner;
 impl<'screen> DataCombiner {
     pub fn init_data_points(
         &self,
-        events: &[AnalyticsEvent<'screen>],
+        events: &[AnalyticsEvent],
         screen_routes: &[ScreenRoute],
-    ) -> Result<Vec<DataPoint<'screen>>, Error> {
+    ) -> Result<Vec<DataPoint>, Error> {
         let end_period = Utc::now();
 
         let one_day_period_metadata =
@@ -67,9 +67,9 @@ impl<'screen> DataCombiner {
 
     fn init_screen_active_time_vars(
         metadata: DataPointMetadata,
-        events: &[AnalyticsEvent<'screen>],
+        events: &[AnalyticsEvent],
         screen_routes: &[ScreenRoute],
-    ) -> Vec<DataPoint<'screen>> {
+    ) -> Vec<DataPoint> {
         let mut screen_active_time_vars: Vec<DataPoint> = screen_routes
             .iter()
             .map(|route| {
@@ -90,9 +90,9 @@ impl<'screen> DataCombiner {
 
     fn init_screen_enter_count_vars(
         metadata: DataPointMetadata,
-        events: &[AnalyticsEvent<'screen>],
+        events: &[AnalyticsEvent],
         screen_routes: &[ScreenRoute],
-    ) -> Vec<DataPoint<'screen>> {
+    ) -> Vec<DataPoint> {
         screen_routes
             .iter()
             .map(|route| {
@@ -108,8 +108,8 @@ impl<'screen> DataCombiner {
 
     fn init_was_active_each_past_period_vars(
         metadatas: Vec<DataPointMetadata>,
-        events: &[AnalyticsEvent<'screen>],
-    ) -> Vec<DataPoint<'screen>> {
+        events: &[AnalyticsEvent],
+    ) -> Vec<DataPoint> {
         metadatas
             .iter()
             .map(|metadata| {
@@ -128,8 +128,8 @@ impl<'screen> DataCombiner {
 
     fn init_was_active_past_n_days_vars(
         metadatas: Vec<DataPointMetadata>,
-        events: &[AnalyticsEvent<'screen>],
-    ) -> Vec<DataPoint<'screen>> {
+        events: &[AnalyticsEvent],
+    ) -> Vec<DataPoint> {
         metadatas
             .iter()
             .map(|metadata| {
@@ -145,8 +145,8 @@ impl<'screen> DataCombiner {
     // TODO: return an iterator instead of Vec: https://xainag.atlassian.net/browse/XN-1517
     fn filter_events_in_this_period(
         metadata: DataPointMetadata,
-        events: &[AnalyticsEvent<'screen>],
-    ) -> Vec<AnalyticsEvent<'screen>> {
+        events: &[AnalyticsEvent],
+    ) -> Vec<AnalyticsEvent> {
         let start_of_period = Self::get_start_of_period(metadata, None);
         Self::filter_events_before_end_of_period(metadata.end, events)
             .iter()
@@ -179,8 +179,8 @@ impl<'screen> DataCombiner {
     // TODO: return an iterator instead of Vec: https://xainag.atlassian.net/browse/XN-1517
     fn filter_events_before_end_of_period(
         end_of_period: DateTime<Utc>,
-        events: &[AnalyticsEvent<'screen>],
-    ) -> Vec<AnalyticsEvent<'screen>> {
+        events: &[AnalyticsEvent],
+    ) -> Vec<AnalyticsEvent> {
         let midnight_end_of_period = get_midnight(end_of_period);
         events
             .iter()
@@ -192,12 +192,12 @@ impl<'screen> DataCombiner {
     // TODO: return an iterator instead of Vec: https://xainag.atlassian.net/browse/XN-1517
     fn get_events_single_route(
         route: &ScreenRoute,
-        all_events: &[AnalyticsEvent<'screen>],
-    ) -> Vec<AnalyticsEvent<'screen>> {
+        all_events: &[AnalyticsEvent],
+    ) -> Vec<AnalyticsEvent> {
         all_events
             .iter()
             .filter(|event| {
-                if let Some(screen_route) = event.screen_route {
+                if let Some(screen_route) = &event.screen_route {
                     screen_route == route
                 } else {
                     false
@@ -250,7 +250,7 @@ mod tests {
             "test1",
             AnalyticsEventType::ScreenEnter,
             end_period - Duration::hours(12),
-            Some(&screen_route),
+            Some(screen_route.clone()),
         );
         let all_events = vec![
             first_event.clone(),
@@ -265,11 +265,8 @@ mod tests {
             DataPoint::ScreenActiveTime(CalcScreenActiveTime::new(metadata, vec![first_event])),
             DataPoint::ScreenActiveTime(CalcScreenActiveTime::new(metadata, all_events.clone())),
         ];
-        let actual_output = DataCombiner::init_screen_active_time_vars(
-            metadata,
-            &all_events,
-            &[screen_route.clone()],
-        );
+        let actual_output =
+            DataCombiner::init_screen_active_time_vars(metadata, &all_events, &[screen_route]);
         assert_eq!(actual_output, expected_output);
     }
 
@@ -284,14 +281,14 @@ mod tests {
             "test1",
             AnalyticsEventType::ScreenEnter,
             end_period - Duration::hours(12),
-            Some(&screen_route),
+            Some(screen_route.clone()),
         )];
         let expected_output = vec![DataPoint::ScreenEnterCount(CalcScreenEnterCount::new(
             metadata,
             events.clone(),
         ))];
         let actual_output =
-            DataCombiner::init_screen_enter_count_vars(metadata, &events, &[screen_route.clone()]);
+            DataCombiner::init_screen_enter_count_vars(metadata, &events, &[screen_route]);
         assert_eq!(actual_output, expected_output);
     }
 
@@ -441,13 +438,13 @@ mod tests {
             "test1",
             AnalyticsEventType::AppEvent,
             timestamp,
-            Some(&home_route),
+            Some(home_route.clone()),
         );
         let other_route_event = AnalyticsEvent::new(
             "test2",
             AnalyticsEventType::ScreenEnter,
             timestamp,
-            Some(&other_route),
+            Some(other_route),
         );
         let all_events = [home_route_event.clone(), other_route_event];
         let expected_output = vec![home_route_event];

--- a/rust/xaynet-analytics/src/data_combination/data_points/data_point.rs
+++ b/rust/xaynet-analytics/src/data_combination/data_points/data_point.rs
@@ -40,16 +40,16 @@ pub trait CalculateDataPoints {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub enum DataPoint<'a> {
-    ScreenActiveTime(CalcScreenActiveTime<'a>),
-    ScreenEnterCount(CalcScreenEnterCount<'a>),
-    WasActiveEachPastPeriod(CalcWasActiveEachPastPeriod<'a>),
-    WasActivePastNDays(CalcWasActivePastNDays<'a>),
+pub enum DataPoint {
+    ScreenActiveTime(CalcScreenActiveTime),
+    ScreenEnterCount(CalcScreenEnterCount),
+    WasActiveEachPastPeriod(CalcWasActiveEachPastPeriod),
+    WasActivePastNDays(CalcWasActivePastNDays),
 }
 
 #[allow(dead_code)]
 // TODO: will be called when preparing the data to be sent to the coordinator
-impl<'a> DataPoint<'a> {
+impl DataPoint {
     fn calculate(&self) -> Vec<u32> {
         match self {
             DataPoint::ScreenActiveTime(data) => data.calculate(),
@@ -62,29 +62,29 @@ impl<'a> DataPoint<'a> {
 
 #[derive(Debug, PartialEq, Eq)]
 // TODO: accept an iterator instead of Vec: https://xainag.atlassian.net/browse/XN-1517
-pub struct CalcScreenActiveTime<'a> {
+pub struct CalcScreenActiveTime {
     pub metadata: DataPointMetadata,
-    pub events: Vec<AnalyticsEvent<'a>>,
+    pub events: Vec<AnalyticsEvent>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
 // TODO: accept an iterator instead of Vec: https://xainag.atlassian.net/browse/XN-1517
-pub struct CalcScreenEnterCount<'a> {
+pub struct CalcScreenEnterCount {
     pub metadata: DataPointMetadata,
-    pub events: Vec<AnalyticsEvent<'a>>,
+    pub events: Vec<AnalyticsEvent>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
 // TODO: accept an iterator instead of Vec: https://xainag.atlassian.net/browse/XN-1517
-pub struct CalcWasActiveEachPastPeriod<'a> {
+pub struct CalcWasActiveEachPastPeriod {
     pub metadata: DataPointMetadata,
-    pub events: Vec<AnalyticsEvent<'a>>,
+    pub events: Vec<AnalyticsEvent>,
     pub period_thresholds: Vec<DateTime<Utc>>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
 // TODO: accept an iterator instead of Vec: https://xainag.atlassian.net/browse/XN-1517
-pub struct CalcWasActivePastNDays<'a> {
+pub struct CalcWasActivePastNDays {
     pub metadata: DataPointMetadata,
-    pub events: Vec<AnalyticsEvent<'a>>,
+    pub events: Vec<AnalyticsEvent>,
 }

--- a/rust/xaynet-analytics/src/data_combination/data_points/screen_active_time.rs
+++ b/rust/xaynet-analytics/src/data_combination/data_points/screen_active_time.rs
@@ -9,8 +9,8 @@ use crate::{
     database::analytics_event::data_model::{AnalyticsEvent, AnalyticsEventType},
 };
 
-impl<'a> CalcScreenActiveTime<'a> {
-    pub fn new(metadata: DataPointMetadata, events: Vec<AnalyticsEvent<'a>>) -> Self {
+impl CalcScreenActiveTime {
+    pub fn new(metadata: DataPointMetadata, events: Vec<AnalyticsEvent>) -> Self {
         Self { metadata, events }
     }
 
@@ -29,7 +29,7 @@ impl<'a> CalcScreenActiveTime<'a> {
     }
 }
 
-impl<'a> CalculateDataPoints for CalcScreenActiveTime<'a> {
+impl CalculateDataPoints for CalcScreenActiveTime {
     fn metadata(&self) -> DataPointMetadata {
         self.metadata
     }
@@ -81,7 +81,7 @@ mod tests {
             "test1",
             AnalyticsEventType::ScreenEnter,
             end_period - Duration::hours(10),
-            Some(&screen_route),
+            Some(screen_route),
         );
         let app_event = AnalyticsEvent::new(
             "test1",
@@ -93,7 +93,7 @@ mod tests {
             screen_enter_event.clone(),
             AnalyticsEvent::new(
                 "test1",
-                AnalyticsEventType::Error,
+                AnalyticsEventType::AppError,
                 end_period - Duration::hours(11),
                 None,
             ),
@@ -129,7 +129,7 @@ mod tests {
             "test1",
             AnalyticsEventType::ScreenEnter,
             end_period - Duration::hours(12),
-            Some(&screen_route),
+            Some(screen_route),
         )];
         let screen_active_time = CalcScreenActiveTime::new(metadata, events);
         assert_eq!(screen_active_time.calculate(), vec![0]);
@@ -147,13 +147,13 @@ mod tests {
                 "test1",
                 AnalyticsEventType::ScreenEnter,
                 end_period - Duration::hours(12),
-                Some(&screen_route),
+                Some(screen_route.clone()),
             ),
             AnalyticsEvent::new(
                 "test2",
                 AnalyticsEventType::ScreenEnter,
                 end_period - Duration::hours(15),
-                Some(&screen_route),
+                Some(screen_route),
             ),
         ];
         let time_between_events =
@@ -176,7 +176,7 @@ mod tests {
             "test1",
             AnalyticsEventType::ScreenEnter,
             end_period - Duration::hours(12),
-            Some(&screen_route),
+            Some(screen_route.clone()),
         );
         let second = AnalyticsEvent::new(
             "test1",
@@ -188,13 +188,13 @@ mod tests {
             "test2",
             AnalyticsEventType::ScreenEnter,
             end_period - Duration::hours(14),
-            Some(&screen_route),
+            Some(screen_route.clone()),
         );
         let fourth = AnalyticsEvent::new(
             "test2",
             AnalyticsEventType::ScreenEnter,
             end_period - Duration::hours(14),
-            Some(&screen_route),
+            Some(screen_route),
         );
         let events = vec![first.clone(), second.clone(), third.clone(), fourth.clone()];
         let time_between_events =

--- a/rust/xaynet-analytics/src/data_combination/data_points/screen_enter_count.rs
+++ b/rust/xaynet-analytics/src/data_combination/data_points/screen_enter_count.rs
@@ -13,7 +13,7 @@ impl CalcScreenEnterCount {
     }
 }
 
-impl<'a> CalculateDataPoints for CalcScreenEnterCount {
+impl CalculateDataPoints for CalcScreenEnterCount {
     fn metadata(&self) -> DataPointMetadata {
         self.metadata
     }

--- a/rust/xaynet-analytics/src/data_combination/data_points/screen_enter_count.rs
+++ b/rust/xaynet-analytics/src/data_combination/data_points/screen_enter_count.rs
@@ -7,13 +7,13 @@ use crate::{
     database::analytics_event::data_model::{AnalyticsEvent, AnalyticsEventType},
 };
 
-impl<'a> CalcScreenEnterCount<'a> {
-    pub fn new(metadata: DataPointMetadata, events: Vec<AnalyticsEvent<'a>>) -> Self {
+impl CalcScreenEnterCount {
+    pub fn new(metadata: DataPointMetadata, events: Vec<AnalyticsEvent>) -> Self {
         Self { metadata, events }
     }
 }
 
-impl<'a> CalculateDataPoints for CalcScreenEnterCount<'a> {
+impl<'a> CalculateDataPoints for CalcScreenEnterCount {
     fn metadata(&self) -> DataPointMetadata {
         self.metadata
     }
@@ -56,7 +56,7 @@ mod tests {
             "test1",
             AnalyticsEventType::ScreenEnter,
             end_period - Duration::hours(12),
-            Some(&screen_route),
+            Some(screen_route),
         )];
         let screen_enter_count = CalcScreenEnterCount::new(metadata, events);
         assert_eq!(screen_enter_count.calculate(), vec![1]);
@@ -74,13 +74,13 @@ mod tests {
                 "test1",
                 AnalyticsEventType::ScreenEnter,
                 end_period - Duration::hours(9),
-                Some(&screen_route),
+                Some(screen_route.clone()),
             ),
             AnalyticsEvent::new(
                 "test2",
                 AnalyticsEventType::ScreenEnter,
                 end_period - Duration::hours(18),
-                Some(&screen_route),
+                Some(screen_route),
             ),
         ];
         let screen_enter_count = CalcScreenEnterCount::new(metadata, events);

--- a/rust/xaynet-analytics/src/data_combination/data_points/was_active_each_past_period.rs
+++ b/rust/xaynet-analytics/src/data_combination/data_points/was_active_each_past_period.rs
@@ -10,10 +10,10 @@ use crate::{
     database::analytics_event::data_model::AnalyticsEvent,
 };
 
-impl<'a> CalcWasActiveEachPastPeriod<'a> {
+impl CalcWasActiveEachPastPeriod {
     pub fn new(
         metadata: DataPointMetadata,
-        events: Vec<AnalyticsEvent<'a>>,
+        events: Vec<AnalyticsEvent>,
         period_thresholds: Vec<DateTime<Utc>>,
     ) -> Self {
         Self {
@@ -45,7 +45,7 @@ impl<'a> CalcWasActiveEachPastPeriod<'a> {
     }
 }
 
-impl<'a> CalculateDataPoints for CalcWasActiveEachPastPeriod<'a> {
+impl CalculateDataPoints for CalcWasActiveEachPastPeriod {
     fn metadata(&self) -> DataPointMetadata {
         self.metadata
     }
@@ -154,7 +154,7 @@ mod tests {
             ),
             AnalyticsEvent::new(
                 "test2",
-                AnalyticsEventType::Error,
+                AnalyticsEventType::AppError,
                 end_period - Duration::hours(15),
                 None,
             ),
@@ -184,7 +184,7 @@ mod tests {
             ),
             AnalyticsEvent::new(
                 "test2",
-                AnalyticsEventType::Error,
+                AnalyticsEventType::AppError,
                 end_period - Duration::hours(36),
                 None,
             ),

--- a/rust/xaynet-analytics/src/data_combination/data_points/was_active_past_n_days.rs
+++ b/rust/xaynet-analytics/src/data_combination/data_points/was_active_past_n_days.rs
@@ -7,13 +7,13 @@ use crate::{
     database::analytics_event::data_model::AnalyticsEvent,
 };
 
-impl<'a> CalcWasActivePastNDays<'a> {
-    pub fn new(metadata: DataPointMetadata, events: Vec<AnalyticsEvent<'a>>) -> Self {
+impl CalcWasActivePastNDays {
+    pub fn new(metadata: DataPointMetadata, events: Vec<AnalyticsEvent>) -> Self {
         Self { metadata, events }
     }
 }
 
-impl<'a> CalculateDataPoints for CalcWasActivePastNDays<'a> {
+impl CalculateDataPoints for CalcWasActivePastNDays {
     fn metadata(&self) -> DataPointMetadata {
         self.metadata
     }

--- a/rust/xaynet-analytics/src/database/analytics_event/adapter.rs
+++ b/rust/xaynet-analytics/src/database/analytics_event/adapter.rs
@@ -65,22 +65,22 @@ impl<'event> IsarAdapter<'event> for AnalyticsEventAdapter {
         isar_object: &'event IsarObject,
         isar_properties: &'event [(String, Property)],
     ) -> Result<AnalyticsEventAdapter, Error> {
-        let name_property = Self::find_property_by_name("name", isar_properties);
-        let eventy_type_property = Self::find_property_by_name("event_type", isar_properties);
-        let timestamp_property = Self::find_property_by_name("timestamp", isar_properties);
-        let screen_route_name_property =
-            Self::find_property_by_name("screen_route_field", isar_properties);
+        let name_property = Self::find_property_by_name("name", isar_properties)?;
+        let event_type_property = Self::find_property_by_name("event_type", isar_properties)?;
+        let timestamp_property = Self::find_property_by_name("timestamp", isar_properties)?;
+        let screen_route_field_property =
+            Self::find_property_by_name("screen_route_field", isar_properties)?;
 
         let name_field = isar_object
-            .read_string(name_property?)
+            .read_string(name_property)
             .ok_or_else(|| anyhow!("unable to read name"))?;
-        let event_type_field = isar_object.read_int(eventy_type_property?);
+        let event_type_field = isar_object.read_int(event_type_property);
         let timestamp_field = isar_object
-            .read_string(timestamp_property?)
+            .read_string(timestamp_property)
             .ok_or_else(|| anyhow!("unable to read timestamp"))?
             .to_string();
         let screen_route_field = isar_object
-            .read_string(screen_route_name_property?)
+            .read_string(screen_route_field_property)
             .map(RelationalField::try_from)
             .transpose()?;
 

--- a/rust/xaynet-analytics/src/database/analytics_event/adapter.rs
+++ b/rust/xaynet-analytics/src/database/analytics_event/adapter.rs
@@ -1,0 +1,127 @@
+use anyhow::{anyhow, Error, Result};
+use isar_core::object::{
+    data_type::DataType,
+    isar_object::{IsarObject, Property},
+    object_builder::ObjectBuilder,
+};
+use std::vec::IntoIter;
+
+use crate::database::{
+    common::{FieldProperty, IsarAdapter, RelationalField, Repo, SchemaGenerator},
+    isar::IsarDb,
+    screen_route::data_model::ScreenRoute,
+};
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct AnalyticsEventAdapter {
+    pub name: String,
+    pub event_type: i32,
+    pub timestamp: String,
+    pub screen_route_field: Option<RelationalField>,
+}
+
+impl AnalyticsEventAdapter {
+    pub fn new<N: Into<String>>(
+        name: N,
+        event_type: i32,
+        timestamp: String,
+        screen_route_field: Option<RelationalField>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            event_type,
+            timestamp,
+            screen_route_field,
+        }
+    }
+}
+
+impl<'event> IsarAdapter<'event> for AnalyticsEventAdapter {
+    fn into_field_properties() -> IntoIter<FieldProperty> {
+        // NOTE: properties need to be ordered by type. Properties with the same type need to be ordered alphabetically
+        // https://github.com/isar/isar-core/blob/1ea9f27edfd6e3708daa47ac6a17995b628f31a6/src/schema/collection_schema.rs
+        vec![
+            FieldProperty::new("event_type".to_string(), DataType::Int),
+            FieldProperty::new("name".to_string(), DataType::String),
+            FieldProperty::new("screen_route_field".to_string(), DataType::String),
+            FieldProperty::new("timestamp".to_string(), DataType::String),
+        ]
+        .into_iter()
+    }
+
+    fn write_with_object_builder(&self, object_builder: &mut ObjectBuilder) {
+        let screen_route_field: Option<&str> = if let Some(field) = &self.screen_route_field {
+            Some(&field.value)
+        } else {
+            None
+        };
+
+        object_builder.write_int(self.event_type);
+        object_builder.write_string(Some(&self.name));
+        object_builder.write_string(screen_route_field);
+        object_builder.write_string(Some(&self.timestamp));
+    }
+
+    fn read(
+        isar_object: &'event IsarObject,
+        isar_properties: &'event [(String, Property)],
+    ) -> Result<AnalyticsEventAdapter, Error> {
+        let name_property = Self::find_property_by_name("name", isar_properties);
+        let eventy_type_property = Self::find_property_by_name("event_type", isar_properties);
+        let timestamp_property = Self::find_property_by_name("timestamp", isar_properties);
+        let screen_route_name_property =
+            Self::find_property_by_name("screen_route_field", isar_properties);
+
+        let name_field = isar_object
+            .read_string(name_property?)
+            .ok_or_else(|| anyhow!("unable to read name"))?;
+        let event_type_field = isar_object.read_int(eventy_type_property?);
+        let timestamp_field = isar_object
+            .read_string(timestamp_property?)
+            .ok_or_else(|| anyhow!("unable to read timestamp"))?
+            .to_string();
+        let screen_route_field_data = isar_object.read_string(screen_route_name_property?);
+        let screen_route_field = if let Some(screen_route) = screen_route_field_data {
+            Some(RelationalField::from(screen_route))
+        } else {
+            None
+        };
+
+        Ok(AnalyticsEventAdapter::new(
+            name_field,
+            event_type_field,
+            timestamp_field,
+            screen_route_field,
+        ))
+    }
+}
+
+impl<'event> SchemaGenerator<'event, AnalyticsEventAdapter> for AnalyticsEventAdapter {}
+
+pub struct AnalyticsEventRelationalAdapter {
+    pub name: String,
+    pub event_type: i32,
+    pub timestamp: String,
+    pub screen_route: Option<ScreenRoute>,
+}
+
+impl AnalyticsEventRelationalAdapter {
+    pub fn new(adapter: AnalyticsEventAdapter, db: &IsarDb) -> Result<Self, Error> {
+        let screen_route = if let Some(screen_route_field) = adapter.screen_route_field {
+            Some(ScreenRoute::get(
+                &screen_route_field.value,
+                db,
+                &screen_route_field.collection_name,
+            )?)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            name: adapter.name.to_string(),
+            event_type: adapter.event_type,
+            timestamp: adapter.timestamp.to_string(),
+            screen_route,
+        })
+    }
+}

--- a/rust/xaynet-analytics/src/database/analytics_event/data_model.rs
+++ b/rust/xaynet-analytics/src/database/analytics_event/data_model.rs
@@ -74,15 +74,13 @@ impl TryFrom<AnalyticsEventRelationalAdapter> for AnalyticsEvent {
     }
 }
 
-impl TryInto<AnalyticsEventAdapter> for AnalyticsEvent {
-    type Error = anyhow::Error;
-
-    fn try_into(self) -> Result<AnalyticsEventAdapter, Self::Error> {
-        Ok(AnalyticsEventAdapter::new(
+impl Into<AnalyticsEventAdapter> for AnalyticsEvent {
+    fn into(self) -> AnalyticsEventAdapter {
+        AnalyticsEventAdapter::new(
             self.name,
             self.event_type as i32,
             self.timestamp.to_rfc3339(),
             self.screen_route.map(RelationalField::from),
-        ))
+        )
     }
 }

--- a/rust/xaynet-analytics/src/database/analytics_event/data_model.rs
+++ b/rust/xaynet-analytics/src/database/analytics_event/data_model.rs
@@ -25,7 +25,10 @@ impl TryFrom<i32> for AnalyticsEventType {
             x if x == AnalyticsEventType::AppError as i32 => Ok(AnalyticsEventType::AppError),
             x if x == AnalyticsEventType::ScreenEnter as i32 => Ok(AnalyticsEventType::ScreenEnter),
             x if x == AnalyticsEventType::UserAction as i32 => Ok(AnalyticsEventType::UserAction),
-            _ => Err(anyhow!("i32 value {:?} is not mapped to an AnalyticsEventType variant", v)),
+            _ => Err(anyhow!(
+                "i32 value {:?} is not mapped to an AnalyticsEventType variant",
+                v
+            )),
         }
     }
 }

--- a/rust/xaynet-analytics/src/database/analytics_event/data_model.rs
+++ b/rust/xaynet-analytics/src/database/analytics_event/data_model.rs
@@ -17,7 +17,7 @@ pub enum AnalyticsEventType {
 }
 
 impl TryFrom<i32> for AnalyticsEventType {
-    type Error = ();
+    type Error = anyhow::Error;
 
     fn try_from(v: i32) -> Result<Self, Self::Error> {
         match v {
@@ -25,7 +25,7 @@ impl TryFrom<i32> for AnalyticsEventType {
             x if x == AnalyticsEventType::AppError as i32 => Ok(AnalyticsEventType::AppError),
             x if x == AnalyticsEventType::ScreenEnter as i32 => Ok(AnalyticsEventType::ScreenEnter),
             x if x == AnalyticsEventType::UserAction as i32 => Ok(AnalyticsEventType::UserAction),
-            _ => Err(()),
+            _ => Err(anyhow!("i32 value {:?} is not mapped to an AnalyticsEventType variant", v)),
         }
     }
 }

--- a/rust/xaynet-analytics/src/database/analytics_event/data_model.rs
+++ b/rust/xaynet-analytics/src/database/analytics_event/data_model.rs
@@ -62,16 +62,14 @@ impl TryFrom<AnalyticsEventRelationalAdapter> for AnalyticsEvent {
             adapter.name,
             TryInto::<AnalyticsEventType>::try_into(adapter.event_type)
                 .map_err(|_| anyhow!("unable to convert event_type into enum"))?,
-            DateTime::parse_from_rfc3339(&adapter.timestamp)
-                .unwrap()
-                .with_timezone(&Utc),
+            DateTime::parse_from_rfc3339(&adapter.timestamp)?.with_timezone(&Utc),
             adapter.screen_route,
         );
         Ok(event)
     }
 }
 
-impl<'event> TryInto<AnalyticsEventAdapter> for AnalyticsEvent {
+impl TryInto<AnalyticsEventAdapter> for AnalyticsEvent {
     type Error = anyhow::Error;
 
     fn try_into(self) -> Result<AnalyticsEventAdapter, Error> {

--- a/rust/xaynet-analytics/src/database/analytics_event/mod.rs
+++ b/rust/xaynet-analytics/src/database/analytics_event/mod.rs
@@ -1,2 +1,3 @@
+pub mod adapter;
 pub mod data_model;
 pub mod repo;

--- a/rust/xaynet-analytics/src/database/analytics_event/repo.rs
+++ b/rust/xaynet-analytics/src/database/analytics_event/repo.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Error, Result};
-use std::convert::{TryFrom, TryInto};
+use std::convert::{Into, TryFrom};
 
 use crate::database::{
     analytics_event::{
@@ -11,9 +11,9 @@ use crate::database::{
 };
 
 impl<'db> Repo<'db, AnalyticsEvent> for AnalyticsEvent {
-    fn add(self, db: &'db IsarDb, collection_name: &str) -> Result<(), Error> {
+    fn save(self, db: &'db IsarDb, collection_name: &str) -> Result<(), Error> {
         let mut object_builder = db.get_object_builder(collection_name)?;
-        let event_adapter: AnalyticsEventAdapter = self.try_into()?;
+        let event_adapter: AnalyticsEventAdapter = self.into();
         event_adapter.write_with_object_builder(&mut object_builder);
         db.put(collection_name, None, object_builder.finish().as_bytes())
     }
@@ -31,7 +31,7 @@ impl<'db> Repo<'db, AnalyticsEvent> for AnalyticsEvent {
 
     fn get(oid: &str, db: &'db IsarDb, collection_name: &str) -> Result<Self, Error> {
         let isar_properties = db.get_collection_properties(collection_name)?;
-        let object_id = db.get_object_id_from_str(oid, collection_name)?;
+        let object_id = db.get_object_id_from_str(collection_name, oid)?;
         let mut transaction = db.get_transaction()?;
         let isar_object =
             db.get_isar_object_by_id(&object_id, collection_name, &mut transaction)?;

--- a/rust/xaynet-analytics/src/database/analytics_event/repo.rs
+++ b/rust/xaynet-analytics/src/database/analytics_event/repo.rs
@@ -1,50 +1,46 @@
-use anyhow::{Error, Result};
+use anyhow::{anyhow, Error, Result};
+use std::convert::{TryFrom, TryInto};
 
 use crate::database::{
-    analytics_event::data_model::AnalyticsEvent,
+    analytics_event::{
+        adapter::{AnalyticsEventAdapter, AnalyticsEventRelationalAdapter},
+        data_model::AnalyticsEvent,
+    },
     common::{IsarAdapter, Repo},
     isar::IsarDb,
 };
 
-pub struct AnalyticsEventRepo<'db> {
-    collection_name: &'db str,
-}
-
-impl<'db> AnalyticsEventRepo<'db> {
-    pub fn new(collection_name: &'db str) -> Self {
-        Self { collection_name }
-    }
-}
-
-impl<'screen, 'db> Repo<AnalyticsEvent<'screen>> for AnalyticsEventRepo<'db> {
-    fn add(&self, event: &AnalyticsEvent, db: &IsarDb) -> Result<(), Error> {
-        let mut object_builder = db.get_object_builder(self.collection_name)?;
-        event.write_with_object_builder(&mut object_builder);
-        db.put(
-            &self.collection_name,
-            None,
-            object_builder.finish().as_bytes(),
-        )
+impl<'db> Repo<'db, AnalyticsEvent> for AnalyticsEvent {
+    fn add(self, db: &'db IsarDb, collection_name: &str) -> Result<(), Error> {
+        let mut object_builder = db.get_object_builder(collection_name)?;
+        let event_adapter: AnalyticsEventAdapter = self.try_into()?;
+        event_adapter.write_with_object_builder(&mut object_builder);
+        db.put(collection_name, None, object_builder.finish().as_bytes())
     }
 
     // TODO: return an iterator instead of Vec: https://xainag.atlassian.net/browse/XN-1517
-    fn get_all(&self, db: &IsarDb) -> Result<Vec<AnalyticsEvent<'screen>>, Error> {
-        let _events_as_bytes = db.get_all_as_bytes(&self.collection_name)?;
-
-        // TODO: not sure how to proceed to parse [u8] using the collection schema. didn't find examples in Isar
-        // implement when possible: https://xainag.atlassian.net/browse/XN-1604
-        todo!()
-    }
-}
-
-pub struct MockAnalyticsEventRepo {}
-
-impl<'screen> Repo<AnalyticsEvent<'screen>> for MockAnalyticsEventRepo {
-    fn add(&self, _object: &AnalyticsEvent, _db: &IsarDb) -> Result<(), Error> {
-        Ok(())
+    fn get_all(db: &'db IsarDb, collection_name: &str) -> Result<Vec<Self>, Error> {
+        let isar_properties = db.get_collection_properties(collection_name)?;
+        db.get_all_isar_objects(collection_name)?
+            .into_iter()
+            .map(|(_, isar_object)| AnalyticsEventAdapter::read(&isar_object, isar_properties))
+            .map(|adapter| AnalyticsEventRelationalAdapter::new(adapter?, &db))
+            .map(|relational_adapter| AnalyticsEvent::try_from(relational_adapter?))
+            .collect()
     }
 
-    fn get_all(&self, _db: &IsarDb) -> Result<Vec<AnalyticsEvent<'screen>>, Error> {
-        Ok(Vec::new())
+    fn get(oid: &str, db: &'db IsarDb, collection_name: &str) -> Result<Self, Error> {
+        let isar_properties = db.get_collection_properties(collection_name)?;
+        let object_id = db.get_object_id_from_str(oid, collection_name)?;
+        let mut transaction = db.get_transaction()?;
+        let isar_object =
+            db.get_isar_object_by_id(&object_id, collection_name, &mut transaction)?;
+        if let Some(isar_object) = isar_object {
+            let adapter = AnalyticsEventAdapter::read(&isar_object, isar_properties)?;
+            let relational_adapter = AnalyticsEventRelationalAdapter::new(adapter, &db)?;
+            AnalyticsEvent::try_from(relational_adapter)
+        } else {
+            Err(anyhow!("unable to get {:?} object", object_id))
+        }
     }
 }

--- a/rust/xaynet-analytics/src/database/common.rs
+++ b/rust/xaynet-analytics/src/database/common.rs
@@ -38,7 +38,7 @@ pub trait Repo<'db, M>
 where
     M: Sized,
 {
-    fn add(self, db: &'db IsarDb, collection_name: &str) -> Result<(), Error>;
+    fn save(self, db: &'db IsarDb, collection_name: &str) -> Result<(), Error>;
 
     fn get_all(db: &'db IsarDb, collection_name: &str) -> Result<Vec<M>, Error>;
 
@@ -67,7 +67,7 @@ impl<'object> IsarAdapter<'object> for MockObject {
 }
 
 impl<'db> Repo<'db, MockObject> for MockObject {
-    fn add(self, _db: &'db IsarDb, _collection_name: &str) -> Result<(), Error> {
+    fn save(self, _db: &'db IsarDb, _collection_name: &str) -> Result<(), Error> {
         unimplemented!()
     }
 
@@ -155,14 +155,8 @@ impl TryFrom<&str> for RelationalField {
     type Error = anyhow::Error;
 
     fn try_from(data: &str) -> Result<Self, Error> {
-        fn stringify(input: Option<&&str>) -> Result<String, Error> {
-            Ok(input
-                .ok_or_else(|| anyhow!("could not unwrap input {:?}", input))?
-                .to_string())
-        }
-
         let data_split: Vec<&str> = data.split('=').collect();
-        if !data_split.len() == 2 {
+        if data_split.len() != 2 {
             return Err(anyhow!(
                 "data {:?} is not a str made of two elements separated by '='",
                 data
@@ -170,8 +164,8 @@ impl TryFrom<&str> for RelationalField {
         }
 
         Ok(Self {
-            value: stringify(data_split.first())?,
-            collection_name: stringify(data_split.last())?,
+            value: data_split[0].to_string(),
+            collection_name: data_split[1].to_string(),
         })
     }
 }

--- a/rust/xaynet-analytics/src/database/controller_data/adapter.rs
+++ b/rust/xaynet-analytics/src/database/controller_data/adapter.rs
@@ -37,10 +37,10 @@ impl<'ctrl> IsarAdapter<'ctrl> for ControllerDataAdapter {
         isar_properties: &'ctrl [(String, Property)],
     ) -> Result<ControllerDataAdapter, Error> {
         let time_data_sent_property =
-            Self::find_property_by_name("time_data_sent", isar_properties);
+            Self::find_property_by_name("time_data_sent", isar_properties)?;
 
         let time_data_sent_data = isar_object
-            .read_string(time_data_sent_property?)
+            .read_string(time_data_sent_property)
             .ok_or_else(|| anyhow!("unable to read time_data_sent"))?;
 
         Ok(ControllerDataAdapter::new(time_data_sent_data.to_string()))

--- a/rust/xaynet-analytics/src/database/controller_data/adapter.rs
+++ b/rust/xaynet-analytics/src/database/controller_data/adapter.rs
@@ -1,0 +1,50 @@
+use anyhow::{anyhow, Error, Result};
+use isar_core::object::{
+    data_type::DataType,
+    isar_object::{IsarObject, Property},
+    object_builder::ObjectBuilder,
+};
+use std::vec::IntoIter;
+
+use crate::database::common::{FieldProperty, IsarAdapter, SchemaGenerator};
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct ControllerDataAdapter {
+    pub time_data_sent: String,
+}
+
+impl ControllerDataAdapter {
+    pub fn new(time_data_sent: String) -> Self {
+        Self { time_data_sent }
+    }
+}
+
+impl<'ctrl> IsarAdapter<'ctrl> for ControllerDataAdapter {
+    fn into_field_properties() -> IntoIter<FieldProperty> {
+        vec![FieldProperty::new(
+            "time_data_sent".to_string(),
+            DataType::String,
+        )]
+        .into_iter()
+    }
+
+    fn write_with_object_builder(&self, object_builder: &mut ObjectBuilder) {
+        object_builder.write_string(Some(&self.time_data_sent));
+    }
+
+    fn read(
+        isar_object: &'ctrl IsarObject,
+        isar_properties: &'ctrl [(String, Property)],
+    ) -> Result<ControllerDataAdapter, Error> {
+        let time_data_sent_property =
+            Self::find_property_by_name("time_data_sent", isar_properties);
+
+        let time_data_sent_data = isar_object
+            .read_string(time_data_sent_property?)
+            .ok_or_else(|| anyhow!("unable to read time_data_sent"))?;
+
+        Ok(ControllerDataAdapter::new(time_data_sent_data.to_string()))
+    }
+}
+
+impl<'ctrl> SchemaGenerator<'ctrl, ControllerDataAdapter> for ControllerDataAdapter {}

--- a/rust/xaynet-analytics/src/database/controller_data/data_model.rs
+++ b/rust/xaynet-analytics/src/database/controller_data/data_model.rs
@@ -1,8 +1,8 @@
+use anyhow::{Error, Result};
 use chrono::{DateTime, Utc};
-use isar_core::object::{data_type::DataType, object_builder::ObjectBuilder};
-use std::vec::IntoIter;
+use std::convert::{TryFrom, TryInto};
 
-use crate::database::common::{FieldProperty, IsarAdapter, SchemaGenerator};
+use crate::database::controller_data::adapter::ControllerDataAdapter;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ControllerData {
@@ -15,23 +15,22 @@ impl ControllerData {
     }
 }
 
-impl IsarAdapter for ControllerData {
-    fn into_field_properties() -> IntoIter<FieldProperty> {
-        vec![FieldProperty::new(
-            "time_data_sent".to_string(),
-            DataType::String,
-        )]
-        .into_iter()
-    }
+impl<'ctrl> TryFrom<ControllerDataAdapter> for ControllerData {
+    type Error = anyhow::Error;
 
-    fn write_with_object_builder(&self, object_builder: &mut ObjectBuilder) {
-        object_builder.write_string(Some(&self.time_data_sent.to_rfc3339()));
-    }
-
-    fn read(_bytes: &[u8]) -> ControllerData {
-        // TODO: implement when Isar will support it: https://xainag.atlassian.net/browse/XN-1604
-        todo!()
+    fn try_from(adapter: ControllerDataAdapter) -> Result<Self, Self::Error> {
+        Ok(ControllerData::new(
+            DateTime::parse_from_rfc3339(&adapter.time_data_sent)
+                .unwrap()
+                .with_timezone(&Utc),
+        ))
     }
 }
 
-impl SchemaGenerator<ControllerData> for ControllerData {}
+impl<'ctrl> TryInto<ControllerDataAdapter> for ControllerData {
+    type Error = anyhow::Error;
+
+    fn try_into(self) -> Result<ControllerDataAdapter, Error> {
+        Ok(ControllerDataAdapter::new(self.time_data_sent.to_rfc3339()))
+    }
+}

--- a/rust/xaynet-analytics/src/database/controller_data/data_model.rs
+++ b/rust/xaynet-analytics/src/database/controller_data/data_model.rs
@@ -1,4 +1,4 @@
-use anyhow::{Error, Result};
+use anyhow::Result;
 use chrono::{DateTime, Utc};
 use std::convert::{TryFrom, TryInto};
 
@@ -28,7 +28,7 @@ impl TryFrom<ControllerDataAdapter> for ControllerData {
 impl TryInto<ControllerDataAdapter> for ControllerData {
     type Error = anyhow::Error;
 
-    fn try_into(self) -> Result<ControllerDataAdapter, Error> {
+    fn try_into(self) -> Result<ControllerDataAdapter, Self::Error> {
         Ok(ControllerDataAdapter::new(self.time_data_sent.to_rfc3339()))
     }
 }

--- a/rust/xaynet-analytics/src/database/controller_data/data_model.rs
+++ b/rust/xaynet-analytics/src/database/controller_data/data_model.rs
@@ -15,19 +15,17 @@ impl ControllerData {
     }
 }
 
-impl<'ctrl> TryFrom<ControllerDataAdapter> for ControllerData {
+impl TryFrom<ControllerDataAdapter> for ControllerData {
     type Error = anyhow::Error;
 
     fn try_from(adapter: ControllerDataAdapter) -> Result<Self, Self::Error> {
         Ok(ControllerData::new(
-            DateTime::parse_from_rfc3339(&adapter.time_data_sent)
-                .unwrap()
-                .with_timezone(&Utc),
+            DateTime::parse_from_rfc3339(&adapter.time_data_sent)?.with_timezone(&Utc),
         ))
     }
 }
 
-impl<'ctrl> TryInto<ControllerDataAdapter> for ControllerData {
+impl TryInto<ControllerDataAdapter> for ControllerData {
     type Error = anyhow::Error;
 
     fn try_into(self) -> Result<ControllerDataAdapter, Error> {

--- a/rust/xaynet-analytics/src/database/controller_data/data_model.rs
+++ b/rust/xaynet-analytics/src/database/controller_data/data_model.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use chrono::{DateTime, Utc};
-use std::convert::{TryFrom, TryInto};
+use std::convert::{Into, TryFrom};
 
 use crate::database::controller_data::adapter::ControllerDataAdapter;
 
@@ -25,10 +25,8 @@ impl TryFrom<ControllerDataAdapter> for ControllerData {
     }
 }
 
-impl TryInto<ControllerDataAdapter> for ControllerData {
-    type Error = anyhow::Error;
-
-    fn try_into(self) -> Result<ControllerDataAdapter, Self::Error> {
-        Ok(ControllerDataAdapter::new(self.time_data_sent.to_rfc3339()))
+impl Into<ControllerDataAdapter> for ControllerData {
+    fn into(self) -> ControllerDataAdapter {
+        ControllerDataAdapter::new(self.time_data_sent.to_rfc3339())
     }
 }

--- a/rust/xaynet-analytics/src/database/controller_data/mod.rs
+++ b/rust/xaynet-analytics/src/database/controller_data/mod.rs
@@ -1,2 +1,3 @@
+pub mod adapter;
 pub mod data_model;
 pub mod repo;

--- a/rust/xaynet-analytics/src/database/controller_data/repo.rs
+++ b/rust/xaynet-analytics/src/database/controller_data/repo.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Error, Result};
-use std::convert::{TryFrom, TryInto};
+use std::convert::{Into, TryFrom};
 
 use crate::database::{
     common::{IsarAdapter, Repo},
@@ -8,9 +8,9 @@ use crate::database::{
 };
 
 impl<'db> Repo<'db, ControllerData> for ControllerData {
-    fn add(self, db: &'db IsarDb, collection_name: &str) -> Result<(), Error> {
+    fn save(self, db: &'db IsarDb, collection_name: &str) -> Result<(), Error> {
         let mut object_builder = db.get_object_builder(collection_name)?;
-        let data_adapter: ControllerDataAdapter = self.try_into()?;
+        let data_adapter: ControllerDataAdapter = self.into();
         data_adapter.write_with_object_builder(&mut object_builder);
         db.put(collection_name, None, object_builder.finish().as_bytes())
     }
@@ -27,7 +27,7 @@ impl<'db> Repo<'db, ControllerData> for ControllerData {
 
     fn get(oid: &str, db: &'db IsarDb, collection_name: &str) -> Result<Self, Error> {
         let isar_properties = db.get_collection_properties(collection_name)?;
-        let object_id = db.get_object_id_from_str(oid, collection_name)?;
+        let object_id = db.get_object_id_from_str(collection_name, oid)?;
         let mut transaction = db.get_transaction()?;
         let isar_object =
             db.get_isar_object_by_id(&object_id, collection_name, &mut transaction)?;

--- a/rust/xaynet-analytics/src/database/isar.rs
+++ b/rust/xaynet-analytics/src/database/isar.rs
@@ -57,7 +57,7 @@ impl IsarDb {
     ) -> Result<Option<IsarObject<'txn>>, Error> {
         self.get_collection(collection_name)?
             .get(transaction, object_id)
-            .map_err(|_| anyhow!("unable to get {:?} object", object_id))
+            .map_err(|err| anyhow!("unable to get {:?} object ({:?})", object_id, err))
     }
 
     pub fn put(

--- a/rust/xaynet-analytics/src/database/isar.rs
+++ b/rust/xaynet-analytics/src/database/isar.rs
@@ -39,7 +39,7 @@ impl IsarDb {
             .find_all_vec(&mut self.begin_txn(false)?)
             .map_err(|_| {
                 anyhow!(
-                    "failed to find all bytes from collection {}",
+                    "failed to find all objects from collection {}",
                     collection_name
                 )
             })

--- a/rust/xaynet-analytics/src/database/screen_route/adapter.rs
+++ b/rust/xaynet-analytics/src/database/screen_route/adapter.rs
@@ -38,14 +38,14 @@ impl<'screen> IsarAdapter<'screen> for ScreenRouteAdapter {
         isar_object: &'screen IsarObject,
         isar_properties: &'screen [(String, Property)],
     ) -> Result<ScreenRouteAdapter, Error> {
-        let name_property = Self::find_property_by_name("name", isar_properties);
-        let created_at_property = Self::find_property_by_name("created_at", isar_properties);
+        let name_property = Self::find_property_by_name("name", isar_properties)?;
+        let created_at_property = Self::find_property_by_name("created_at", isar_properties)?;
 
         let name_data = isar_object
-            .read_string(name_property?)
+            .read_string(name_property)
             .ok_or_else(|| anyhow!("unable to read name"))?;
         let created_at_data = isar_object
-            .read_string(created_at_property?)
+            .read_string(created_at_property)
             .ok_or_else(|| anyhow!("unable to read created_at"))?;
 
         Ok(ScreenRouteAdapter::new(

--- a/rust/xaynet-analytics/src/database/screen_route/adapter.rs
+++ b/rust/xaynet-analytics/src/database/screen_route/adapter.rs
@@ -1,0 +1,58 @@
+use anyhow::{anyhow, Error, Result};
+use isar_core::object::{
+    data_type::DataType,
+    isar_object::{IsarObject, Property},
+    object_builder::ObjectBuilder,
+};
+use std::vec::IntoIter;
+
+use crate::database::common::{FieldProperty, IsarAdapter, SchemaGenerator};
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct ScreenRouteAdapter {
+    pub name: String,
+    pub created_at: String,
+}
+
+impl ScreenRouteAdapter {
+    pub fn new(name: String, created_at: String) -> Self {
+        Self { name, created_at }
+    }
+}
+
+impl<'screen> IsarAdapter<'screen> for ScreenRouteAdapter {
+    fn into_field_properties() -> IntoIter<FieldProperty> {
+        vec![
+            FieldProperty::new("created_at".to_string(), DataType::String),
+            FieldProperty::new("name".to_string(), DataType::String),
+        ]
+        .into_iter()
+    }
+
+    fn write_with_object_builder(&self, object_builder: &mut ObjectBuilder) {
+        object_builder.write_string(Some(&self.created_at));
+        object_builder.write_string(Some(&self.name));
+    }
+
+    fn read(
+        isar_object: &'screen IsarObject,
+        isar_properties: &'screen [(String, Property)],
+    ) -> Result<ScreenRouteAdapter, Error> {
+        let name_property = Self::find_property_by_name("name", isar_properties);
+        let created_at_property = Self::find_property_by_name("created_at", isar_properties);
+
+        let name_data = isar_object
+            .read_string(name_property?)
+            .ok_or_else(|| anyhow!("unable to read name"))?;
+        let created_at_data = isar_object
+            .read_string(created_at_property?)
+            .ok_or_else(|| anyhow!("unable to read created_at"))?;
+
+        Ok(ScreenRouteAdapter::new(
+            name_data.to_string(),
+            created_at_data.to_string(),
+        ))
+    }
+}
+
+impl<'screen> SchemaGenerator<'screen, ScreenRouteAdapter> for ScreenRouteAdapter {}

--- a/rust/xaynet-analytics/src/database/screen_route/data_model.rs
+++ b/rust/xaynet-analytics/src/database/screen_route/data_model.rs
@@ -1,4 +1,4 @@
-use anyhow::{Error, Result};
+use anyhow::Result;
 use chrono::{DateTime, Utc};
 use std::convert::{TryFrom, TryInto};
 
@@ -36,7 +36,7 @@ impl TryFrom<ScreenRouteAdapter> for ScreenRoute {
 impl TryInto<ScreenRouteAdapter> for ScreenRoute {
     type Error = anyhow::Error;
 
-    fn try_into(self) -> Result<ScreenRouteAdapter, Error> {
+    fn try_into(self) -> Result<ScreenRouteAdapter, Self::Error> {
         Ok(ScreenRouteAdapter::new(
             self.name,
             self.created_at.to_rfc3339(),

--- a/rust/xaynet-analytics/src/database/screen_route/data_model.rs
+++ b/rust/xaynet-analytics/src/database/screen_route/data_model.rs
@@ -22,15 +22,13 @@ impl ScreenRoute {
     }
 }
 
-impl<'screen> TryFrom<ScreenRouteAdapter> for ScreenRoute {
+impl TryFrom<ScreenRouteAdapter> for ScreenRoute {
     type Error = anyhow::Error;
 
     fn try_from(adapter: ScreenRouteAdapter) -> Result<Self, Self::Error> {
         Ok(ScreenRoute::new(
             adapter.name,
-            DateTime::parse_from_rfc3339(&adapter.created_at)
-                .unwrap()
-                .with_timezone(&Utc),
+            DateTime::parse_from_rfc3339(&adapter.created_at)?.with_timezone(&Utc),
         ))
     }
 }

--- a/rust/xaynet-analytics/src/database/screen_route/data_model.rs
+++ b/rust/xaynet-analytics/src/database/screen_route/data_model.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use chrono::{DateTime, Utc};
-use std::convert::{TryFrom, TryInto};
+use std::convert::{Into, TryFrom};
 
 use crate::database::{
     common::{CollectionNames, RelationalField},
@@ -33,14 +33,9 @@ impl TryFrom<ScreenRouteAdapter> for ScreenRoute {
     }
 }
 
-impl TryInto<ScreenRouteAdapter> for ScreenRoute {
-    type Error = anyhow::Error;
-
-    fn try_into(self) -> Result<ScreenRouteAdapter, Self::Error> {
-        Ok(ScreenRouteAdapter::new(
-            self.name,
-            self.created_at.to_rfc3339(),
-        ))
+impl Into<ScreenRouteAdapter> for ScreenRoute {
+    fn into(self) -> ScreenRouteAdapter {
+        ScreenRouteAdapter::new(self.name, self.created_at.to_rfc3339())
     }
 }
 

--- a/rust/xaynet-analytics/src/database/screen_route/data_model.rs
+++ b/rust/xaynet-analytics/src/database/screen_route/data_model.rs
@@ -1,8 +1,11 @@
+use anyhow::{Error, Result};
 use chrono::{DateTime, Utc};
-use isar_core::object::{data_type::DataType, object_builder::ObjectBuilder};
-use std::vec::IntoIter;
+use std::convert::{TryFrom, TryInto};
 
-use crate::database::common::{FieldProperty, IsarAdapter, SchemaGenerator};
+use crate::database::{
+    common::{CollectionNames, RelationalField},
+    screen_route::adapter::ScreenRouteAdapter,
+};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ScreenRoute {
@@ -19,24 +22,35 @@ impl ScreenRoute {
     }
 }
 
-impl IsarAdapter for ScreenRoute {
-    fn into_field_properties() -> IntoIter<FieldProperty> {
-        vec![
-            FieldProperty::new("created_at".to_string(), DataType::String),
-            FieldProperty::new("name".to_string(), DataType::String),
-        ]
-        .into_iter()
-    }
+impl<'screen> TryFrom<ScreenRouteAdapter> for ScreenRoute {
+    type Error = anyhow::Error;
 
-    fn write_with_object_builder(&self, object_builder: &mut ObjectBuilder) {
-        object_builder.write_string(Some(&self.created_at.to_rfc3339()));
-        object_builder.write_string(Some(&self.name));
-    }
-
-    fn read(_bytes: &[u8]) -> ScreenRoute {
-        // TODO: implement when Isar will support it: https://xainag.atlassian.net/browse/XN-1604
-        todo!()
+    fn try_from(adapter: ScreenRouteAdapter) -> Result<Self, Self::Error> {
+        Ok(ScreenRoute::new(
+            adapter.name,
+            DateTime::parse_from_rfc3339(&adapter.created_at)
+                .unwrap()
+                .with_timezone(&Utc),
+        ))
     }
 }
 
-impl SchemaGenerator<ScreenRoute> for ScreenRoute {}
+impl TryInto<ScreenRouteAdapter> for ScreenRoute {
+    type Error = anyhow::Error;
+
+    fn try_into(self) -> Result<ScreenRouteAdapter, Error> {
+        Ok(ScreenRouteAdapter::new(
+            self.name,
+            self.created_at.to_rfc3339(),
+        ))
+    }
+}
+
+impl From<ScreenRoute> for RelationalField {
+    fn from(screen_route: ScreenRoute) -> Self {
+        Self {
+            value: screen_route.name,
+            collection_name: CollectionNames::SCREEN_ROUTES.to_string(),
+        }
+    }
+}

--- a/rust/xaynet-analytics/src/database/screen_route/mod.rs
+++ b/rust/xaynet-analytics/src/database/screen_route/mod.rs
@@ -1,2 +1,3 @@
+pub mod adapter;
 pub mod data_model;
 pub mod repo;

--- a/rust/xaynet-analytics/src/database/screen_route/repo.rs
+++ b/rust/xaynet-analytics/src/database/screen_route/repo.rs
@@ -1,50 +1,46 @@
-use anyhow::{Error, Result};
+use anyhow::{anyhow, Error, Result};
+use std::convert::{TryFrom, TryInto};
 
 use crate::database::{
     common::{IsarAdapter, Repo},
     isar::IsarDb,
-    screen_route::data_model::ScreenRoute,
+    screen_route::{adapter::ScreenRouteAdapter, data_model::ScreenRoute},
 };
 
-pub struct ScreenRouteRepo<'db> {
-    collection_name: &'db str,
-}
-
-impl<'db> ScreenRouteRepo<'db> {
-    pub fn new(collection_name: &'db str) -> Self {
-        Self { collection_name }
-    }
-}
-
-impl<'db> Repo<ScreenRoute> for ScreenRouteRepo<'db> {
-    fn add(&self, route: &ScreenRoute, db: &IsarDb) -> Result<(), Error> {
-        let mut object_builder = db.get_object_builder(&self.collection_name)?;
-        route.write_with_object_builder(&mut object_builder);
-        let object_id = db.get_object_id_from_str(&self.collection_name, &route.name)?;
+impl<'db> Repo<'db, ScreenRoute> for ScreenRoute {
+    fn add(self, db: &'db IsarDb, collection_name: &str) -> Result<(), Error> {
+        let mut object_builder = db.get_object_builder(collection_name)?;
+        let route_adapter: ScreenRouteAdapter = self.try_into()?;
+        route_adapter.write_with_object_builder(&mut object_builder);
+        let object_id = db.get_object_id_from_str(collection_name, &route_adapter.name)?;
         db.put(
-            &self.collection_name,
+            collection_name,
             Some(object_id),
             object_builder.finish().as_bytes(),
         )
     }
 
     // TODO: return an iterator instead of Vec: https://xainag.atlassian.net/browse/XN-1517
-    fn get_all(&self, db: &IsarDb) -> Result<Vec<ScreenRoute>, Error> {
-        let _routes_as_bytes = db.get_all_as_bytes(&self.collection_name)?;
-
-        // TODO: not sure how to proceed to parse [u8] using the collection schema. didn't find examples in Isar
-        todo!()
-    }
-}
-
-pub struct MockScreenRouteRepo {}
-
-impl Repo<ScreenRoute> for MockScreenRouteRepo {
-    fn add(&self, _object: &ScreenRoute, _db: &IsarDb) -> Result<(), Error> {
-        Ok(())
+    fn get_all(db: &'db IsarDb, collection_name: &str) -> Result<Vec<Self>, Error> {
+        let isar_properties = db.get_collection_properties(collection_name)?;
+        db.get_all_isar_objects(collection_name)?
+            .into_iter()
+            .map(|(_, isar_object)| ScreenRouteAdapter::read(&isar_object, isar_properties))
+            .map(|screen_route_adapter| ScreenRoute::try_from(screen_route_adapter?))
+            .collect()
     }
 
-    fn get_all(&self, _db: &IsarDb) -> Result<Vec<ScreenRoute>, Error> {
-        Ok(Vec::new())
+    fn get(oid: &str, db: &'db IsarDb, collection_name: &str) -> Result<Self, Error> {
+        let isar_properties = db.get_collection_properties(collection_name)?;
+        let object_id = db.get_object_id_from_str(oid, collection_name)?;
+        let mut transaction = db.get_transaction()?;
+        let isar_object =
+            db.get_isar_object_by_id(&object_id, collection_name, &mut transaction)?;
+        if let Some(isar_object) = isar_object {
+            let screen_route_adapter = ScreenRouteAdapter::read(&isar_object, isar_properties)?;
+            ScreenRoute::try_from(screen_route_adapter)
+        } else {
+            Err(anyhow!("unable to get {:?} object", object_id))
+        }
     }
 }

--- a/rust/xaynet-analytics/src/database/screen_route/repo.rs
+++ b/rust/xaynet-analytics/src/database/screen_route/repo.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Error, Result};
-use std::convert::{TryFrom, TryInto};
+use std::convert::{Into, TryFrom};
 
 use crate::database::{
     common::{IsarAdapter, Repo},
@@ -8,9 +8,9 @@ use crate::database::{
 };
 
 impl<'db> Repo<'db, ScreenRoute> for ScreenRoute {
-    fn add(self, db: &'db IsarDb, collection_name: &str) -> Result<(), Error> {
+    fn save(self, db: &'db IsarDb, collection_name: &str) -> Result<(), Error> {
         let mut object_builder = db.get_object_builder(collection_name)?;
-        let route_adapter: ScreenRouteAdapter = self.try_into()?;
+        let route_adapter: ScreenRouteAdapter = self.into();
         route_adapter.write_with_object_builder(&mut object_builder);
         let object_id = db.get_object_id_from_str(collection_name, &route_adapter.name)?;
         db.put(
@@ -32,7 +32,7 @@ impl<'db> Repo<'db, ScreenRoute> for ScreenRoute {
 
     fn get(oid: &str, db: &'db IsarDb, collection_name: &str) -> Result<Self, Error> {
         let isar_properties = db.get_collection_properties(collection_name)?;
-        let object_id = db.get_object_id_from_str(oid, collection_name)?;
+        let object_id = db.get_object_id_from_str(collection_name, oid)?;
         let mut transaction = db.get_transaction()?;
         let isar_object =
             db.get_isar_object_by_id(&object_id, collection_name, &mut transaction)?;

--- a/rust/xaynet-analytics/src/sender.rs
+++ b/rust/xaynet-analytics/src/sender.rs
@@ -4,8 +4,8 @@ use crate::data_combination::data_points::data_point::DataPoint;
 
 pub struct Sender;
 
-impl<'ctrl> Sender {
-    pub fn send(&self, _data_points: Vec<DataPoint<'ctrl>>) -> Result<(), Error> {
+impl Sender {
+    pub fn send(&self, _data_points: Vec<DataPoint>) -> Result<(), Error> {
         // TODO: https://xainag.atlassian.net/browse/XN-1647
         todo!()
     }


### PR DESCRIPTION
[XN-1642](https://xainag.atlassian.net/browse/XN-1642)

Add and implement get and get_all methods, with reading objects from the db.

It also refactors a bit `AnalyticsController`, the data models and the fact that now `Repo` is just a trait on the data models. 
It also adds the `RelationalField` abstraction to be able to save and retrieve instances of data models as fields of other data models (one of the fields of `AnalyticsEvent` is `ScreenRoute`).

It's very likely that some of this could be more efficient, but I struggled a bit with ownerships.