### PR TITLE
Bump rustc and fix compilation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -344,7 +344,7 @@ jobs:
         uses: actions-rs/tarpaulin@v0.1
         with:
           version: '0.16.0'
-          args: '--manifest-path rust/Cargo.toml --all-features --force-clean --lib --ignore-tests --ignored'
+          args: '--manifest-path rust/Cargo.toml --all-features --force-clean --lib --ignore-tests --ignored --workspace --exclude xaynet-analytics'
 
       - name: Stop docker-compose
         working-directory: ./docker

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,8 +10,8 @@ on:
       - 'README.tpl'
 
 env:
-  RUST_STABLE: 1.52.1
-  RUST_NIGHTLY: nightly-2021-05-10
+  RUST_STABLE: 1.55.0
+  RUST_NIGHTLY: nightly-2021-09-09
 
 jobs:
   registry-cache:

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -20,9 +20,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
 
 [[package]]
 name = "async-trait"
@@ -752,9 +752,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
+checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
 
 [[package]]
 name = "paste-impl"
@@ -1245,9 +1245,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
+checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1651,7 +1651,7 @@ dependencies = [
  "bytes",
  "derive_more",
  "futures",
- "paste 1.0.5",
+ "paste 1.0.6",
  "rand",
  "reqwest",
  "serde",
@@ -1678,6 +1678,6 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf68b08513768deaa790264a7fac27a58cbf2705cfcdc9448362229217d7e970"
+checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -57,12 +57,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,31 +910,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-ordinalize"
-version = "3.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d52ff39419d3e16961ecfb9e32f5042bdaacf9a4cc553d2d688057117bae49b"
-dependencies = [
- "num-bigint 0.3.2",
- "num-traits 0.2.14",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "enum_dispatch"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8946e241a7774d5327d92749c50806f275f57d031d2229ecbfd65469a8ad338e"
-dependencies = [
- "once_cell",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "event-listener"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1230,9 +1199,6 @@ name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "headers"
@@ -1502,30 +1468,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
-name = "isar-core"
-version = "0.0.0"
-source = "git+https://github.com/isar/isar-core?rev=59d9008be33343d1fd313c659e50e2835365a19d#59d9008be33343d1fd313c659e50e2835365a19d"
-dependencies = [
- "byteorder",
- "crossbeam-channel",
- "enum-ordinalize",
- "enum_dispatch",
- "hashbrown",
- "itertools",
- "libc",
- "lmdb-sys",
- "once_cell",
- "paste",
- "rand 0.8.4",
- "serde 1.0.130",
- "serde_json",
- "serde_repr",
- "thiserror",
- "unicode-segmentation",
- "wyhash",
-]
-
-[[package]]
 name = "itertools"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1600,16 +1542,6 @@ name = "linked-hash-map"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
-
-[[package]]
-name = "lmdb-sys"
-version = "0.1.0"
-source = "git+https://github.com/isar/isar-core?rev=59d9008be33343d1fd313c659e50e2835365a19d#59d9008be33343d1fd313c659e50e2835365a19d"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
 
 [[package]]
 name = "lock_api"
@@ -1809,22 +1741,11 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
 dependencies = [
- "num-bigint 0.4.0",
+ "num-bigint",
  "num-complex",
  "num-integer",
  "num-iter",
  "num-rational",
- "num-traits 0.2.14",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d0a3d5e207573f948a9e5376662aa743a2ea13f7c50a554d7af443a73fbfeba"
-dependencies = [
- "autocfg",
- "num-integer",
  "num-traits 0.2.14",
 ]
 
@@ -1878,7 +1799,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
 dependencies = [
  "autocfg",
- "num-bigint 0.4.0",
+ "num-bigint",
  "num-integer",
  "num-traits 0.2.14",
  "serde 1.0.130",
@@ -2725,17 +2646,6 @@ dependencies = [
  "percent-encoding",
  "serde 1.0.130",
  "thiserror",
-]
-
-[[package]]
-name = "serde_repr"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc6b7951b17b051f3210b063f12cc17320e2fe30ae05b0fe2a3abb068551c76"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -3787,15 +3697,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wyhash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf6e163c25e3fac820b4b453185ea2dea3b6a3e0a721d4d23d75bd33734c295"
-dependencies = [
- "rand_core 0.6.2",
-]
-
-[[package]]
 name = "xaynet"
 version = "0.11.0"
 dependencies = [
@@ -3803,15 +3704,6 @@ dependencies = [
  "xaynet-mobile",
  "xaynet-sdk",
  "xaynet-server",
-]
-
-[[package]]
-name = "xaynet-analytics"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "chrono",
- "isar-core",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 members = [
     "xaynet",
-    "xaynet-analytics",
+    # "xaynet-analytics",
     "xaynet-core",
     "xaynet-mobile",
     "xaynet-server",

--- a/rust/xaynet-analytics/src/lib.rs
+++ b/rust/xaynet-analytics/src/lib.rs
@@ -8,7 +8,11 @@
 //! a framework that allows mobile applications to collect and aggregate
 //! analytics data via the _Privacy-Enhancing Technology_ (PET) protocol.
 
+#[cfg(not(tarpaulin))]
 pub mod controller;
+#[cfg(not(tarpaulin))]
 pub mod data_combination;
+#[cfg(not(tarpaulin))]
 pub mod database;
+#[cfg(not(tarpaulin))]
 pub mod sender;

--- a/rust/xaynet-core/src/crypto/sign.rs
+++ b/rust/xaynet-core/src/crypto/sign.rs
@@ -129,7 +129,7 @@ pub struct Signature(sign::Signature);
 mod manually_derive_serde_for_signature {
     //! TODO:
     //! remove this if sodiumoxide decides to reintroduce serialization of signatures
-    //! https://github.com/sodiumoxide/sodiumoxide/pull/434
+    //! <https://github.com/sodiumoxide/sodiumoxide/pull/434>
 
     use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 

--- a/rust/xaynet-core/src/lib.rs
+++ b/rust/xaynet-core/src/lib.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(doc, forbid(broken_intra_doc_links, private_intra_doc_links))]
+#![cfg_attr(
+    doc,
+    forbid(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)
+)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/xaynetwork/xaynet/master/assets/xaynet_banner.png",
     html_favicon_url = "https://raw.githubusercontent.com/xaynetwork/xaynet/master/assets/favicon.png",

--- a/rust/xaynet-core/src/message/message.rs
+++ b/rust/xaynet-core/src/message/message.rs
@@ -639,7 +639,7 @@ impl Message {
         // it. Otherwise compute it.
         let signature = match self.signature {
             Some(signature) => signature,
-            None => sk.sign_detached(&writer.signed_data_mut()),
+            None => sk.sign_detached(writer.signed_data_mut()),
         };
         signature.to_bytes(&mut writer.signature_mut());
     }

--- a/rust/xaynet-mobile/src/lib.rs
+++ b/rust/xaynet-mobile/src/lib.rs
@@ -1,4 +1,7 @@
-#![cfg_attr(doc, forbid(broken_intra_doc_links, private_intra_doc_links))]
+#![cfg_attr(
+    doc,
+    forbid(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)
+)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/xaynetwork/xaynet/master/assets/xaynet_banner.png",
     html_favicon_url = "https://raw.githubusercontent.com/xaynetwork/xaynet/master/assets/favicon.png",

--- a/rust/xaynet-sdk/src/lib.rs
+++ b/rust/xaynet-sdk/src/lib.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(doc, forbid(broken_intra_doc_links, private_intra_doc_links))]
+#![cfg_attr(
+    doc,
+    forbid(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)
+)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/xaynetwork/xaynet/master/assets/xaynet_banner.png",
     html_favicon_url = "https://raw.githubusercontent.com/xaynetwork/xaynet/master/assets/favicon.png",

--- a/rust/xaynet-server/src/lib.rs
+++ b/rust/xaynet-server/src/lib.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(doc, forbid(broken_intra_doc_links, private_intra_doc_links))]
+#![cfg_attr(
+    doc,
+    forbid(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)
+)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/xaynetwork/xaynet/master/assets/xaynet_banner.png",
     html_favicon_url = "https://raw.githubusercontent.com/xaynetwork/xaynet/master/assets/favicon.png",

--- a/rust/xaynet-server/src/services/messages/decryptor.rs
+++ b/rust/xaynet-server/src/services/messages/decryptor.rs
@@ -55,7 +55,7 @@ where
             info!("decrypting message");
             let res = keys
                 .secret
-                .decrypt(&data.as_ref(), &keys.public)
+                .decrypt(data.as_ref(), &keys.public)
                 .map_err(|_| ServiceError::Decrypt);
             let _ = tx.send(res);
         });

--- a/rust/xaynet-server/src/state_machine/initializer.rs
+++ b/rust/xaynet-server/src/state_machine/initializer.rs
@@ -240,7 +240,7 @@ where
     ) -> StateMachineInitializationResult<Model> {
         match self
             .store
-            .global_model(&global_model_id)
+            .global_model(global_model_id)
             .await
             .map_err(StateMachineInitializationError::FetchGlobalModel)?
         {

--- a/rust/xaynet-server/src/state_machine/tests/initializer.rs
+++ b/rust/xaynet-server/src/state_machine/tests/initializer.rs
@@ -261,7 +261,7 @@ async fn integration_state_machine_initializer_failed_to_find_global_model() {
     // set a model id but don't store a model
     let global_model_id = "1_412957050209fcfa733b1fb4ad51f321";
     store
-        .set_latest_global_model_id(&global_model_id)
+        .set_latest_global_model_id(global_model_id)
         .await
         .unwrap();
 

--- a/rust/xaynet-server/src/storage/coordinator_storage/redis/mod.rs
+++ b/rust/xaynet-server/src/storage/coordinator_storage/redis/mod.rs
@@ -756,7 +756,7 @@ pub(in crate) mod tests {
         let sum_pks = create_and_add_sum_participant_entries(&mut client, 4).await;
         for (number, sum_pk) in sum_pks.iter().enumerate() {
             let mask_1 = create_mask(10, number as u32);
-            let res = client.incr_mask_score(&sum_pk, &mask_1).await;
+            let res = client.incr_mask_score(sum_pk, &mask_1).await;
             assert!(res.is_ok())
         }
 

--- a/rust/xaynet-server/src/storage/model_storage/s3.rs
+++ b/rust/xaynet-server/src/storage/model_storage/s3.rs
@@ -185,7 +185,7 @@ impl ModelStorage for Client {
         round_seed: &RoundSeed,
         global_model: &Model,
     ) -> StorageResult<String> {
-        let id = Self::create_global_model_id(round_id, &round_seed);
+        let id = Self::create_global_model_id(round_id, round_seed);
 
         debug!("upload global model: {}", id);
         let output = self

--- a/rust/xaynet-server/src/storage/store.rs
+++ b/rust/xaynet-server/src/storage/store.rs
@@ -165,7 +165,7 @@ where
         global_model: &Model,
     ) -> StorageResult<String> {
         self.model
-            .set_global_model(round_id, &round_seed, &global_model)
+            .set_global_model(round_id, round_seed, global_model)
             .await
     }
 

--- a/rust/xaynet-server/src/storage/tests/utils.rs
+++ b/rust/xaynet-server/src/storage/tests/utils.rs
@@ -103,9 +103,7 @@ pub async fn add_local_seed_entries(
     let mut update_result = Vec::new();
 
     for (update_pk, local_seed_dict) in local_seed_entries {
-        let res = client
-            .add_local_seed_dict(&update_pk, &local_seed_dict)
-            .await;
+        let res = client.add_local_seed_dict(update_pk, local_seed_dict).await;
         assert!(res.is_ok());
         update_result.push(res.unwrap())
     }

--- a/rust/xaynet/src/lib.rs
+++ b/rust/xaynet/src/lib.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(doc, forbid(broken_intra_doc_links, private_intra_doc_links))]
+#![cfg_attr(
+    doc,
+    forbid(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)
+)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/xaynetwork/xaynet/master/assets/xaynet_banner.png",
     html_favicon_url = "https://raw.githubusercontent.com/xaynetwork/xaynet/master/assets/favicon.png",


### PR DESCRIPTION
**Summary**

- remove `xaynet-analytics` from the workspace for now
  - issues between `isar` and `rustc > 1.52` need to be fixed before this can be enabled again
  - tarpaulin needs to be excluded explicitely otherwise the crate still shows up with zero percent coverage
- update ci to `rustc 1.55.0`
- fix new clippy and doc lints
