### PR TITLE
DEVOPS-22 Auto cleanup stale/inactive Docker Hub tags

### DIFF
--- a/.github/workflows/dockerhub-cleanup.yml
+++ b/.github/workflows/dockerhub-cleanup.yml
@@ -36,7 +36,7 @@ jobs:
           echo -e "Inactive tags:"
           /tmp/hub-tool tag ls xaynetwork/xaynet | grep -e STATUS -e inactive
           echo -e "\n\n"
-          for tag in $(/tmp/hub-tool tag ls xaynetwork/xaynet | grep inactive | grep -v -e "v[0-9]\.[0-9]\+\.[0-9]\+" | awk '{ print $1 }')
+          for tag in $(/tmp/hub-tool tag ls xaynetwork/xaynet | grep inactive | grep -v -e "v[0-9]\+\.[0-9]\+\.[0-9]\+" | awk '{ print $1 }')
             do
               /tmp/hub-tool tag rm -f ${tag}
           done

--- a/.github/workflows/dockerhub-cleanup.yml
+++ b/.github/workflows/dockerhub-cleanup.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Setup hub-tool
         run: |
-					LATEST=$(curl --silent "https://api.github.com/repos/$1/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+					LATEST=$(curl --silent "https://api.github.com/repos/docker/hub-tool/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
           wget https://github.com/docker/hub-tool/releases/download/${LATEST}/hub-tool-linux-amd64.tar.gz -O /tmp/hub-tool-linux-amd64.tar.gz
           tar xzvf /tmp/hub-tool-linux-amd64.tar.gz --strip-components 1 -C /usr/local/bin/ hub-tool/hub-tool
           /usr/bin/expect <(cat << EOF

--- a/.github/workflows/dockerhub-cleanup.yml
+++ b/.github/workflows/dockerhub-cleanup.yml
@@ -38,5 +38,5 @@ jobs:
           echo -e "\n\n"
           for tag in $(/tmp/hub-tool tag ls xaynetwork/xaynet | grep inactive | awk '{ print $1 }')
             do
-              echo /tmp/hub-tool tag rm -f ${tag}
+              /tmp/hub-tool tag rm -f ${tag}
           done

--- a/.github/workflows/dockerhub-cleanup.yml
+++ b/.github/workflows/dockerhub-cleanup.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Setup hub-tool
         run: |
-					LATEST=$(curl --silent "https://api.github.com/repos/docker/hub-tool/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+          LATEST=$(curl --silent "https://api.github.com/repos/docker/hub-tool/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
           wget https://github.com/docker/hub-tool/releases/download/${LATEST}/hub-tool-linux-amd64.tar.gz -O /tmp/hub-tool-linux-amd64.tar.gz
           tar xzvf /tmp/hub-tool-linux-amd64.tar.gz --strip-components 1 -C /usr/local/bin/ hub-tool/hub-tool
           /usr/bin/expect <(cat << EOF

--- a/.github/workflows/dockerhub-cleanup.yml
+++ b/.github/workflows/dockerhub-cleanup.yml
@@ -1,0 +1,60 @@
+name: DockerHub Scheduled Cleanup
+
+on:
+  schedule:
+    - cron: '00 00 * * sun'
+  workflow_dispatch:
+
+jobs:
+  dockerhub-cleanup-inactive:
+    name: Cleanup inactive xaynet tags on Dockerhub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Setup hub-tool
+        run: |
+					get_latest_release() {
+					  curl --silent "https://api.github.com/repos/$1/releases/latest" | # Get latest release from GitHub api
+					    grep '"tag_name":' |                                            # Get tag line
+					    sed -E 's/.*"([^"]+)".*/\1/'                                    # Pluck JSON value
+					}
+          LATEST=$(get_latest_release docker/hub-tool)
+          wget https://github.com/docker/hub-tool/releases/download/${LATEST}/hub-tool-linux-amd64.tar.gz -O /tmp/hub-tool-linux-amd64.tar.gz
+          tar xzvf /tmp/hub-tool-linux-amd64.tar.gz --strip-components 1 -C /usr/local/bin/ hub-tool/hub-tool
+          /usr/bin/expect <(cat << EOF
+          spawn hub-tool login ${{ secrets.DOCKER_USERNAME }}
+          expect "Password:"
+          send "${{ secrets.DOCKER_PASSWORD }}\r"
+          interact
+          EOF
+          )
+          echo -e "Inactive tags:"
+          hub-tool tag ls xaynetwork/xaynet | grep inactive | awk '{ print $1 }'
+
+
+      #- name: Notify on Slack
+      #  uses: 8398a7/action-slack@v3
+      #  if: always()
+      #  with:
+      #    status: custom
+      #    fields: workflow,job,repo,ref
+      #    custom_payload: |
+      #      {
+      #        username: 'GitHub Actions',
+      #        icon_emoji: ':octocat:',
+      #        attachments: [{
+      #          color: '${{ steps.docker.outcome }}' === 'success' ? 'good' : '${{ steps.docker.outcome }}' === 'failure' ? 'danger' : 'warning',
+      #          text: `${process.env.AS_WORKFLOW}\nRepository: :xaynet: ${process.env.AS_REPO}\nRef: ${process.env.AS_REF}\nTags: development`,
+      #        }]
+      #      }
+      #  env:
+      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #    SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/dockerhub-cleanup.yml
+++ b/.github/workflows/dockerhub-cleanup.yml
@@ -10,46 +10,33 @@ jobs:
     name: Cleanup inactive xaynet tags on Dockerhub
     runs-on: ubuntu-latest
     steps:
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
       - name: Setup hub-tool
+        env:
+          DHUSER: ${{ secrets.DOCKER_USERNAME }}
+          DHTOKEN: ${{ secrets.DOCKER_PASSWORD }}
         run: |
-          LATEST=$(curl --silent "https://api.github.com/repos/docker/hub-tool/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+          export DEBIAN_FRONTEND="noninteractive"
+          sudo apt update
+          sudo apt install -y jq
+          LATEST=$(curl -s "https://api.github.com/repos/docker/hub-tool/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
           wget https://github.com/docker/hub-tool/releases/download/${LATEST}/hub-tool-linux-amd64.tar.gz -O /tmp/hub-tool-linux-amd64.tar.gz
-          tar xzvf /tmp/hub-tool-linux-amd64.tar.gz --strip-components 1 -C /usr/local/bin/ hub-tool/hub-tool
-          /usr/bin/expect <(cat << EOF
-          spawn hub-tool login ${{ secrets.DOCKER_USERNAME }}
-          expect "Password:"
-          send "${{ secrets.DOCKER_PASSWORD }}\r"
-          interact
-          EOF
-          )
+          tar xzvf /tmp/hub-tool-linux-amd64.tar.gz --strip-components 1 -C /tmp hub-tool/hub-tool
+          mkdir -pv -m 700 ~/.docker
+          chmod -v 600 ~/.docker/config.json
+          echo -ne "ewogICJ1c2VybmFtZSI6ICJESFVTRVIiLAogICJwYXNzd29yZCI6ICJESFRPS0VOIgp9Cg==" | base64 -d > /tmp/auth.json
+          echo -ne "ewogICJhdXRocyI6IHsKICAgICJodWItdG9vbCI6IHsKICAgICAgImF1dGgiOiAiREhVU0VSVE9LRU4iCiAgICB9LAogICAgImh1Yi10b29sLXJlZnJlc2gtdG9rZW4iOiB7CiAgICAgICJhdXRoIjogIkRIVVNFUiIKICAgIH0sCiAgICAiaHViLXRvb2wtdG9rZW4iOiB7CiAgICAgICJhdXRoIjogIkRIVVNFUiIsCiAgICAgICJpZGVudGl0eXRva2VuIjogIkpXVFRPS0VOIgogICAgfQogIH0KfQoK" | base64 -d > ~/.docker/config.json
+          RUSERTOKEN=$(echo -ne "${DHUSER}:${DHTOKEN}" | base64 -w0)
+          RUSER=$(echo -ne "${DHUSER}:" | base64 -w0)
+          RTOKEN=$(echo -ne "${DHTOKEN}" | base64 -w0)
+          sed -i -e "s,DHUSERTOKEN,${RUSERTOKEN},g" -e "s,DHUSER,${RUSER},g" -e "s,DHTOKEN,${RTOKEN},g" /tmp/auth.json ~/.docker/config.json
+          JWT=$(curl -s -XPOST "https://hub.docker.com/v2/users/login" -H "Content-Type:application/json" -d "@/tmp/auth.json" | jq -r .token)
+          sed -i -e "s,JWTTOKEN,${JWT},g" ~/.docker/config.json
+      - name: Delete target tags
+        run: |
           echo -e "Inactive tags:"
-          hub-tool tag ls xaynetwork/xaynet | grep inactive | awk '{ print $1 }'
-
-
-      #- name: Notify on Slack
-      #  uses: 8398a7/action-slack@v3
-      #  if: always()
-      #  with:
-      #    status: custom
-      #    fields: workflow,job,repo,ref
-      #    custom_payload: |
-      #      {
-      #        username: 'GitHub Actions',
-      #        icon_emoji: ':octocat:',
-      #        attachments: [{
-      #          color: '${{ steps.docker.outcome }}' === 'success' ? 'good' : '${{ steps.docker.outcome }}' === 'failure' ? 'danger' : 'warning',
-      #          text: `${process.env.AS_WORKFLOW}\nRepository: :xaynet: ${process.env.AS_REPO}\nRef: ${process.env.AS_REF}\nTags: development`,
-      #        }]
-      #      }
-      #  env:
-      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #    SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          /tmp/hub-tool tag ls xaynetwork/xaynet | grep -e STATUS -e inactive
+          echo -e "\n\n"
+          for tag in $(/tmp/hub-tool tag ls xaynetwork/xaynet | grep inactive | awk '{ print $1 }')
+            do
+              echo /tmp/hub-tool tag rm -f ${tag}
+          done

--- a/.github/workflows/dockerhub-cleanup.yml
+++ b/.github/workflows/dockerhub-cleanup.yml
@@ -36,7 +36,7 @@ jobs:
           echo -e "Inactive tags:"
           /tmp/hub-tool tag ls xaynetwork/xaynet | grep -e STATUS -e inactive
           echo -e "\n\n"
-          for tag in $(/tmp/hub-tool tag ls xaynetwork/xaynet | grep inactive | awk '{ print $1 }')
+          for tag in $(/tmp/hub-tool tag ls xaynetwork/xaynet | grep inactive | grep -v -e "v[0-9]\.[0-9]\+\.[0-9]\+" | awk '{ print $1 }')
             do
               /tmp/hub-tool tag rm -f ${tag}
           done

--- a/.github/workflows/dockerhub-cleanup.yml
+++ b/.github/workflows/dockerhub-cleanup.yml
@@ -21,12 +21,7 @@ jobs:
 
       - name: Setup hub-tool
         run: |
-					get_latest_release() {
-					  curl --silent "https://api.github.com/repos/$1/releases/latest" | # Get latest release from GitHub api
-					    grep '"tag_name":' |                                            # Get tag line
-					    sed -E 's/.*"([^"]+)".*/\1/'                                    # Pluck JSON value
-					}
-          LATEST=$(get_latest_release docker/hub-tool)
+					LATEST=$(curl --silent "https://api.github.com/repos/$1/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
           wget https://github.com/docker/hub-tool/releases/download/${LATEST}/hub-tool-linux-amd64.tar.gz -O /tmp/hub-tool-linux-amd64.tar.gz
           tar xzvf /tmp/hub-tool-linux-amd64.tar.gz --strip-components 1 -C /usr/local/bin/ hub-tool/hub-tool
           /usr/bin/expect <(cat << EOF


### PR DESCRIPTION
The idea is to have this running every week and getting rid of these inactive tags we have on Docker Hub:

![image](https://user-images.githubusercontent.com/15200226/125576079-bfe1a89b-02f7-4181-8720-53a3f37162fb.png)

I've also made this possible to trigger via a `workflow_dispatch` event, so we can run it whenever we want.
You'll notice that my commit history changes drasticallly out of nowhere, that's because I spent yesterday testing this on a private repo so I wouldn't clutter `xaynet`'s Actions history.